### PR TITLE
Add fertilization endpoint to PlantController

### DIFF
--- a/plants/src/main/java/com/marvin/plants/controller/PlantController.java
+++ b/plants/src/main/java/com/marvin/plants/controller/PlantController.java
@@ -258,4 +258,33 @@ public class PlantController {
         return Mono.fromCallable(() -> plantService.waterPlant(plantId, lastWatered))
                 .subscribeOn(Schedulers.boundedElastic());
     }
+
+    /**
+     * Records that a plant has been fertilized and updates fertilizing schedule.
+     *
+     * @param id             ID of the plant to fertilize
+     * @param lastFertilized Date when the plant was last fertilized
+     * @return Mono containing ResponseEntity with updated plant data
+     */
+    @PatchMapping("/{id}/fertilized")
+    public Mono<ResponseEntity<PlantDTO>> fertilizePlant(
+            @PathVariable long id,
+            @RequestParam("last-fertilized") LocalDate lastFertilized
+    ) {
+        return Mono.just(id)
+                .flatMap(plantId -> updateFertilizingDate(plantId, lastFertilized))
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Updates the fertilizing date for a plant. Runs on boundedElastic scheduler to avoid blocking the event loop.
+     *
+     * @param plantId        ID of the plant to update
+     * @param lastFertilized Date when the plant was last fertilized
+     * @return Mono containing updated plant data
+     */
+    private Mono<PlantDTO> updateFertilizingDate(long plantId, LocalDate lastFertilized) {
+        return Mono.fromCallable(() -> plantService.fertilizePlant(plantId, lastFertilized))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
 }

--- a/plants/src/main/java/com/marvin/plants/service/PlantService.java
+++ b/plants/src/main/java/com/marvin/plants/service/PlantService.java
@@ -85,6 +85,15 @@ public class PlantService {
         return plantMapper.toPlantDTO(plant);
     }
 
+    @Transactional
+    public PlantDTO fertilizePlant(long id, LocalDate lastFertilized) {
+
+        final Plant plant = plantRepository.findById(id).orElseThrow();
+        fertilizePlant(plant, lastFertilized);
+
+        return plantMapper.toPlantDTO(plant);
+    }
+
     private void waterPlant(Plant plant, LocalDate lastWatered) {
         plant.setLastWateredDate(lastWatered);
         plant.setNextWateredDate(lastWatered.plusDays(plant.getWateringFrequency()));


### PR DESCRIPTION
## Summary
- Add public `fertilizePlant(long id, LocalDate lastFertilized)` method to PlantService
- Add `PATCH /{id}/fertilized` endpoint to PlantController for recording plant fertilization
- Implementation mirrors the existing watering functionality

## Test plan
- [ ] Verify the endpoint updates `lastFertilizedDate` and `nextFertilizedDate` correctly
- [ ] Verify the endpoint returns the updated plant data