### PR TITLE
fix: remove field-level comments from influxdb classes

### DIFF
--- a/influxdb/src/main/java/com/marvin/influxdb/costs/AbstractCostImport.java
+++ b/influxdb/src/main/java/com/marvin/influxdb/costs/AbstractCostImport.java
@@ -24,19 +24,14 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractCostImport<DTO, MEAS> {
 
-    /** Logger for this class. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCostImport.class);
 
-    /** UTC timezone constant for date conversions. */
     private static final String UTC_TIMEZONE = "UTC";
 
-    /** InfluxDB bucket name for costs. */
     private static final String COSTS_BUCKET = "costs";
 
-    /** InfluxDB organization name. */
     private static final String WILDFLY_DOMAIN_ORG = "wildfly_domain";
 
-    /** The InfluxDB client instance. */
     private final InfluxDBClient influxDBClient;
 
     /**

--- a/influxdb/src/main/java/com/marvin/influxdb/costs/CostType.java
+++ b/influxdb/src/main/java/com/marvin/influxdb/costs/CostType.java
@@ -12,13 +12,10 @@ package com.marvin.influxdb.costs;
  */
 public enum CostType {
 
-    /** Daily cost type for operational expenses. */
     DAILY("daily"),
 
-    /** Monthly cost type for recurring monthly expenses. */
     MONTHLY("monthly"),
 
-    /** Salary cost type for employee compensation. */
     SALARY("salary");
 
     private final String value;


### PR DESCRIPTION
## Summary
- Removed only field-level comments from InfluxDB module classes
- Preserved all class-level and method-level documentation
- Focused cleanup on unnecessary field comment noise

## Changes Made
### AbstractCostImport.java
- Removed 5 field-level comments:
  - LOGGER field comment
  - UTC_TIMEZONE constant comment
  - COSTS_BUCKET constant comment  
  - WILDFLY_DOMAIN_ORG constant comment
  - influxDBClient field comment

### CostType.java
- Removed 3 enum constant comments:
  - DAILY enum value comment
  - MONTHLY enum value comment
  - SALARY enum value comment

## What Remains
- All class-level Javadoc documentation preserved
- All method-level Javadoc documentation preserved
- All constructor comments preserved
- Clean, readable code without redundant field comments

## Test plan
- [x] Verify code compiles without issues
- [x] Confirm class and method documentation intact
- [x] Check no field-level comments remain
- [x] Validate formatting consistency