### PR TITLE
fix: resolve Checkstyle violations in vocabulary test files

### DIFF
--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerErrorHandlingTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerErrorHandlingTest.java
@@ -39,9 +39,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenWordNotFoundException_ShouldReturn404WithStructuredError() {
-    String word = "nonexistentword";
-    WordNotFoundException exception = new WordNotFoundException(word);
+  void getWordWhenWordNotFoundExceptionShouldReturn404WithStructuredError() {
+    final String word = "nonexistentword";
+    final WordNotFoundException exception = new WordNotFoundException(word);
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -59,9 +59,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenInvalidWordException_ShouldReturn400WithStructuredError() {
-    String word = "invalid123";
-    InvalidWordException exception = new InvalidWordException(word);
+  void getWordWhenInvalidWordExceptionShouldReturn400WithStructuredError() {
+    final String word = "invalid123";
+    final InvalidWordException exception = new InvalidWordException(word);
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -79,9 +79,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenRateLimitExceededException_ShouldReturn429WithStructuredError() {
-    String word = "test";
-    RateLimitExceededException exception = new RateLimitExceededException();
+  void getWordWhenRateLimitExceededExceptionShouldReturn429WithStructuredError() {
+    final String word = "test";
+    final RateLimitExceededException exception = new RateLimitExceededException();
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -97,9 +97,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenDictionaryServiceUnavailableException_ShouldReturn503WithStructuredError() {
-    String word = "test";
-    DictionaryServiceUnavailableException exception = new DictionaryServiceUnavailableException();
+  void getWordWhenDictionaryServiceUnavailableExceptionShouldReturn503WithStructuredError() {
+    final String word = "test";
+    final DictionaryServiceUnavailableException exception = new DictionaryServiceUnavailableException();
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -116,9 +116,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenGenericDictionaryApiException_ShouldReturnCorrectStatusCodeWithStructuredError() {
-    String word = "test";
-    DictionaryApiException exception = new DictionaryApiException(
+  void getWordWhenGenericDictionaryApiExceptionShouldReturnCorrectStatusCodeWithStructuredError() {
+    final String word = "test";
+    final DictionaryApiException exception = new DictionaryApiException(
         "Some API error occurred",
         402,
         "PAYMENT_REQUIRED"
@@ -139,9 +139,9 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenRuntimeException_ShouldReturn500WithStructuredError() {
-    String word = "test";
-    RuntimeException exception = new RuntimeException("Unexpected error");
+  void getWordWhenRuntimeExceptionShouldReturn500WithStructuredError() {
+    final String word = "test";
+    final RuntimeException exception = new RuntimeException("Unexpected error");
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -157,10 +157,10 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenCustomRateLimitMessage_ShouldReturnCustomMessage() {
-    String word = "test";
-    String customMessage = "Rate limit: 100 requests per hour exceeded. Try again later.";
-    RateLimitExceededException exception = new RateLimitExceededException(customMessage);
+  void getWordWhenCustomRateLimitMessageShouldReturnCustomMessage() {
+    final String word = "test";
+    final String customMessage = "Rate limit: 100 requests per hour exceeded. Try again later.";
+    final RateLimitExceededException exception = new RateLimitExceededException(customMessage);
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -176,11 +176,12 @@ class FlashcardControllerErrorHandlingTest {
   }
 
   @Test
-  void getWord_WhenCustomServiceUnavailableMessage_ShouldReturnCustomMessage() {
-    String word = "test";
-    String customMessage = "Dictionary API is under maintenance. Please try again in 5 minutes.";
-    DictionaryServiceUnavailableException exception = new DictionaryServiceUnavailableException(
-        customMessage);
+  void getWordWhenCustomServiceUnavailableMessageShouldReturnCustomMessage() {
+    final String word = "test";
+    final String customMessage =
+        "Dictionary API is under maintenance. Please try again in 5 minutes.";
+    final DictionaryServiceUnavailableException exception =
+        new DictionaryServiceUnavailableException(customMessage);
 
     when(dictionaryClient.getWord(word)).thenReturn(Mono.error(exception));
 
@@ -197,28 +198,29 @@ class FlashcardControllerErrorHandlingTest {
 
 
   @Test
-  void verifyExceptionProperties_AreCorrectlyMapped() {
-    String word = "testword";
+  void verifyExceptionPropertiesAreCorrectlyMapped() {
+    final String word = "testword";
 
     // Test WordNotFoundException properties
-    WordNotFoundException wordNotFound = new WordNotFoundException(word);
+    final WordNotFoundException wordNotFound = new WordNotFoundException(word);
     assert wordNotFound.getWord().equals(word);
     assert wordNotFound.getStatusCode() == 404;
     assert wordNotFound.getErrorType().equals("WORD_NOT_FOUND");
 
     // Test InvalidWordException properties
-    InvalidWordException invalidWord = new InvalidWordException(word);
+    final InvalidWordException invalidWord = new InvalidWordException(word);
     assert invalidWord.getWord().equals(word);
     assert invalidWord.getStatusCode() == 400;
     assert invalidWord.getErrorType().equals("INVALID_WORD");
 
     // Test RateLimitExceededException properties
-    RateLimitExceededException rateLimit = new RateLimitExceededException();
+    final RateLimitExceededException rateLimit = new RateLimitExceededException();
     assert rateLimit.getStatusCode() == 429;
     assert rateLimit.getErrorType().equals("RATE_LIMIT_EXCEEDED");
 
     // Test DictionaryServiceUnavailableException properties
-    DictionaryServiceUnavailableException serviceUnavailable = new DictionaryServiceUnavailableException();
+    final DictionaryServiceUnavailableException serviceUnavailable =
+        new DictionaryServiceUnavailableException();
     assert serviceUnavailable.getStatusCode() == 503;
     assert serviceUnavailable.getErrorType().equals("SERVICE_UNAVAILABLE");
   }

--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
@@ -41,37 +41,34 @@ class FlashcardControllerTest {
 
   private WebTestClient webTestClient;
 
-  private FlashcardEntity testFlashcardEntity;
-  private Flashcard testFlashcard;
+  private final FlashcardEntity testFlashcardEntity = new FlashcardEntity(
+      1,
+      "test-deck",
+      "anki-123",
+      "test front",
+      "test back",
+      "test description",
+      true
+  );
+
+  private final Flashcard testFlashcard = new Flashcard(
+      1,
+      "test-deck",
+      "anki-123",
+      "test front",
+      "test back",
+      "test description",
+      true
+  );
 
   @BeforeEach
   void setUp() {
     webTestClient = WebTestClient.bindToController(flashcardController).build();
-
-    testFlashcardEntity = new FlashcardEntity(
-        1,
-        "test-deck",
-        "anki-123",
-        "test front",
-        "test back",
-        "test description",
-        true
-    );
-
-    testFlashcard = new Flashcard(
-        1,
-        "test-deck",
-        "anki-123",
-        "test front",
-        "test back",
-        "test description",
-        true
-    );
   }
 
   @Test
-  void getWord_ShouldReturnDictionaryEntries() {
-    List<DictionaryEntry> expectedEntries = List.of(new DictionaryEntry(
+  void getWordShouldReturnDictionaryEntries() {
+    final List<DictionaryEntry> expectedEntries = List.of(new DictionaryEntry(
         "hello",
         "/həˈloʊ/",
         List.of(),
@@ -91,7 +88,7 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFlashcard_WhenFlashcardExists_ShouldReturnFlashcard() {
+  void getFlashcardWhenFlashcardExistsShouldReturnFlashcard() {
     when(flashcardService.get(1)).thenReturn(testFlashcardEntity);
 
     webTestClient.get()
@@ -103,7 +100,7 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFlashcard_WhenFlashcardNotExists_ShouldReturnNotFound() {
+  void getFlashcardWhenFlashcardNotExistsShouldReturnNotFound() {
     when(flashcardService.get(999)).thenReturn(null);
 
     webTestClient.get()
@@ -113,9 +110,9 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFlashcards_WithoutParams_ShouldReturnAllFlashcards() {
-    List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
-    List<Flashcard> expectedFlashcards = List.of(testFlashcard);
+  void getFlashcardsWithoutParamsShouldReturnAllFlashcards() {
+    final List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
+    final List<Flashcard> expectedFlashcards = List.of(testFlashcard);
 
     when(flashcardService.get(null, null)).thenReturn(flashcardEntities);
 
@@ -128,9 +125,9 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFlashcards_WithMissingAnkiIdParam_ShouldReturnFlashcardsWithoutAnkiId() {
-    List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
-    List<Flashcard> expectedFlashcards = List.of(testFlashcard);
+  void getFlashcardsWithMissingAnkiIdParamShouldReturnFlashcardsWithoutAnkiId() {
+    final List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
+    final List<Flashcard> expectedFlashcards = List.of(testFlashcard);
 
     when(flashcardService.get("ankiId", null)).thenReturn(flashcardEntities);
 
@@ -146,9 +143,9 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFlashcards_WithUpdatedParam_ShouldReturnUpdatedFlashcards() {
-    List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
-    List<Flashcard> expectedFlashcards = List.of(testFlashcard);
+  void getFlashcardsWithUpdatedParamShouldReturnUpdatedFlashcards() {
+    final List<FlashcardEntity> flashcardEntities = List.of(testFlashcardEntity);
+    final List<Flashcard> expectedFlashcards = List.of(testFlashcard);
 
     when(flashcardService.get(null, true)).thenReturn(flashcardEntities);
 
@@ -164,9 +161,9 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFile_ShouldReturnCsvFile() throws Exception {
-    byte[] expectedFileContent = "#separator:tab\n#html:false\n#guid column:1\ntest-content".getBytes(
-        StandardCharsets.UTF_8);
+  void getFileShouldReturnCsvFile() throws Exception {
+    final byte[] expectedFileContent = "#separator:tab\n#html:false\n#guid column:1\ntest-content"
+        .getBytes(StandardCharsets.UTF_8);
 
     when(flashcardService.getFile()).thenReturn(expectedFileContent);
 
@@ -184,7 +181,7 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void getFile_WhenExceptionThrown_ShouldReturnInternalServerError() throws Exception {
+  void getFileWhenExceptionThrownShouldReturnInternalServerError() throws Exception {
     when(flashcardService.getFile()).thenThrow(new RuntimeException("File generation failed"));
 
     webTestClient.get()
@@ -197,8 +194,8 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void addFlashcard_ShouldCreateFlashcardAndReturnLocation() {
-    Flashcard newFlashcard = new Flashcard(
+  void addFlashcardShouldCreateFlashcardAndReturnLocation() {
+    final Flashcard newFlashcard = new Flashcard(
         null,
         "new-deck",
         "anki-456",
@@ -208,7 +205,7 @@ class FlashcardControllerTest {
         false
     );
 
-    FlashcardEntity savedEntity = new FlashcardEntity(
+    final FlashcardEntity savedEntity = new FlashcardEntity(
         2,
         "new-deck",
         "anki-456",
@@ -231,7 +228,7 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void updateFlashcard_ShouldUpdateFlashcardAndReturnNoContent() {
+  void updateFlashcardShouldUpdateFlashcardAndReturnNoContent() {
     when(flashcardService.update(any(FlashcardEntity.class))).thenReturn(1);
 
     webTestClient.put()
@@ -244,13 +241,13 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void updateFlashcards_WithValidFile_ShouldImportAndUpdate() {
-    String csvContent = "deck1\tanki-123\tfront1\tback1\tdescription1\n";
-    byte[] fileBytes = csvContent.getBytes(StandardCharsets.UTF_8);
+  void updateFlashcardsWithValidFileShouldImportAndUpdate() {
+    final String csvContent = "deck1\tanki-123\tfront1\tback1\tdescription1\n";
+    final byte[] fileBytes = csvContent.getBytes(StandardCharsets.UTF_8);
 
     lenient().when(flashcardService.importFlashcards(fileBytes)).thenReturn(1);
 
-    FilePart filePart = createMockFilePart("test.csv", fileBytes);
+    final FilePart filePart = createMockFilePart("test.csv", fileBytes);
 
     webTestClient.put()
         .uri("/vocabulary/flashcards/file")
@@ -262,8 +259,8 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void updateFlashcards_WithEmptyFile_ShouldHandleGracefully() {
-    FilePart filePart = createMockFilePart("empty.csv", new byte[0]);
+  void updateFlashcardsWithEmptyFileShouldHandleGracefully() {
+    final FilePart filePart = createMockFilePart("empty.csv", new byte[0]);
 
     lenient().when(flashcardService.importFlashcards(new byte[0])).thenReturn(0);
 
@@ -277,14 +274,14 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void updateFlashcards_WhenExceptionThrown_ShouldHandleError() {
-    String csvContent = "invalid content";
-    byte[] fileBytes = csvContent.getBytes(StandardCharsets.UTF_8);
+  void updateFlashcardsWhenExceptionThrownShouldHandleError() {
+    final String csvContent = "invalid content";
+    final byte[] fileBytes = csvContent.getBytes(StandardCharsets.UTF_8);
 
     lenient().when(flashcardService.importFlashcards(fileBytes))
         .thenThrow(new RuntimeException("Import failed"));
 
-    FilePart filePart = createMockFilePart("test.csv", fileBytes);
+    final FilePart filePart = createMockFilePart("test.csv", fileBytes);
 
     webTestClient.put()
         .uri("/vocabulary/flashcards/file")
@@ -296,7 +293,7 @@ class FlashcardControllerTest {
   }
 
   @Test
-  void handleException_ShouldReturnErrorResponse() {
+  void handleExceptionShouldReturnErrorResponse() {
     // Force an exception by mocking the service to throw an exception
     when(dictionaryClient.getWord(any())).thenThrow(new RuntimeException("Test exception"));
 
@@ -311,33 +308,46 @@ class FlashcardControllerTest {
         });
   }
 
-  private FilePart createMockFilePart(String filename, byte[] content) {
-    return new FilePart() {
-      @Override
-      public String filename() {
-        return filename;
-      }
+  private FilePart createMockFilePart(final String filename, final byte[] content) {
+    return new MockFilePart(filename, content);
+  }
 
-      @Override
-      public String name() {
-        return "file";
-      }
+  /**
+   * Mock implementation of FilePart for testing purposes.
+   */
+  private static class MockFilePart implements FilePart {
+    private final String filename;
+    private final byte[] content;
 
-      @Override
-      public Flux<DataBuffer> content() {
-        DataBuffer buffer = new DefaultDataBufferFactory().wrap(content);
-        return Flux.just(buffer);
-      }
+    MockFilePart(final String filename, final byte[] content) {
+      this.filename = filename;
+      this.content = content;
+    }
 
-      @Override
-      public org.springframework.http.HttpHeaders headers() {
-        return org.springframework.http.HttpHeaders.EMPTY;
-      }
+    @Override
+    public String filename() {
+      return filename;
+    }
 
-      @Override
-      public reactor.core.publisher.Mono<Void> transferTo(java.nio.file.Path dest) {
-        return reactor.core.publisher.Mono.empty();
-      }
-    };
+    @Override
+    public String name() {
+      return "file";
+    }
+
+    @Override
+    public Flux<DataBuffer> content() {
+      final DataBuffer buffer = new DefaultDataBufferFactory().wrap(content);
+      return Flux.just(buffer);
+    }
+
+    @Override
+    public org.springframework.http.HttpHeaders headers() {
+      return org.springframework.http.HttpHeaders.EMPTY;
+    }
+
+    @Override
+    public reactor.core.publisher.Mono<Void> transferTo(final java.nio.file.Path dest) {
+      return reactor.core.publisher.Mono.empty();
+    }
   }
 }

--- a/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/DictionaryClientTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/DictionaryClientTest.java
@@ -22,10 +22,10 @@ class DictionaryClientTest {
   }
 
   @Test
-  void getWord_WhenNullWord_ShouldReturnInvalidWordException() {
-    String nullWord = null;
+  void getWordWhenNullWordShouldReturnInvalidWordException() {
+    final String nullWord = null;
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(nullWord);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(nullWord);
 
     StepVerifier.create(result)
         .expectErrorMatches(throwable ->
@@ -37,10 +37,10 @@ class DictionaryClientTest {
   }
 
   @Test
-  void getWord_WhenEmptyWord_ShouldReturnInvalidWordException() {
-    String emptyWord = "";
+  void getWordWhenEmptyWordShouldReturnInvalidWordException() {
+    final String emptyWord = "";
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(emptyWord);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(emptyWord);
 
     StepVerifier.create(result)
         .expectErrorMatches(throwable ->
@@ -52,10 +52,10 @@ class DictionaryClientTest {
   }
 
   @Test
-  void getWord_WhenBlankWord_ShouldReturnInvalidWordException() {
-    String blankWord = "   ";
+  void getWordWhenBlankWordShouldReturnInvalidWordException() {
+    final String blankWord = "   ";
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(blankWord);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(blankWord);
 
     StepVerifier.create(result)
         .expectErrorMatches(throwable ->
@@ -67,10 +67,10 @@ class DictionaryClientTest {
   }
 
   @Test
-  void getWord_WhenWordWithNumbers_ShouldReturnInvalidWordException() {
-    String wordWithNumbers = "hello123";
+  void getWordWhenWordWithNumbersShouldReturnInvalidWordException() {
+    final String wordWithNumbers = "hello123";
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(wordWithNumbers);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(wordWithNumbers);
 
     StepVerifier.create(result)
         .expectErrorMatches(throwable ->
@@ -82,10 +82,10 @@ class DictionaryClientTest {
   }
 
   @Test
-  void getWord_WhenWordWithSpecialCharacters_ShouldReturnInvalidWordException() {
-    String wordWithSpecialChars = "hello!@#";
+  void getWordWhenWordWithSpecialCharactersShouldReturnInvalidWordException() {
+    final String wordWithSpecialChars = "hello!@#";
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(wordWithSpecialChars);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(wordWithSpecialChars);
 
     StepVerifier.create(result)
         .expectErrorMatches(throwable ->
@@ -98,14 +98,14 @@ class DictionaryClientTest {
 
 
   @Test
-  void invalidWordException_ShouldContainCorrectProperties() {
-    String invalidWord = "test123";
+  void invalidWordExceptionShouldContainCorrectProperties() {
+    final String invalidWord = "test123";
 
-    Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(invalidWord);
+    final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(invalidWord);
 
     StepVerifier.create(result)
         .consumeErrorWith(throwable -> {
-          InvalidWordException exception = (InvalidWordException) throwable;
+          final InvalidWordException exception = (InvalidWordException) throwable;
           assert exception.getWord().equals(invalidWord);
           assert exception.getStatusCode() == 400;
           assert exception.getErrorType().equals("INVALID_WORD");
@@ -114,16 +114,16 @@ class DictionaryClientTest {
   }
 
   @Test
-  void validation_ShouldAcceptValidWordPatterns() {
+  void validationShouldAcceptValidWordPatterns() {
     // Test that valid patterns don't immediately throw validation errors
     // Note: These might still fail at the API call level, but not due to validation
-    String[] validWords = {
+    final String[] validWords = {
         "hello",
         "world",
         "test"
     };
 
-    for (String word : validWords) {
+    for (final String word : validWords) {
       try {
         dictionaryClient.getWord(word);
         // If we get here without exception, validation passed
@@ -135,8 +135,8 @@ class DictionaryClientTest {
   }
 
   @Test
-  void validation_ShouldRejectInvalidWordPatterns() {
-    String[] invalidWords = {
+  void validationShouldRejectInvalidWordPatterns() {
+    final String[] invalidWords = {
         "hello123",
         "test@word",
         "word#hash",
@@ -152,8 +152,8 @@ class DictionaryClientTest {
         "hello%world"
     };
 
-    for (String word : invalidWords) {
-      Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(word);
+    for (final String word : invalidWords) {
+      final Mono<List<DictionaryEntry>> result = dictionaryClient.getWord(word);
 
       // These should all fail validation with InvalidWordException
       StepVerifier.create(result)

--- a/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryIntegrationTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryIntegrationTest.java
@@ -7,12 +7,12 @@ import reactor.test.StepVerifier;
 class WiktionaryIntegrationTest {
 
   @Test
-  void getWord_WithValidWord_ShouldReturnEntriesFromWiktionary() {
-    HtmlCleaner htmlCleaner = new HtmlCleaner();
-    WiktionaryResponseMapper responseMapper = new WiktionaryResponseMapper(htmlCleaner);
-    DictionaryClient dictionaryClient = new DictionaryClient(responseMapper);
+  void getWordWithValidWordShouldReturnEntriesFromWiktionary() {
+    final HtmlCleaner htmlCleaner = new HtmlCleaner();
+    final WiktionaryResponseMapper responseMapper = new WiktionaryResponseMapper(htmlCleaner);
+    final DictionaryClient dictionaryClient = new DictionaryClient(responseMapper);
 
-    String testWord = "hello";
+    final String testWord = "hello";
 
     StepVerifier.create(dictionaryClient.getWord(testWord))
         .expectNextMatches(entries -> {
@@ -20,7 +20,7 @@ class WiktionaryIntegrationTest {
             return false;
           }
 
-          DictionaryEntry entry = entries.get(0);
+          final DictionaryEntry entry = entries.get(0);
           return entry.word().equals(testWord) &&
               !entry.meanings().isEmpty() &&
               entry.meanings().get(0).partOfSpeech() != null &&

--- a/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryResponseMapperTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryResponseMapperTest.java
@@ -22,17 +22,17 @@ class WiktionaryResponseMapperTest {
   }
 
   @Test
-  void mapToDictionaryEntries_WithEmptyDefinitions_ShouldFilterThemOut() {
+  void mapToDictionaryEntriesWithEmptyDefinitionsShouldFilterThemOut() {
     // Create test data with empty definitions
-    Map<String, List<WiktionaryResponseMapper.WiktionaryDefinition>> response = Map.of("en",
+    final Map<String, List<WiktionaryResponseMapper.WiktionaryDefinition>> response = Map.of("en",
         List.of(
             createDefinitionWithMixedContent()
         ));
 
-    List<DictionaryEntry> entries = responseMapper.mapToDictionaryEntries("test", response);
+    final List<DictionaryEntry> entries = responseMapper.mapToDictionaryEntries("test", response);
 
     assertEquals(1, entries.size());
-    DictionaryEntry entry = entries.get(0);
+    final DictionaryEntry entry = entries.get(0);
     assertEquals(1, entry.meanings().size());
 
     // Should only have 4 valid definitions (not 9 total with empty ones)
@@ -46,11 +46,12 @@ class WiktionaryResponseMapperTest {
   }
 
   private WiktionaryResponseMapper.WiktionaryDefinition createDefinitionWithMixedContent() {
-    WiktionaryResponseMapper.WiktionaryDefinition definition = new WiktionaryResponseMapper.WiktionaryDefinition();
+    final WiktionaryResponseMapper.WiktionaryDefinition definition =
+        new WiktionaryResponseMapper.WiktionaryDefinition();
     definition.setPartOfSpeech("Noun");
 
     // Mix of valid and empty definitions
-    List<WiktionaryResponseMapper.WiktionaryDefinition.Definition> definitions = List.of(
+    final List<WiktionaryResponseMapper.WiktionaryDefinition.Definition> definitions = List.of(
         createDefinition("A valid definition", null),
         createDefinition("", null), // empty
         createDefinition("   ", null), // whitespace only
@@ -68,7 +69,8 @@ class WiktionaryResponseMapperTest {
 
   private WiktionaryResponseMapper.WiktionaryDefinition.Definition createDefinition(
       String definition, String example) {
-    WiktionaryResponseMapper.WiktionaryDefinition.Definition def = new WiktionaryResponseMapper.WiktionaryDefinition.Definition();
+    final WiktionaryResponseMapper.WiktionaryDefinition.Definition def =
+        new WiktionaryResponseMapper.WiktionaryDefinition.Definition();
     def.setDefinition(definition);
     if (example != null) {
       def.setExamples(List.of(example));


### PR DESCRIPTION
## Summary
- Fixed all Checkstyle violations in vocabulary test files
- Converted test method names from underscore format to camelCase (e.g., `getWord_WhenExceptionThrown_ShouldReturn404` → `getWordWhenExceptionThrownShouldReturn404`)
- Added `final` modifier to local variables that are assigned once and never reassigned
- Fixed line length violations by breaking lines longer than 120 characters
- Refactored anonymous inner class to meet the 20-line limit requirement

## Test Plan
- [x] All vocabulary test files pass Checkstyle validation
- [x] All tests still pass and maintain original functionality
- [x] Code follows project's style guidelines

## Files Changed
- `vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerErrorHandlingTest.java`
- `vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java`
- `vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/DictionaryClientTest.java`
- `vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryIntegrationTest.java`
- `vocabulary/src/test/java/com/marvin/vocabulary/dictionaryapi/WiktionaryResponseMapperTest.java`