### PR TITLE
Refactor uploader module according to clean code standards

### DIFF
--- a/uploader/src/main/java/com/marvin/upload/GoogleDriveException.java
+++ b/uploader/src/main/java/com/marvin/upload/GoogleDriveException.java
@@ -2,12 +2,11 @@ package com.marvin.upload;
 
 public class GoogleDriveException extends Exception {
 
-  public GoogleDriveException(String message) {
-    super(message);
-  }
+    public GoogleDriveException(String message) {
+        super(message);
+    }
 
-  public GoogleDriveException(Exception e) {
-    super(e);
-  }
-
+    public GoogleDriveException(Exception e) {
+        super(e);
+    }
 }

--- a/uploader/src/main/java/com/marvin/upload/Uploader.java
+++ b/uploader/src/main/java/com/marvin/upload/Uploader.java
@@ -18,76 +18,100 @@ import org.springframework.stereotype.Component;
 @Component
 public class Uploader {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Uploader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Uploader.class);
 
-  private static final DateTimeFormatter FILE_DTF = DateTimeFormatter.ofPattern(
-      "yyyyMMdd_hhmmss");
+    private static final DateTimeFormatter FILE_DTF = DateTimeFormatter.ofPattern(
+            "yyyyMMdd_hhmmss");
 
-  private final String costExportFolder;
-  private final String parentFolderName;
-  private final GoogleDrive googleDrive;
+    private final String costExportFolder;
+    private final String parentFolderName;
+    private final GoogleDrive googleDrive;
 
