### PR TITLE
feat: auto-create Google Drive folder if it does not exist

### DIFF
--- a/uploader/src/main/java/com/marvin/upload/GoogleDrive.java
+++ b/uploader/src/main/java/com/marvin/upload/GoogleDrive.java
@@ -46,7 +46,8 @@ public class GoogleDrive {
             final FileList result = searchFolderByName(service, folderName);
 
             if (result == null || result.getFiles().isEmpty()) {
-                throw new GoogleDriveException("No folder with name " + folderName + " found!");
+                LOGGER.info("Folder '{}' not found, creating it.", folderName);
+                return createFolder(service, folderName);
             }
 
             return result.getFiles().get(0).getId();
@@ -172,6 +173,20 @@ public class GoogleDrive {
                 .create(fileMetadata, mediaContent)
                 .setFields("id")
                 .execute();
+    }
+
+    private String createFolder(Drive service, String folderName) throws Exception {
+        final File folderMetadata = new File();
+        folderMetadata.setName(folderName);
+        folderMetadata.setMimeType("application/vnd.google-apps.folder");
+
+        final File folder = service.files()
+                .create(folderMetadata)
+                .setFields("id")
+                .execute();
+
+        LOGGER.info("Created folder '{}' with ID: {}", folderName, folder.getId());
+        return folder.getId();
     }
 
     private File createFileMetadata(Path path, String parent) {


### PR DESCRIPTION
## Summary
- `GoogleDrive.getFileId()` previously threw a `GoogleDriveException` when the target folder was not found on Drive, causing upload failures
- It now calls a new private `createFolder()` method to create the missing folder and returns the new ID transparently
- No changes to callers (`Uploader`) are required

## Test plan
- [ ] Verify that uploading to a non-existent folder creates it on Drive and completes successfully
- [ ] Verify that uploading to an existing folder still resolves the correct ID without creating duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)