### PR TITLE
feat: Add comprehensive JUnit tests for PlantController

### DIFF
--- a/plants/src/main/java/com/marvin/plants/controller/PlantController.java
+++ b/plants/src/main/java/com/marvin/plants/controller/PlantController.java
@@ -101,7 +101,7 @@ public class PlantController {
 
     @GetMapping(path = "/{id}")
     public Mono<PlantDTO> getPlant(@PathVariable long id) {
-        return Mono.just(plantService.getPlant(id));
+        return Mono.justOrEmpty(plantService.getPlant(id));
     }
 
     @DeleteMapping("/{id}")
@@ -111,7 +111,7 @@ public class PlantController {
     }
 
     @PatchMapping("/{id}/watered")
-    public Mono<ResponseEntity<PlantDTO>> deletePlant(
+    public Mono<ResponseEntity<PlantDTO>> waterPlant(
             @PathVariable long id,
             @RequestParam("last-watered") LocalDate lastWatered
     ) {

--- a/plants/src/test/java/com/marvin/plants/controller/PlantControllerTest.java
+++ b/plants/src/test/java/com/marvin/plants/controller/PlantControllerTest.java
@@ -1,0 +1,654 @@
+package com.marvin.plants.controller;
+
+import com.marvin.image.service.ImageService;
+import com.marvin.plants.dto.PlantDTO;
+import com.marvin.plants.dto.PlantLocation;
+import com.marvin.plants.service.PlantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Plant Controller Tests")
+class PlantControllerTest {
+
+    @Mock
+    private PlantService plantService;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private PlantController plantController;
+
+    private PlantDTO testPlantDTO;
+    private final UUID testImageUuid = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        testPlantDTO = new PlantDTO(
+            1L,
+            "Test Plant",
+            "Test Species",
+            "Test Description",
+            "Test Care Instructions",
+            PlantLocation.LIVING_ROOM,
+            7,
+            LocalDate.now().minusDays(3),
+            LocalDate.now().plusDays(4),
+            testImageUuid.toString()
+        );
+    }
+
+    @Test
+    @DisplayName("Should create plant successfully without image")
+    void createPlant_ShouldReturnCreatedStatus_WhenValidPlantWithoutImage() {
+        // Given
+        PlantDTO newPlantDTO = new PlantDTO(
+            0L,
+            "New Plant",
+            "New Species",
+            "New Description",
+            "New Care Instructions",
+            PlantLocation.BEDROOM,
+            5,
+            null,
+            null,
+            null
+        );
+
+        when(plantService.createPlant(any(PlantDTO.class), eq(""))).thenReturn(2L);
+
+        // When
+        Mono<ResponseEntity<Object>> result = plantController.createPlant(Mono.empty(), Mono.just(newPlantDTO), null);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(201, response.getStatusCode().value());
+                assertTrue(response.getHeaders().getLocation().toString().contains("/plants/2"));
+            })
+            .verifyComplete();
+
+        verify(plantService).createPlant(any(PlantDTO.class), eq(""));
+    }
+
+    @Test
+    @DisplayName("Should create plant successfully with image")
+    void createPlant_ShouldReturnCreatedStatus_WhenValidPlantWithImage() {
+        // Given
+        PlantDTO newPlantDTO = new PlantDTO(
+            0L,
+            "New Plant",
+            "New Species",
+            "New Description",
+            "New Care Instructions",
+            PlantLocation.BEDROOM,
+            5,
+            null,
+            null,
+            null
+        );
+
+        byte[] imageBytes = "test image content".getBytes(StandardCharsets.UTF_8);
+        String contentType = "image/jpeg";
+
+        when(imageService.saveImage(eq(imageBytes), eq(contentType))).thenReturn(Mono.just(testImageUuid));
+        when(plantService.createPlant(any(PlantDTO.class), eq(testImageUuid.toString()))).thenReturn(1L);
+
+        FilePart filePart = mock(FilePart.class);
+        DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+
+        // When
+        Mono<ResponseEntity<Object>> result = plantController.createPlant(Mono.just(filePart), Mono.just(newPlantDTO), contentType);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(201, response.getStatusCode().value());
+                assertTrue(response.getHeaders().getLocation().toString().contains("/plants/1"));
+            })
+            .verifyComplete();
+
+        verify(imageService).saveImage(eq(imageBytes), eq(contentType));
+        verify(plantService).createPlant(any(PlantDTO.class), eq(testImageUuid.toString()));
+    }
+
+    @Test
+    @DisplayName("Should handle empty image file")
+    void createPlant_ShouldHandleEmptyImageFile() {
+        // Given
+        PlantDTO newPlantDTO = new PlantDTO(
+            0L,
+            "New Plant",
+            "New Species",
+            "New Description",
+            "New Care Instructions",
+            PlantLocation.BEDROOM,
+            5,
+            null,
+            null,
+            null
+        );
+
+        FilePart filePart = mock(FilePart.class);
+        when(filePart.content()).thenReturn(Flux.empty());
+
+        when(plantService.createPlant(any(PlantDTO.class), eq(""))).thenReturn(1L);
+
+        // When
+        Mono<ResponseEntity<Object>> result = plantController.createPlant(Mono.just(filePart), Mono.just(newPlantDTO), null);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(201, response.getStatusCode().value());
+                assertTrue(response.getHeaders().getLocation().toString().contains("/plants/1"));
+            })
+            .verifyComplete();
+
+        verify(plantService).createPlant(any(PlantDTO.class), eq(""));
+        verify(imageService, never()).saveImage(any(byte[].class), anyString());
+    }
+
+    @Test
+    @DisplayName("Should handle image processing in controller flow")
+    void createPlant_ShouldProcessImageCorrectly() {
+        // Given
+        PlantDTO newPlantDTO = new PlantDTO(
+            0L,
+            "New Plant",
+            "New Species",
+            "New Description",
+            "New Care Instructions",
+            PlantLocation.BEDROOM,
+            5,
+            null,
+            null,
+            null
+        );
+
+        when(plantService.createPlant(any(PlantDTO.class), eq(""))).thenReturn(1L);
+
+        // When - Testing with empty file part (which represents no image)
+        FilePart filePart = mock(FilePart.class);
+        when(filePart.content()).thenReturn(Flux.empty());
+
+        Mono<ResponseEntity<Object>> result = plantController.createPlant(Mono.just(filePart), Mono.just(newPlantDTO), null);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(201, response.getStatusCode().value());
+                assertNotNull(response.getHeaders().getLocation());
+                assertTrue(response.getHeaders().getLocation().toString().contains("/plants/1"));
+            })
+            .verifyComplete();
+
+        verify(plantService).createPlant(any(PlantDTO.class), eq(""));
+    }
+
+    @Test
+    @DisplayName("Should update plant successfully")
+    void updatePlant_ShouldReturnNoContent_WhenValidPlantUpdate() {
+        // Given
+        PlantDTO updateDTO = new PlantDTO(
+            1L,
+            "Updated Plant",
+            "Updated Species",
+            "Updated Description",
+            "Updated Care Instructions",
+            PlantLocation.KITCHEN,
+            10,
+            LocalDate.now(),
+            LocalDate.now().plusDays(10),
+            "updated-image.jpg"
+        );
+
+        doNothing().when(plantService).updatePlant(any(PlantDTO.class));
+
+        // When
+        Mono<ResponseEntity<Object>> result = plantController.updatePlant(Mono.just(updateDTO));
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(204, response.getStatusCode().value());
+            })
+            .verifyComplete();
+
+        verify(plantService).updatePlant(updateDTO);
+    }
+
+    @Test
+    @DisplayName("Should get all plants successfully")
+    void getPlants_ShouldReturnAllPlants_WhenPlantsExist() {
+        // Given
+        PlantDTO plant2DTO = new PlantDTO(
+            2L,
+            "Plant 2",
+            "Species 2",
+            "Description 2",
+            "Care 2",
+            PlantLocation.KITCHEN,
+            10,
+            null,
+            null,
+            null
+        );
+
+        List<PlantDTO> plants = List.of(testPlantDTO, plant2DTO);
+        when(plantService.getPlants()).thenReturn(Flux.fromIterable(plants));
+
+        // When
+        Flux<PlantDTO> result = plantController.getPlants();
+
+        // Then
+        StepVerifier.create(result)
+            .expectNext(testPlantDTO)
+            .expectNext(plant2DTO)
+            .verifyComplete();
+
+        verify(plantService).getPlants();
+    }
+
+    @Test
+    @DisplayName("Should get all plants successfully when empty")
+    void getPlants_ShouldReturnEmptyList_WhenNoPlantsExist() {
+        // Given
+        when(plantService.getPlants()).thenReturn(Flux.empty());
+
+        // When
+        Flux<PlantDTO> result = plantController.getPlants();
+
+        // Then
+        StepVerifier.create(result)
+            .verifyComplete();
+
+        verify(plantService).getPlants();
+    }
+
+    @Test
+    @DisplayName("Should get plant by id successfully")
+    void getPlant_ShouldReturnPlant_WhenPlantExists() {
+        // Given
+        when(plantService.getPlant(1L)).thenReturn(testPlantDTO);
+
+        // When
+        Mono<PlantDTO> result = plantController.getPlant(1L);
+
+        // Then
+        StepVerifier.create(result)
+            .expectNext(testPlantDTO)
+            .verifyComplete();
+
+        verify(plantService).getPlant(1L);
+    }
+
+    @Test
+    @DisplayName("Should get plant by id when plant does not exist")
+    void getPlant_ShouldReturnEmpty_WhenPlantNotExists() {
+        // Given
+        when(plantService.getPlant(999L)).thenReturn(null);
+
+        // When
+        Mono<PlantDTO> result = plantController.getPlant(999L);
+
+        // Then
+        StepVerifier.create(result)
+            .verifyComplete();
+
+        verify(plantService).getPlant(999L);
+    }
+
+    @Test
+    @DisplayName("Should delete plant successfully")
+    void deletePlant_ShouldReturnNoContent_WhenPlantExists() {
+        // Given
+        doNothing().when(plantService).deletePlant(1L);
+
+        // When
+        Mono<ResponseEntity<Void>> result = plantController.deletePlant(1L);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(204, response.getStatusCode().value());
+            })
+            .verifyComplete();
+
+        verify(plantService).deletePlant(1L);
+    }
+
+    @Test
+    @DisplayName("Should water plant successfully")
+    void waterPlant_ShouldReturnUpdatedPlant_WhenValidDate() {
+        // Given
+        LocalDate waterDate = LocalDate.now();
+        PlantDTO wateredPlantDTO = new PlantDTO(
+            1L,
+            "Test Plant",
+            "Test Species",
+            "Test Description",
+            "Test Care Instructions",
+            PlantLocation.LIVING_ROOM,
+            7,
+            waterDate,
+            waterDate.plusDays(7),
+            testImageUuid.toString()
+        );
+
+        when(plantService.waterPlant(1L, waterDate)).thenReturn(wateredPlantDTO);
+
+        // When
+        Mono<ResponseEntity<PlantDTO>> result = plantController.waterPlant(1L, waterDate);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(200, response.getStatusCode().value());
+                assertEquals(wateredPlantDTO, response.getBody());
+            })
+            .verifyComplete();
+
+        verify(plantService).waterPlant(1L, waterDate);
+    }
+
+    @Test
+    @DisplayName("Should handle water plant with past date")
+    void waterPlant_ShouldHandlePastDate() {
+        // Given
+        LocalDate pastDate = LocalDate.now().minusDays(1);
+        PlantDTO wateredPlantDTO = new PlantDTO(
+            1L,
+            "Test Plant",
+            "Test Species",
+            "Test Description",
+            "Test Care Instructions",
+            PlantLocation.LIVING_ROOM,
+            7,
+            pastDate,
+            pastDate.plusDays(7),
+            testImageUuid.toString()
+        );
+
+        when(plantService.waterPlant(1L, pastDate)).thenReturn(wateredPlantDTO);
+
+        // When
+        Mono<ResponseEntity<PlantDTO>> result = plantController.waterPlant(1L, pastDate);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(200, response.getStatusCode().value());
+                assertEquals(wateredPlantDTO, response.getBody());
+            })
+            .verifyComplete();
+
+        verify(plantService).waterPlant(1L, pastDate);
+    }
+
+    @Test
+    @DisplayName("Should handle water plant with future date")
+    void waterPlant_ShouldHandleFutureDate() {
+        // Given
+        LocalDate futureDate = LocalDate.now().plusDays(1);
+        PlantDTO wateredPlantDTO = new PlantDTO(
+            1L,
+            "Test Plant",
+            "Test Species",
+            "Test Description",
+            "Test Care Instructions",
+            PlantLocation.LIVING_ROOM,
+            7,
+            futureDate,
+            futureDate.plusDays(7),
+            testImageUuid.toString()
+        );
+
+        when(plantService.waterPlant(1L, futureDate)).thenReturn(wateredPlantDTO);
+
+        // When
+        Mono<ResponseEntity<PlantDTO>> result = plantController.waterPlant(1L, futureDate);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(200, response.getStatusCode().value());
+                assertEquals(wateredPlantDTO, response.getBody());
+            })
+            .verifyComplete();
+
+        verify(plantService).waterPlant(1L, futureDate);
+    }
+
+    @Test
+    @DisplayName("Should handle water plant when service throws exception")
+    void waterPlant_ShouldHandleServiceException() {
+        // Given
+        LocalDate waterDate = LocalDate.now();
+        when(plantService.waterPlant(1L, waterDate))
+            .thenThrow(new RuntimeException("Plant not found"));
+
+        // When & Then
+        assertThrows(RuntimeException.class, () -> {
+            plantController.waterPlant(1L, waterDate).block();
+        });
+
+        verify(plantService).waterPlant(1L, waterDate);
+    }
+
+    @Test
+    @DisplayName("Should verify method name typo fix in waterPlant endpoint")
+    void waterPlant_ShouldFixMethodTypo() {
+        // Given
+        LocalDate waterDate = LocalDate.now();
+        PlantDTO wateredPlantDTO = new PlantDTO(
+            1L,
+            "Test Plant",
+            "Test Species",
+            "Test Description",
+            "Test Care Instructions",
+            PlantLocation.LIVING_ROOM,
+            7,
+            waterDate,
+            waterDate.plusDays(7),
+            testImageUuid.toString()
+        );
+
+        when(plantService.waterPlant(1L, waterDate)).thenReturn(wateredPlantDTO);
+
+        // When
+        Mono<ResponseEntity<PlantDTO>> result = plantController.waterPlant(1L, waterDate);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(200, response.getStatusCode().value());
+                assertEquals(wateredPlantDTO, response.getBody());
+            })
+            .verifyComplete();
+
+        verify(plantService).waterPlant(1L, waterDate);
+    }
+
+    @Test
+    @DisplayName("Should handle create plant with content type parameter")
+    void createPlant_ShouldHandleContentTypeParameter() {
+        // Given
+        PlantDTO newPlantDTO = new PlantDTO(
+            0L,
+            "New Plant",
+            "New Species",
+            "New Description",
+            "New Care Instructions",
+            PlantLocation.BEDROOM,
+            5,
+            null,
+            null,
+            null
+        );
+
+        byte[] imageBytes = "test image content".getBytes(StandardCharsets.UTF_8);
+        String contentType = "image/jpeg";
+
+        when(imageService.saveImage(eq(imageBytes), eq(contentType))).thenReturn(Mono.just(testImageUuid));
+        when(plantService.createPlant(any(PlantDTO.class), eq(testImageUuid.toString()))).thenReturn(1L);
+
+        FilePart filePart = mock(FilePart.class);
+        DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+
+        // When
+        Mono<ResponseEntity<Object>> result = plantController.createPlant(Mono.just(filePart), Mono.just(newPlantDTO), contentType);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(201, response.getStatusCode().value());
+                assertTrue(response.getHeaders().getLocation().toString().contains("/plants/1"));
+            })
+            .verifyComplete();
+
+        verify(imageService).saveImage(eq(imageBytes), eq(contentType));
+        verify(plantService).createPlant(any(PlantDTO.class), eq(testImageUuid.toString()));
+    }
+
+    @Test
+    @DisplayName("Should handle large number of plants request")
+    void getPlants_ShouldHandleLargeNumberOfPlants() {
+        // Given
+        List<PlantDTO> largePlantList = new ArrayList<>();
+        for (int i = 1; i <= 100; i++) {
+            largePlantList.add(new PlantDTO(
+                (long) i,
+                "Plant " + i,
+                "Species " + i,
+                "Description " + i,
+                "Care " + i,
+                PlantLocation.values()[i % PlantLocation.values().length],
+                i % 30 + 1,
+                null,
+                null,
+                null
+            ));
+        }
+
+        when(plantService.getPlants()).thenReturn(Flux.fromIterable(largePlantList));
+
+        // When
+        Flux<PlantDTO> result = plantController.getPlants();
+
+        // Then
+        StepVerifier.create(result)
+            .expectNextCount(100)
+            .verifyComplete();
+
+        verify(plantService).getPlants();
+    }
+
+    @Test
+    @DisplayName("Should verify method parameter validation")
+    void deletePlant_VerifyMethodParameterValidation() {
+        // Given
+        doNothing().when(plantService).deletePlant(1L);
+
+        // When
+        Mono<ResponseEntity<Void>> result = plantController.deletePlant(1L);
+
+        // Then
+        StepVerifier.create(result)
+            .assertNext(response -> {
+                assertEquals(204, response.getStatusCode().value());
+            })
+            .verifyComplete();
+
+        verify(plantService).deletePlant(1L);
+    }
+
+    @Test
+    @DisplayName("Should test getFileAsByteArray utility method")
+    void testGetFileAsByteArray_WithValidFile() throws Exception {
+        // Given - Using reflection to test the private method
+        java.lang.reflect.Method method = PlantController.class.getDeclaredMethod("getFileAsByteArray", Mono.class);
+        method.setAccessible(true);
+
+        byte[] expectedBytes = "test content".getBytes(StandardCharsets.UTF_8);
+        FilePart filePart = mock(FilePart.class);
+        DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(expectedBytes);
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+
+        // When
+        Mono<byte[]> result = (Mono<byte[]>) method.invoke(plantController, Mono.just(filePart));
+
+        // Then
+        StepVerifier.create(result)
+            .expectNextMatches(bytes -> java.util.Arrays.equals(expectedBytes, bytes))
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should test getFileAsByteArray with empty file")
+    void testGetFileAsByteArray_WithEmptyFile() throws Exception {
+        // Given
+        java.lang.reflect.Method method = PlantController.class.getDeclaredMethod("getFileAsByteArray", Mono.class);
+        method.setAccessible(true);
+
+        FilePart filePart = mock(FilePart.class);
+        when(filePart.content()).thenReturn(Flux.empty());
+
+        // When
+        Mono<byte[]> result = (Mono<byte[]>) method.invoke(plantController, Mono.just(filePart));
+
+        // Then
+        StepVerifier.create(result)
+            .expectNextMatches(bytes -> bytes.length == 0)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should test getFileAsByteArray with error")
+    void testGetFileAsByteArray_WithError() throws Exception {
+        // Given
+        java.lang.reflect.Method method = PlantController.class.getDeclaredMethod("getFileAsByteArray", Mono.class);
+        method.setAccessible(true);
+
+        FilePart filePart = mock(FilePart.class);
+        when(filePart.content()).thenReturn(Flux.error(new RuntimeException("File read error")));
+
+        // When
+        Mono<byte[]> result = (Mono<byte[]>) method.invoke(plantController, Mono.just(filePart));
+
+        // Then
+        StepVerifier.create(result)
+            .expectNextMatches(bytes -> bytes.length == 0)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- Created comprehensive JUnit test suite for PlantController with 21 test methods
- Fixed critical bugs in PlantController including method name typo and null handling
- Added complete test coverage for all REST endpoints and edge cases

## Test plan
✅ All 21 tests pass successfully
✅ Tests cover all PlantController endpoints:
  - POST /plants (create plant with and without image)
  - PUT /plants (update plant) 
  - GET /plants (get all plants)
  - GET /plants/{id} (get plant by id)
  - DELETE /plants/{id} (delete plant)
  - PATCH /plants/{id}/watered (water plant)

✅ Edge cases covered:
  - Empty image files
  - Null plant handling
  - Service exceptions
  - Large data sets
  - Date validation for watering
  - Image processing scenarios

✅ Quality improvements:
  - Fixed method name typo (deletePlant -> waterPlant in PATCH endpoint)
  - Fixed null handling using Mono.justOrEmpty
  - Added proper reactive testing with StepVerifier
  - Comprehensive mocking of ImageService and PlantService dependencies