-  public Uploader(
-      @Value("${uploader.cost-export-folder}") String costExportFolder,
-      @Value("${uploader.parent-folder-name}") String parentFolderName,
-      GoogleDrive googleDrive
-  ) {
-    this.costExportFolder = costExportFolder;
-    this.parentFolderName = parentFolderName;
-    this.googleDrive = googleDrive;
-  }
-
-  public void zipAndUploadCostFiles(List<Path> filesToZipAndUpload) {
-
-    LOGGER.info("Going to zip and upload files!");
-
-    final Path dirPath = Paths.get(costExportFolder);
-    final Path zipFilePath = dirPath.resolve(
-        "files_" + LocalDateTime.now().format(FILE_DTF) + ".zip");
-
-    try (ZipOutputStream zipOutputStream = new ZipOutputStream(
-        Files.newOutputStream(zipFilePath))) {
-      zipOutputStream.setLevel(9);
-      filesToZipAndUpload.stream()
-          .filter(path -> !Files.isDirectory(path))
-          .forEach(path -> {
-            Path filePath = dirPath.resolve(path);
-            ZipEntry zipEntry = new ZipEntry(filePath.toString());
-            LOGGER.info("Added zip entry {}", zipEntry.getName());
-            try {
-              zipOutputStream.putNextEntry(zipEntry);
-              Files.copy(filePath, zipOutputStream);
-              zipOutputStream.closeEntry();
-            } catch (IOException e) {
-              throw new UncheckedIOException(e);
-            }
-          });
-    } catch (IOException e) {
-      throw new RuntimeException("Could not handle files!", e);
+    public Uploader(
+            @Value("${uploader.cost-export-folder}") String costExportFolder,
+            @Value("${uploader.parent-folder-name}") String parentFolderName,
+            GoogleDrive googleDrive
+    ) {
+        this.costExportFolder = costExportFolder;
+        this.parentFolderName = parentFolderName;
+        this.googleDrive = googleDrive;
     }
 
-    try {
-      String parentId = googleDrive.getFileId(parentFolderName);
-      googleDrive.uploadFile(zipFilePath, parentId);
-      for (Path path : filesToZipAndUpload) {
-        Path filePath = dirPath.resolve(path);
-        try {
-          Files.delete(filePath);
-          LOGGER.info("Deleted file {}!", filePath);
+    public void zipAndUploadCostFiles(List<Path> filesToZipAndUpload) {
+        LOGGER.info("Going to zip and upload files!");
+
+        final Path dirPath = Paths.get(costExportFolder);
+        final Path zipFilePath = generateZipFilePath(dirPath);
+
+        createZipFile(filesToZipAndUpload, dirPath, zipFilePath);
+        uploadToGoogleDrive(zipFilePath);
+        cleanupFiles(filesToZipAndUpload, dirPath, zipFilePath);
+    }
+
+    private Path generateZipFilePath(Path dirPath) {
+        final String timestamp = LocalDateTime.now().format(FILE_DTF);
+        return dirPath.resolve("files_" + timestamp + ".zip");
+    }
+
+    private void createZipFile(List<Path> filesToZipAndUpload, Path dirPath, Path zipFilePath) {
+        try (final ZipOutputStream zipOutputStream = new ZipOutputStream(
+                Files.newOutputStream(zipFilePath))) {
+            zipOutputStream.setLevel(9);
+            filesToZipAndUpload.stream()
+                    .filter(path -> !Files.isDirectory(path))
+                    .forEach(path -> addFileToZip(path, dirPath, zipOutputStream));
         } catch (IOException e) {
-          LOGGER.error("Could not delete file {}!", filePath, e);
+            throw new RuntimeException("Could not create zip file!", e);
         }
-      }
-      try {
-        Files.delete(zipFilePath);
-        LOGGER.info("Deleted file {}!", zipFilePath);
-      } catch (IOException e) {
-        LOGGER.error("Could not delete file {}!", zipFilePath, e);
-      }
-    } catch (GoogleDriveException e) {
-      LOGGER.error("Could not upload file!", e);
-      throw new IllegalStateException(e);
     }
-  }
 
+    private void addFileToZip(Path path, Path dirPath, ZipOutputStream zipOutputStream) {
+        final Path filePath = dirPath.resolve(path);
+        final ZipEntry zipEntry = new ZipEntry(filePath.toString());
+        LOGGER.info("Added zip entry {}", zipEntry.getName());
+
+        try {
+            zipOutputStream.putNextEntry(zipEntry);
+            Files.copy(filePath, zipOutputStream);
+            zipOutputStream.closeEntry();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void uploadToGoogleDrive(Path zipFilePath) {
+        try {
+            final String parentId = googleDrive.getFileId(parentFolderName);
+            googleDrive.uploadFile(zipFilePath, parentId);
+        } catch (GoogleDriveException e) {
+            LOGGER.error("Could not upload file!", e);
+            throw new IllegalStateException("Failed to upload zip file to Google Drive", e);
+        }
+    }
+
+    private void cleanupFiles(List<Path> filesToZipAndUpload, Path dirPath, Path zipFilePath) {
+        deleteUploadedFiles(filesToZipAndUpload, dirPath);
+        deleteZipFile(zipFilePath);
+    }
+
+    private void deleteUploadedFiles(List<Path> filesToZipAndUpload, Path dirPath) {
+        for (Path path : filesToZipAndUpload) {
+            final Path filePath = dirPath.resolve(path);
+            try {
+                Files.delete(filePath);
+                LOGGER.info("Deleted file {}!", filePath);
+            } catch (IOException e) {
+                LOGGER.error("Could not delete file {}!", filePath, e);
+            }
+        }
+    }
+
+    private void deleteZipFile(Path zipFilePath) {
+        try {
+            Files.delete(zipFilePath);
+            LOGGER.info("Deleted file {}!", zipFilePath);
+        } catch (IOException e) {
+            LOGGER.error("Could not delete file {}!", zipFilePath, e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Refactored the uploader module to follow clean code principles
- Improved code readability, maintainability, and testability

## Changes Made
- **GoogleDrive.java**:
  - Extracted duplicate Drive service creation into `createDriveService()` method
  - Parameterized hardcoded folder name in `getFileId()` method
  - Split file upload logic into smaller, focused methods
  - Renamed `getCredentialsPath()` to `getCredentials()` for clarity
  - Fixed method naming and improved error handling

- **Uploader.java**:
  - Split the large `zipAndUploadCostFiles()` method into smaller methods with single responsibilities
  - Extracted zip file creation logic into `createZipFile()` and `addFileToZip()` methods
  - Separated file cleanup logic into `deleteUploadedFiles()` and `deleteZipFile()` methods
  - Improved error messages and exception handling
  - Fixed code formatting and indentation

- **GoogleDriveException.java**:
  - Fixed code formatting and indentation

## Test plan
- [x] Build passes successfully
- [x] Checkstyle validation passes
- [x] No functional changes introduced