### PR TITLE
Remove comments from sensor integration classes

### DIFF
--- a/importer/src/main/java/com/marvin/app/sensor/dto/SensorData.java
+++ b/importer/src/main/java/com/marvin/app/sensor/dto/SensorData.java
@@ -10,22 +10,6 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.time.Instant;
 import java.util.Map;
 
-/**
- * InfluxDB measurement record for sensor data.
- *
- * <p>This record represents sensor data that can be stored in InfluxDB.
- * It supports dynamic measurements, entities, fields, and tags as shown in the JSON example.</p>
- *
- * @param measurement   the name of the measurement (can be wildcard %)
- * @param entityId      the unique identifier of the sensor entity
- * @param friendlyName  the human-readable name of the sensor
- * @param timestamp     the timestamp when the sensor reading was taken
- * @param fields        the sensor values as a map (e.g., humidity value)
- * @param tags          the tags associated with the sensor reading
- * @author Marvin Application
- * @version 1.0
- * @since 1.0
- */
 @Measurement(name = "%")
 public record SensorData(
     @Column(name = "measurement", tag = true)
@@ -61,24 +45,16 @@ public record SensorData(
     boolean humiditySensor
 ) {
 
-    /**
-     * Gets the primary sensor value from the fields map.
-     * Assumes the first value in the fields map is the primary sensor reading.
-     *
-     * @return the primary sensor value, or null if no fields are present
-     */
     public Double getPrimaryValue() {
         if (fields == null || fields.isEmpty()) {
             return null;
         }
 
-        // Try to find a "value" field first
         Object value = fields.get("value");
         if (value instanceof Number) {
             return ((Number) value).doubleValue();
         }
 
-        // If no "value" field, return the first numeric value found
         return fields.values().stream()
                 .filter(Number.class::isInstance)
                 .map(Number.class::cast)

--- a/importer/src/main/java/com/marvin/app/sensor/importer/SensorDataFileTypeHandler.java
+++ b/importer/src/main/java/com/marvin/app/sensor/importer/SensorDataFileTypeHandler.java
@@ -6,67 +6,30 @@ import com.marvin.app.sensor.dto.SensorData;
 import com.marvin.app.sensor.service.SensorDataImport;
 import org.springframework.stereotype.Component;
 
-/**
- * FileTypeHandler for processing sensor data files.
- *
- * <p>This component handles the processing of sensor data files by implementing
- * the FileTypeHandler interface. It can handle files with "sensor" in their name
- * and uses SensorDataImportService to process the data.</p>
- *
- * @author Marvin Application
- * @version 1.0
- * @since 1.0
- */
 @Component
 public class SensorDataFileTypeHandler implements FileTypeHandler<SensorData> {
 
     private final SensorDataImportService sensorDataImportService;
 
-    /**
-     * Constructs a SensorDataFileTypeHandler with the specified import service.
-     *
-     * @param sensorDataImportService the service for importing sensor data
-     */
     public SensorDataFileTypeHandler(final SensorDataImportService sensorDataImportService) {
         this.sensorDataImportService = sensorDataImportService;
     }
 
-    /**
-     * Determines if this handler can process the specified file type.
-     *
-     * @param fileType the file type to check
-     * @return true if the file type contains "sensor", false otherwise
-     */
     @Override
     public boolean canHandle(final String fileType) {
         return fileType != null && fileType.toLowerCase().contains("sensor");
     }
 
-    /**
-     * Gets the DTO class that this handler processes.
-     *
-     * @return the SensorData class
-     */
     @Override
     public Class<SensorData> getDtoClass() {
         return SensorData.class;
     }
 
-    /**
-     * Gets the import service for processing sensor data.
-     *
-     * @return the SensorDataImportService
-     */
     @Override
     public ImportService<SensorData> getImportService() {
         return sensorDataImportService;
     }
 
-    /**
-     * Sends the sensor data DTO to the import service for processing.
-     *
-     * @param sensorData the sensor data to import
-     */
     @Override
     public void send(final SensorData sensorData) {
         sensorDataImportService.importData(sensorData);

--- a/importer/src/main/java/com/marvin/app/sensor/importer/SensorDataImportService.java
+++ b/importer/src/main/java/com/marvin/app/sensor/importer/SensorDataImportService.java
@@ -7,17 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/**
- * Import service for processing sensor data.
- *
- * <p>This service implements the ImportService interface to handle the import
- * of sensor data using the SensorDataImport component which internally uses
- * the GenericPojoImporter.</p>
- *
- * @author Marvin Application
- * @version 1.0
- * @since 1.0
- */
 @Service
 public class SensorDataImportService implements ImportService<SensorData> {
 
@@ -25,23 +14,10 @@ public class SensorDataImportService implements ImportService<SensorData> {
 
     private final SensorDataImport sensorDataImport;
 
-    /**
-     * Constructs a SensorDataImportService with the specified sensor data import component.
-     *
-     * @param sensorDataImport the component for importing sensor data to InfluxDB
-     */
     public SensorDataImportService(final SensorDataImport sensorDataImport) {
         this.sensorDataImport = sensorDataImport;
     }
 
-    /**
-     * Imports sensor data into InfluxDB.
-     *
-     * <p>This method processes the incoming sensor data and forwards it to the
-     * SensorDataImport component which uses GenericPojoImporter to write it to InfluxDB.</p>
-     *
-     * @param data the sensor data to import
-     */
     @Override
     public void importData(final SensorData data) {
         if (data == null) {

--- a/importer/src/main/java/com/marvin/app/sensor/service/SensorDataImport.java
+++ b/importer/src/main/java/com/marvin/app/sensor/service/SensorDataImport.java
@@ -6,56 +6,25 @@ import com.marvin.influxdb.core.InfluxWriteConfig;
 import com.marvin.app.sensor.dto.SensorData;
 import org.springframework.stereotype.Component;
 
-/**
- * Service class for importing sensor data into InfluxDB.
- *
- * <p>This component provides functionality for importing sensor data using the GenericPojoImporter.
- * It handles the mapping and validation of sensor data for storage in InfluxDB.</p>
- *
- * @author Marvin Application
- * @version 1.0
- * @since 1.0
- */
 @Component
 public class SensorDataImport {
 
     private final GenericPojoImporter<SensorData> genericPojoImporter;
 
-    /**
-     * Constructs a SensorDataImport with the specified InfluxDB client.
-     *
-     * @param influxDBClient the InfluxDB client to use for writing sensor data
-     */
     public SensorDataImport(final InfluxDBClient influxDBClient) {
-        // Create a config for sensor data - you might want to make this configurable
         InfluxWriteConfig config = InfluxWriteConfig.create("sensors", "wildfly_domain",
                                                             com.influxdb.client.domain.WritePrecision.S);
         this.genericPojoImporter = new GenericPojoImporter<>(influxDBClient, config);
     }
 
-    /**
-     * Imports a single sensor data record into InfluxDB.
-     *
-     * @param sensorData the sensor data to import
-     */
     public void importSensorData(final SensorData sensorData) {
         genericPojoImporter.importPojo(sensorData);
     }
 
-    /**
-     * Imports multiple sensor data records into InfluxDB in batch.
-     *
-     * @param sensorDataList the list of sensor data records to import
-     */
     public void importSensorDataBatch(final java.util.List<SensorData> sensorDataList) {
         genericPojoImporter.importBatch(sensorDataList);
     }
 
-    /**
-     * Gets the underlying GenericPojoImporter for advanced usage.
-     *
-     * @return the GenericPojoImporter instance
-     */
     protected GenericPojoImporter<SensorData> getGenericPojoImporter() {
         return genericPojoImporter;
     }


### PR DESCRIPTION
## Summary
This pull request removes all Javadoc comments from the sensor integration classes in the importer module as requested.

### Changes Made
- **SensorData.java**: Removed class-level and method-level Javadoc comments, keeping only essential annotations and code
- **SensorDataImport.java**: Removed all Javadoc comments while preserving the @Component annotation and functionality
- **SensorDataImportService.java**: Removed Javadoc comments while maintaining logging statements and error handling
- **SensorDataFileTypeHandler.java**: Removed all documentation comments, keeping Spring annotations and interface implementations

### What Was Preserved
- All functional code and logic
- Spring component annotations (@Component, @Service)
- Override annotations for interface methods
- Import statements and package declarations
- All business logic and error handling

### Files Modified
- `importer/src/main/java/com/marvin/app/sensor/dto/SensorData.java`
- `importer/src/main/java/com/marvin/app/sensor/service/SensorDataImport.java`
- `importer/src/main/java/com/marvin/app/sensor/importer/SensorDataImportService.java`
- `importer/src/main/java/com/marvin/app/sensor/importer/SensorDataFileTypeHandler.java`

## Test plan
- [x] All sensor integration tests continue to pass (5/5 ✅)
- [x] Code compiles successfully
- [x] Spring component annotations preserved
- [x] Functionality remains intact

The code is now more concise while maintaining all original functionality.