### PR TITLE
feat: add encrypted database backup scripts

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,185 @@
+# Database Backup & Encryption
+
+Encrypted backup system for the PostgreSQL database used by the adapter application. Backups are compressed and encrypted using hybrid RSA+AES encryption, producing a single `.zip` file safe for upload to external storage.
+
+## Quick Start
+
+```bash
+# 1. Generate example RSA keys (replace with your own later)
+./generate-keys.sh
+
+# 2. Create an encrypted backup
+./backup.sh
+
+# 3. Restore from an encrypted backup
+./restore.sh ./backups/costs_backup_20260301_120000.zip
+```
+
+## How It Works
+
+Since RSA cannot directly encrypt large files, the system uses **hybrid encryption**:
+
+1. **`pg_dump`** exports the entire database (all schemas and data) as a plain SQL file
+2. **`gzip`** compresses the SQL dump
+3. A random **AES-256** symmetric key is generated
+4. The compressed dump is encrypted with **AES-256-CBC** using the random key
+5. The AES key is encrypted with the **RSA public key**
+6. Both encrypted files are packaged into a single **`.zip`** archive
+
+To restore, the process is reversed using the RSA private key.
+
+## Scripts
+
+### `generate-keys.sh`
+
+Generates a 4096-bit RSA key pair for encryption/decryption.
+
+```bash
+# Generate keys in the default location (./keys/)
+./generate-keys.sh
+
+# Generate keys in a custom directory
+./generate-keys.sh /path/to/key/directory
+```
+
+### `backup.sh`
+
+Creates an encrypted database backup.
+
+```bash
+# Using defaults (localhost:5432, database: costs, user: marvin)
+./backup.sh
+
+# Custom output directory
+./backup.sh --output-dir /mnt/backups
+
+# Custom public key
+./backup.sh --public-key /path/to/my_public.pem
+
+# Using environment variables
+DB_HOST=db.example.com DB_PORT=5432 DB_NAME=costs DB_USER=admin PGPASSWORD=secret ./backup.sh
+```
+
+**Environment Variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `costs` | Database name |
+| `DB_USER` | `marvin` | Database user |
+| `PGPASSWORD` | `password` | Database password |
+| `BACKUP_DIR` | `./backups` | Output directory for backup files |
+| `PUBLIC_KEY` | `./keys/backup_public.pem` | Path to RSA public key |
+
+### `restore.sh`
+
+Decrypts and restores a backup to the database.
+
+```bash
+# Full restore to database
+./restore.sh ./backups/costs_backup_20260301_120000.zip
+
+# Decrypt only (produces .sql file without restoring)
+./restore.sh ./backups/costs_backup_20260301_120000.zip --decrypt-only
+
+# Custom private key
+./restore.sh ./backups/costs_backup_20260301_120000.zip --private-key /path/to/my_private.pem
+
+# Restore to a different database
+DB_HOST=db.example.com DB_NAME=costs_staging ./restore.sh ./backups/costs_backup_20260301_120000.zip
+```
+
+**Environment Variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `costs` | Database name |
+| `DB_USER` | `marvin` | Database user |
+| `PGPASSWORD` | `password` | Database password |
+| `PRIVATE_KEY` | `./keys/backup_private.pem` | Path to RSA private key |
+
+## Database Schemas
+
+The backup includes all schemas in the `costs` database:
+
+| Schema | Description |
+|--------|-------------|
+| `finance` | Daily costs, monthly costs, base costs, salary, special costs |
+| `exports` | Export run tracking |
+| `mental_arithmetic` | Arithmetic sessions, problems, settings |
+| `plants` | Plant data with audit tables |
+| `vocabulary` | Flashcards, decks, vocabulary |
+| `images` | Image storage |
+| `linkwarden` | Linkwarden data |
+| `public` | Flyway history tables |
+
+## Replacing Example Keys
+
+The example keys in `keys/` are for development/testing only. To use your own keys:
+
+### Option 1: Generate new keys with the helper script
+
+```bash
+./generate-keys.sh
+# Confirm overwrite when prompted
+```
+
+### Option 2: Use your own existing keys
+
+```bash
+# Place your keys in the keys/ directory
+cp /path/to/your/public_key.pem ./keys/backup_public.pem
+cp /path/to/your/private_key.pem ./keys/backup_private.pem
+
+# Or specify paths directly
+./backup.sh --public-key /path/to/your/public_key.pem
+./restore.sh backup.zip --private-key /path/to/your/private_key.pem
+```
+
+### Key Requirements
+
+- RSA key, minimum 2048-bit (4096-bit recommended)
+- PEM format
+- Public key must be in SPKI/X.509 format (`-----BEGIN PUBLIC KEY-----`)
+- Private key in PKCS#8 format (`-----BEGIN PRIVATE KEY-----`)
+
+## Prerequisites
+
+The following tools must be installed:
+
+- `pg_dump` / `psql` — PostgreSQL client tools
+- `openssl` — For RSA and AES encryption
+- `gzip` / `gunzip` — For compression
+- `zip` / `unzip` — For packaging
+
+Install on Debian/Ubuntu:
+
+```bash
+sudo apt-get install postgresql-client openssl gzip zip
+```
+
+## Security Notes
+
+- **Never commit private keys** to version control. The `keys/.gitignore` prevents this.
+- The AES key is randomly generated per backup and securely discarded after encryption.
+- Temporary unencrypted files are cleaned up automatically (even on script failure via `trap`).
+- For production, consider using `.pgpass` or `pg_service.conf` instead of `PGPASSWORD`.
+- Store the private key separately from the encrypted backups for proper security.
+
+## File Structure
+
+```
+backup/
+├── keys/
+│   ├── .gitignore              # Prevents key files from being committed
+│   ├── backup_public.pem       # RSA public key (for encryption)
+│   └── backup_private.pem      # RSA private key (for decryption) - KEEP SECURE
+├── backups/                    # Created automatically, contains backup .zip files
+├── backup.sh                   # Main backup script
+├── restore.sh                  # Restore/decrypt script
+├── generate-keys.sh            # RSA key pair generator
+└── README.md                   # This file
+```

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# backup.sh - Encrypted PostgreSQL database backup
+#
+# Creates a full database dump (all schemas and data), compresses it,
+# encrypts it using hybrid RSA+AES encryption, and packages it as a zip file.
+#
+# Usage: ./backup.sh [--output-dir DIR] [--public-key PATH]
+#
+# Environment Variables:
+#   DB_HOST      - Database host (default: localhost)
+#   DB_PORT      - Database port (default: 5432)
+#   DB_NAME      - Database name (default: costs)
+#   DB_USER      - Database user (default: marvin)
+#   PGPASSWORD   - Database password (default: password)
+#   BACKUP_DIR   - Output directory for backups (default: ./backups)
+#   PUBLIC_KEY   - Path to RSA public key (default: ./keys/backup_public.pem)
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-costs}"
+DB_USER="${DB_USER:-marvin}"
+export PGPASSWORD="${PGPASSWORD:-password}"
+
+BACKUP_DIR="${BACKUP_DIR:-${SCRIPT_DIR}/backups}"
+PUBLIC_KEY="${PUBLIC_KEY:-${SCRIPT_DIR}/keys/backup_public.pem}"
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            BACKUP_DIR="$2"
+            shift 2
+            ;;
+        --public-key)
+            PUBLIC_KEY="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--output-dir DIR] [--public-key PATH]"
+            echo ""
+            echo "Environment Variables:"
+            echo "  DB_HOST      Database host (default: localhost)"
+            echo "  DB_PORT      Database port (default: 5432)"
+            echo "  DB_NAME      Database name (default: costs)"
+            echo "  DB_USER      Database user (default: marvin)"
+            echo "  PGPASSWORD   Database password (default: password)"
+            echo "  BACKUP_DIR   Output directory (default: ./backups)"
+            echo "  PUBLIC_KEY   RSA public key path (default: ./keys/backup_public.pem)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# File naming
+DUMP_FILE="${BACKUP_DIR}/${DB_NAME}_${TIMESTAMP}.sql"
+COMPRESSED_FILE="${DUMP_FILE}.gz"
+ENCRYPTED_FILE="${COMPRESSED_FILE}.enc"
+AES_KEY_FILE="${BACKUP_DIR}/aes_key_${TIMESTAMP}.bin"
+ENCRYPTED_KEY_FILE="${AES_KEY_FILE}.enc"
+FINAL_ZIP="${BACKUP_DIR}/${DB_NAME}_backup_${TIMESTAMP}.zip"
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+cleanup() {
+    log "Cleaning up temporary files..."
+    rm -f "${DUMP_FILE}" "${COMPRESSED_FILE}" "${ENCRYPTED_FILE}" \
+          "${AES_KEY_FILE}" "${ENCRYPTED_KEY_FILE}" 2>/dev/null || true
+}
+
+# Always clean up on exit
+trap cleanup EXIT
+
+check_prerequisites() {
+    local missing=()
+
+    for cmd in pg_dump openssl gzip zip; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            missing+=("${cmd}")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log "ERROR: Missing required tools: ${missing[*]}"
+        log "Install them with: sudo apt-get install postgresql-client openssl gzip zip"
+        exit 1
+    fi
+}
+
+validate_public_key() {
+    if [[ ! -f "${PUBLIC_KEY}" ]]; then
+        log "ERROR: RSA public key not found at: ${PUBLIC_KEY}"
+        log "Generate keys first: ./generate-keys.sh"
+        exit 1
+    fi
+
+    # Validate it's a proper PEM public key
+    if ! openssl pkey -pubin -in "${PUBLIC_KEY}" -noout 2>/dev/null; then
+        log "ERROR: Invalid RSA public key: ${PUBLIC_KEY}"
+        exit 1
+    fi
+
+    log "Using public key: ${PUBLIC_KEY}"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+echo "============================================"
+echo "  Encrypted Database Backup"
+echo "============================================"
+echo ""
+
+log "Starting backup process..."
+log "Database: ${DB_USER}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
+# Step 0: Check prerequisites
+check_prerequisites
+validate_public_key
+
+# Create backup directory
+mkdir -p "${BACKUP_DIR}"
+
+# Step 1: Dump the entire database (all schemas and data)
+log "Step 1/6: Dumping database..."
+pg_dump \
+    --host="${DB_HOST}" \
+    --port="${DB_PORT}" \
+    --username="${DB_USER}" \
+    --dbname="${DB_NAME}" \
+    --format=plain \
+    --no-owner \
+    --no-privileges \
+    --verbose \
+    --file="${DUMP_FILE}" \
+    2>&1 | while IFS= read -r line; do log "  pg_dump: ${line}"; done
+
+if [[ ! -f "${DUMP_FILE}" ]] || [[ ! -s "${DUMP_FILE}" ]]; then
+    log "ERROR: Database dump failed or produced empty file"
+    exit 1
+fi
+
+DUMP_SIZE=$(du -h "${DUMP_FILE}" | cut -f1)
+log "  Dump size: ${DUMP_SIZE}"
+
+# Step 2: Compress the dump
+log "Step 2/6: Compressing dump with gzip..."
+gzip -9 "${DUMP_FILE}"
+
+COMPRESSED_SIZE=$(du -h "${COMPRESSED_FILE}" | cut -f1)
+log "  Compressed size: ${COMPRESSED_SIZE}"
+
+# Step 3: Generate a random AES-256 key
+log "Step 3/6: Generating random AES-256 key..."
+openssl rand 32 > "${AES_KEY_FILE}"
+
+# Step 4: Encrypt the compressed dump with AES-256-CBC
+log "Step 4/6: Encrypting data with AES-256-CBC..."
+openssl enc -aes-256-cbc \
+    -salt \
+    -pbkdf2 \
+    -iter 100000 \
+    -in "${COMPRESSED_FILE}" \
+    -out "${ENCRYPTED_FILE}" \
+    -pass file:"${AES_KEY_FILE}"
+
+ENCRYPTED_SIZE=$(du -h "${ENCRYPTED_FILE}" | cut -f1)
+log "  Encrypted size: ${ENCRYPTED_SIZE}"
+
+# Step 5: Encrypt the AES key with RSA public key
+log "Step 5/6: Encrypting AES key with RSA public key..."
+openssl pkeyutl \
+    -encrypt \
+    -pubin \
+    -inkey "${PUBLIC_KEY}" \
+    -in "${AES_KEY_FILE}" \
+    -out "${ENCRYPTED_KEY_FILE}"
+
+# Step 6: Package into a zip file
+log "Step 6/6: Packaging into zip archive..."
+
+# Rename files for cleaner archive contents
+ARCHIVE_DATA_NAME="${DB_NAME}_${TIMESTAMP}.sql.gz.enc"
+ARCHIVE_KEY_NAME="${DB_NAME}_${TIMESTAMP}.key.enc"
+
+cp "${ENCRYPTED_FILE}" "${BACKUP_DIR}/${ARCHIVE_DATA_NAME}"
+cp "${ENCRYPTED_KEY_FILE}" "${BACKUP_DIR}/${ARCHIVE_KEY_NAME}"
+
+(cd "${BACKUP_DIR}" && zip -j "${FINAL_ZIP}" "${ARCHIVE_DATA_NAME}" "${ARCHIVE_KEY_NAME}")
+
+# Clean up the copies used for zipping
+rm -f "${BACKUP_DIR}/${ARCHIVE_DATA_NAME}" "${BACKUP_DIR}/${ARCHIVE_KEY_NAME}"
+
+FINAL_SIZE=$(du -h "${FINAL_ZIP}" | cut -f1)
+
+echo ""
+echo "============================================"
+echo "  Backup Complete"
+echo "============================================"
+echo ""
+log "Output file: ${FINAL_ZIP}"
+log "File size:   ${FINAL_SIZE}"
+log "Database:    ${DB_NAME}"
+log "Timestamp:   ${TIMESTAMP}"
+echo ""
+echo "To restore this backup, run:"
+echo "  ./restore.sh ${FINAL_ZIP}"
+echo ""

--- a/backup/backups/.gitignore
+++ b/backup/backups/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all backup files
+*
+!.gitignore

--- a/backup/generate-keys.sh
+++ b/backup/generate-keys.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# generate-keys.sh - Generate RSA key pair for database backup encryption
+#
+# Usage: ./generate-keys.sh [key_directory]
+#
+# Generates a 4096-bit RSA key pair used by backup.sh and restore.sh.
+# The private key should be stored securely and NEVER committed to version control.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEY_DIR="${1:-${SCRIPT_DIR}/keys}"
+KEY_SIZE=4096
+PRIVATE_KEY="${KEY_DIR}/backup_private.pem"
+PUBLIC_KEY="${KEY_DIR}/backup_public.pem"
+
+echo "============================================"
+echo "  RSA Key Pair Generator for DB Backup"
+echo "============================================"
+echo ""
+
+# Check for openssl
+if ! command -v openssl &>/dev/null; then
+    echo "ERROR: openssl is not installed. Please install it first."
+    exit 1
+fi
+
+# Create key directory if it doesn't exist
+mkdir -p "${KEY_DIR}"
+
+# Check if keys already exist
+if [[ -f "${PRIVATE_KEY}" || -f "${PUBLIC_KEY}" ]]; then
+    echo "WARNING: Key files already exist in ${KEY_DIR}:"
+    [[ -f "${PRIVATE_KEY}" ]] && echo "  - ${PRIVATE_KEY}"
+    [[ -f "${PUBLIC_KEY}" ]] && echo "  - ${PUBLIC_KEY}"
+    echo ""
+    read -rp "Overwrite existing keys? (y/N): " confirm
+    if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+        echo "Aborted. Existing keys were not modified."
+        exit 0
+    fi
+fi
+
+echo "Generating ${KEY_SIZE}-bit RSA private key..."
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:${KEY_SIZE} -out "${PRIVATE_KEY}" 2>/dev/null
+
+echo "Extracting public key..."
+openssl pkey -in "${PRIVATE_KEY}" -pubout -out "${PUBLIC_KEY}" 2>/dev/null
+
+# Set restrictive permissions on private key
+chmod 600 "${PRIVATE_KEY}"
+chmod 644 "${PUBLIC_KEY}"
+
+echo ""
+echo "Keys generated successfully:"
+echo "  Private key: ${PRIVATE_KEY} (mode: 600)"
+echo "  Public key:  ${PUBLIC_KEY} (mode: 644)"
+echo ""
+echo "============================================"
+echo "  IMPORTANT NOTES"
+echo "============================================"
+echo ""
+echo "  1. The PRIVATE KEY is needed to DECRYPT/RESTORE backups."
+echo "     Store it securely and NEVER commit it to version control."
+echo ""
+echo "  2. The PUBLIC KEY is needed to ENCRYPT/CREATE backups."
+echo "     It can be safely distributed."
+echo ""
+echo "  3. To replace these example keys with your own:"
+echo "     - Run this script again, or"
+echo "     - Place your own .pem files in: ${KEY_DIR}"
+echo ""

--- a/backup/keys/.gitignore
+++ b/backup/keys/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all key files - never commit private keys!
+*.pem
+*.key

--- a/backup/restore.sh
+++ b/backup/restore.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# restore.sh - Decrypt and restore a PostgreSQL database backup
+#
+# Decrypts an encrypted backup zip created by backup.sh and restores it
+# to the target PostgreSQL database.
+#
+# Usage: ./restore.sh <backup_zip_file> [--private-key PATH] [--decrypt-only]
+#
+# Environment Variables:
+#   DB_HOST      - Database host (default: localhost)
+#   DB_PORT      - Database port (default: 5432)
+#   DB_NAME      - Database name (default: costs)
+#   DB_USER      - Database user (default: marvin)
+#   PGPASSWORD   - Database password (default: password)
+#   PRIVATE_KEY  - Path to RSA private key (default: ./keys/backup_private.pem)
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-costs}"
+DB_USER="${DB_USER:-marvin}"
+export PGPASSWORD="${PGPASSWORD:-password}"
+
+PRIVATE_KEY="${PRIVATE_KEY:-${SCRIPT_DIR}/keys/backup_private.pem}"
+DECRYPT_ONLY=false
+
+# ============================================================================
+# Parse arguments
+# ============================================================================
+
+BACKUP_ZIP=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --private-key)
+            PRIVATE_KEY="$2"
+            shift 2
+            ;;
+        --decrypt-only)
+            DECRYPT_ONLY=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 <backup_zip_file> [--private-key PATH] [--decrypt-only]"
+            echo ""
+            echo "Arguments:"
+            echo "  backup_zip_file   Path to the encrypted backup zip file"
+            echo ""
+            echo "Options:"
+            echo "  --private-key     Path to RSA private key (default: ./keys/backup_private.pem)"
+            echo "  --decrypt-only    Only decrypt, do not restore to database"
+            echo ""
+            echo "Environment Variables:"
+            echo "  DB_HOST      Database host (default: localhost)"
+            echo "  DB_PORT      Database port (default: 5432)"
+            echo "  DB_NAME      Database name (default: costs)"
+            echo "  DB_USER      Database user (default: marvin)"
+            echo "  PGPASSWORD   Database password (default: password)"
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            BACKUP_ZIP="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "${BACKUP_ZIP}" ]]; then
+    echo "ERROR: No backup zip file specified."
+    echo "Usage: $0 <backup_zip_file> [--private-key PATH] [--decrypt-only]"
+    exit 1
+fi
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+TEMP_DIR=""
+
+cleanup() {
+    log "Cleaning up temporary files..."
+    if [[ -n "${TEMP_DIR}" && -d "${TEMP_DIR}" ]]; then
+        rm -rf "${TEMP_DIR}"
+    fi
+}
+
+trap cleanup EXIT
+
+check_prerequisites() {
+    local missing=()
+
+    for cmd in openssl gunzip unzip; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            missing+=("${cmd}")
+        fi
+    done
+
+    if [[ "${DECRYPT_ONLY}" == false ]]; then
+        if ! command -v psql &>/dev/null; then
+            missing+=("psql")
+        fi
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log "ERROR: Missing required tools: ${missing[*]}"
+        log "Install them with: sudo apt-get install postgresql-client openssl gzip unzip"
+        exit 1
+    fi
+}
+
+validate_private_key() {
+    if [[ ! -f "${PRIVATE_KEY}" ]]; then
+        log "ERROR: RSA private key not found at: ${PRIVATE_KEY}"
+        log "Specify the correct path with: --private-key /path/to/key.pem"
+        exit 1
+    fi
+
+    if ! openssl pkey -in "${PRIVATE_KEY}" -noout 2>/dev/null; then
+        log "ERROR: Invalid RSA private key: ${PRIVATE_KEY}"
+        exit 1
+    fi
+
+    log "Using private key: ${PRIVATE_KEY}"
+}
+
+validate_backup_file() {
+    if [[ ! -f "${BACKUP_ZIP}" ]]; then
+        log "ERROR: Backup file not found: ${BACKUP_ZIP}"
+        exit 1
+    fi
+
+    if ! file "${BACKUP_ZIP}" | grep -qi "zip"; then
+        log "WARNING: File may not be a valid zip archive: ${BACKUP_ZIP}"
+    fi
+
+    log "Using backup file: ${BACKUP_ZIP}"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+echo "============================================"
+echo "  Encrypted Database Restore"
+echo "============================================"
+echo ""
+
+log "Starting restore process..."
+
+# Step 0: Check prerequisites
+check_prerequisites
+validate_private_key
+validate_backup_file
+
+# Create temporary working directory
+TEMP_DIR="$(mktemp -d)"
+log "Working directory: ${TEMP_DIR}"
+
+# Step 1: Unzip the archive
+log "Step 1/5: Extracting zip archive..."
+unzip -o "${BACKUP_ZIP}" -d "${TEMP_DIR}"
+
+# Find the encrypted data and key files
+ENCRYPTED_DATA=$(find "${TEMP_DIR}" -name "*.sql.gz.enc" | head -1)
+ENCRYPTED_KEY=$(find "${TEMP_DIR}" -name "*.key.enc" | head -1)
+
+if [[ -z "${ENCRYPTED_DATA}" || -z "${ENCRYPTED_KEY}" ]]; then
+    log "ERROR: Could not find encrypted data (.sql.gz.enc) or key (.key.enc) in archive"
+    log "Archive contents:"
+    ls -la "${TEMP_DIR}"
+    exit 1
+fi
+
+log "  Found encrypted data: $(basename "${ENCRYPTED_DATA}")"
+log "  Found encrypted key:  $(basename "${ENCRYPTED_KEY}")"
+
+# Step 2: Decrypt the AES key using RSA private key
+log "Step 2/5: Decrypting AES key with RSA private key..."
+AES_KEY_FILE="${TEMP_DIR}/aes_key.bin"
+openssl pkeyutl \
+    -decrypt \
+    -inkey "${PRIVATE_KEY}" \
+    -in "${ENCRYPTED_KEY}" \
+    -out "${AES_KEY_FILE}"
+
+# Step 3: Decrypt the data using AES key
+log "Step 3/5: Decrypting data with AES-256-CBC..."
+COMPRESSED_FILE="${TEMP_DIR}/backup.sql.gz"
+openssl enc -d -aes-256-cbc \
+    -salt \
+    -pbkdf2 \
+    -iter 100000 \
+    -in "${ENCRYPTED_DATA}" \
+    -out "${COMPRESSED_FILE}" \
+    -pass file:"${AES_KEY_FILE}"
+
+# Step 4: Decompress
+log "Step 4/5: Decompressing..."
+gunzip "${COMPRESSED_FILE}"
+SQL_FILE="${TEMP_DIR}/backup.sql"
+
+SQL_SIZE=$(du -h "${SQL_FILE}" | cut -f1)
+log "  Decompressed SQL dump size: ${SQL_SIZE}"
+
+if [[ "${DECRYPT_ONLY}" == true ]]; then
+    # Copy the decrypted SQL to the current directory
+    OUTPUT_SQL="$(dirname "${BACKUP_ZIP}")/$(basename "${BACKUP_ZIP}" .zip).sql"
+    cp "${SQL_FILE}" "${OUTPUT_SQL}"
+    echo ""
+    echo "============================================"
+    echo "  Decryption Complete (--decrypt-only)"
+    echo "============================================"
+    echo ""
+    log "Decrypted SQL dump: ${OUTPUT_SQL}"
+    log "File size: ${SQL_SIZE}"
+    echo ""
+    echo "To manually restore, run:"
+    echo "  psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} -d ${DB_NAME} -f ${OUTPUT_SQL}"
+    echo ""
+    exit 0
+fi
+
+# Step 5: Restore to database
+log "Step 5/5: Restoring to database ${DB_USER}@${DB_HOST}:${DB_PORT}/${DB_NAME}..."
+echo ""
+
+read -rp "This will restore the backup to database '${DB_NAME}'. Continue? (y/N): " confirm
+if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+    echo "Aborted. Database was not modified."
+    exit 0
+fi
+
+psql \
+    --host="${DB_HOST}" \
+    --port="${DB_PORT}" \
+    --username="${DB_USER}" \
+    --dbname="${DB_NAME}" \
+    --file="${SQL_FILE}" \
+    --set ON_ERROR_STOP=off \
+    2>&1 | while IFS= read -r line; do log "  psql: ${line}"; done
+
+echo ""
+echo "============================================"
+echo "  Restore Complete"
+echo "============================================"
+echo ""
+log "Database '${DB_NAME}' has been restored from: $(basename "${BACKUP_ZIP}")"
+echo ""


### PR DESCRIPTION
- backup.sh: dumps entire PostgreSQL database (all schemas), compresses with gzip, encrypts with AES-256-CBC, encrypts AES key with RSA public key, packages into a timestamped zip file
- restore.sh: reverses the process - unzips, RSA decrypts AES key, AES decrypts data, decompresses, restores to database via psql
- generate-keys.sh: generates 4096-bit RSA key pair for encryption
- README.md: full usage documentation with key replacement instructions
- keys/.gitignore: prevents private/public key files from being committed
- backups/.gitignore: prevents backup files from being committed

Uses hybrid RSA+AES encryption since RSA cannot directly encrypt large files. Environment variables with defaults matching docker-compose for flexible deployment.