### PR TITLE
Add seasonal fertilizing logic

### DIFF
--- a/plants/src/main/java/com/marvin/plants/service/PlantService.java
+++ b/plants/src/main/java/com/marvin/plants/service/PlantService.java
@@ -102,7 +102,21 @@ public class PlantService {
     private void fertilizePlant(Plant plant, LocalDate lastFertilized) {
         if (lastFertilized != null && plant.getFertilizingFrequency() != null) {
             plant.setLastFertilizedDate(lastFertilized);
-            plant.setNextFertilizedDate(lastFertilized.plusDays(plant.getFertilizingFrequency()));
+            LocalDate nextFertilized = lastFertilized.plusDays(plant.getFertilizingFrequency());
+
+            // Fertilizing period is April (month 4) to October (month 10)
+            // If next fertilizing date is outside this range, set to April 15th
+            int month = nextFertilized.getMonthValue();
+            if (month < 4 || month > 10) {
+                int year = nextFertilized.getYear();
+                // If current month is October, November, or December, increment year
+                if (month >= 10) {
+                    year++;
+                }
+                nextFertilized = LocalDate.of(year, 4, 15);
+            }
+
+            plant.setNextFertilizedDate(nextFertilized);
         }
     }
 


### PR DESCRIPTION
## Summary
- Extended `fertilizePlant` method to respect seasonal fertilizing period (April through October)
- When next fertilizing date falls outside the allowed period, it is automatically set to April 15th

## Changes
- Modified `PlantService.fertilizePlant()` to check if the calculated next fertilizing date is within April-October
- If the month is outside this range (November-March), sets next fertilizing date to April 15th

## Test plan
- [x] Code compiles
- [ ] Manual testing with dates outside fertilizing period (e.g., November, February)
- [ ] Verify edge cases (late September with frequency extending past October)