### PR TITLE
Add JPA entity classes for mental-arithmetic module

### DIFF
--- a/mental-arithmetic/build.gradle
+++ b/mental-arithmetic/build.gradle
@@ -1,2 +1,6 @@
 group = 'com.marvin.mental-arithmetic'
 version = '0.0.1-SNAPSHOT'
+
+dependencies {
+    implementation project(':database')
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/configuration/FlywayConfig.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/configuration/FlywayConfig.java
@@ -1,0 +1,21 @@
+package com.marvin.mental.arithmetic.configuration;
+
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean(initMethod = "migrate")
+    public Flyway flywayMentalArithmetic(DataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration/mental-arithmetic")
+                .schemas("mental_arithmetic")
+                .table("flyway_schema_history_mental_arithmetic")
+                .baselineOnMigrate(true)
+                .load();
+    }
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticProblemEntity.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticProblemEntity.java
@@ -1,0 +1,86 @@
+package com.marvin.mental.arithmetic.entity;
+
+import com.marvin.mental.arithmetic.enums.Difficulty;
+import com.marvin.mental.arithmetic.enums.OperationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "arithmetic_problem", schema = "mental_arithmetic")
+public class ArithmeticProblemEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private ArithmeticSessionEntity session;
+
+    @Column(name = "expression", nullable = false)
+    private String expression;
+
+    @Column(name = "answer", nullable = false)
+    private Integer answer;
+
+    @Column(name = "user_answer")
+    private Integer userAnswer;
+
+    @Column(name = "is_correct")
+    private Boolean isCorrect;
+
+    @Column(name = "time_spent", nullable = false)
+    private Long timeSpent;
+
+    @Column(name = "presented_at", nullable = false)
+    private Instant presentedAt;
+
+    @Column(name = "answered_at")
+    private Instant answeredAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "operation_type", nullable = false)
+    private OperationType operationType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false)
+    private Difficulty difficulty;
+
+    @Column(name = "operand1", nullable = false)
+    private Integer operand1;
+
+    @Column(name = "operand2", nullable = false)
+    private Integer operand2;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArithmeticProblemEntity that = (ArithmeticProblemEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticSessionEntity.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticSessionEntity.java
@@ -1,0 +1,106 @@
+package com.marvin.mental.arithmetic.entity;
+
+import com.marvin.mental.arithmetic.enums.SessionStatus;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "arithmetic_session", schema = "mental_arithmetic")
+public class ArithmeticSessionEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "start_time")
+    private Instant startTime;
+
+    @Column(name = "end_time")
+    private Instant endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SessionStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settings_id", nullable = false)
+    private ArithmeticSettingsEntity settings;
+
+    @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArithmeticProblemEntity> problems = new HashSet<>();
+
+    @Column(name = "current_problem_index", nullable = false)
+    private Integer currentProblemIndex;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    @Column(name = "correct_answers", nullable = false)
+    private Integer correctAnswers;
+
+    @Column(name = "incorrect_answers", nullable = false)
+    private Integer incorrectAnswers;
+
+    @Column(name = "total_time_spent", nullable = false)
+    private Long totalTimeSpent;
+
+    @Column(name = "problems_completed", nullable = false)
+    private Integer problemsCompleted;
+
+    @Column(name = "total_problems", nullable = false)
+    private Integer totalProblems;
+
+    @Column(name = "accuracy", nullable = false)
+    private Double accuracy;
+
+    @Column(name = "avg_time_per_problem", nullable = false)
+    private Double avgTimePerProblem;
+
+    @Column(name = "is_completed", nullable = false)
+    private Boolean isCompleted;
+
+    @Column(name = "is_timed_out", nullable = false)
+    private Boolean isTimedOut;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArithmeticSessionEntity that = (ArithmeticSessionEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticSettingsEntity.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/ArithmeticSettingsEntity.java
@@ -1,0 +1,103 @@
+package com.marvin.mental.arithmetic.entity;
+
+import com.marvin.mental.arithmetic.enums.Difficulty;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "arithmetic_settings", schema = "mental_arithmetic")
+public class ArithmeticSettingsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "arithmetic_settings_id_gen")
+    @SequenceGenerator(name = "arithmetic_settings_id_gen", sequenceName = "mental_arithmetic.arithmetic_settings_id_seq", allocationSize = 1)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false)
+    private Difficulty difficulty;
+
+    @Column(name = "problem_count", nullable = false)
+    private Integer problemCount;
+
+    @Column(name = "time_limit")
+    private Integer timeLimit;
+
+    @Column(name = "show_immediate_feedback", nullable = false)
+    private Boolean showImmediateFeedback;
+
+    @Column(name = "allow_pause", nullable = false)
+    private Boolean allowPause;
+
+    @Column(name = "show_progress", nullable = false)
+    private Boolean showProgress;
+
+    @Column(name = "show_timer", nullable = false)
+    private Boolean showTimer;
+
+    @Column(name = "enable_sound", nullable = false)
+    private Boolean enableSound;
+
+    @Column(name = "use_keypad", nullable = false)
+    private Boolean useKeypad;
+
+    @Column(name = "session_name")
+    private String sessionName;
+
+    @Column(name = "shuffle_problems", nullable = false)
+    private Boolean shuffleProblems;
+
+    @Column(name = "repeat_incorrect_problems", nullable = false)
+    private Boolean repeatIncorrectProblems;
+
+    @Column(name = "max_retries", nullable = false)
+    private Integer maxRetries;
+
+    @Column(name = "show_correct_answer", nullable = false)
+    private Boolean showCorrectAnswer;
+
+    @Column(name = "font_size")
+    private String fontSize;
+
+    @Column(name = "high_contrast")
+    private Boolean highContrast;
+
+    @OneToMany(mappedBy = "settings", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SettingsOperationEntity> operations = new HashSet<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArithmeticSettingsEntity that = (ArithmeticSettingsEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/SettingsOperationEntity.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/SettingsOperationEntity.java
@@ -1,0 +1,52 @@
+package com.marvin.mental.arithmetic.entity;
+
+import com.marvin.mental.arithmetic.enums.OperationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "settings_operations", schema = "mental_arithmetic")
+@IdClass(SettingsOperationId.class)
+public class SettingsOperationEntity {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settings_id", nullable = false)
+    private ArithmeticSettingsEntity settings;
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "operation_type", nullable = false)
+    private OperationType operationType;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsOperationEntity that = (SettingsOperationEntity) o;
+        return Objects.equals(settings, that.settings) && operationType == that.operationType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(settings, operationType);
+    }
+}

--- a/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/SettingsOperationId.java
+++ b/mental-arithmetic/src/main/java/com/marvin/mental/arithmetic/entity/SettingsOperationId.java
@@ -1,0 +1,33 @@
+package com.marvin.mental.arithmetic.entity;
+
+import com.marvin.mental.arithmetic.enums.OperationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettingsOperationId implements Serializable {
+
+    private Integer settings;
+    private OperationType operationType;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsOperationId that = (SettingsOperationId) o;
+        return Objects.equals(settings, that.settings) && operationType == that.operationType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(settings, operationType);
+    }
+}


### PR DESCRIPTION
## Summary
Adds JPA entity classes for the mental-arithmetic module database tables.

- `ArithmeticSettingsEntity` - settings table entity with operations relationship
- `SettingsOperationEntity` - junction table entity for settings-operations many-to-many
- `ArithmeticSessionEntity` - session table entity with settings and problems relationships
- `ArithmeticProblemEntity` - problem table entity with session relationship
- `FlywayConfig` - Flyway configuration for mental_arithmetic schema
- Added `database` module dependency for JPA support

## Test plan
- [x] Build compiles successfully