### PR TITLE
feat(vocabulary): add sync run tracking endpoint for anki addon

### DIFF
--- a/vocabulary/src/main/java/com/marvin/vocabulary/controller/SyncRunController.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/controller/SyncRunController.java
@@ -1,0 +1,46 @@
+package com.marvin.vocabulary.controller;
+
+import com.marvin.database.repository.BackupRunRepository;
+import com.marvin.entities.exports.BackupRunEntity;
+import com.marvin.vocabulary.dto.AnkiSyncRunRequest;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@RestController
+@RequestMapping("/vocabulary")
+@RequiredArgsConstructor
+public class SyncRunController {
+
+    private static final String ANKI_SYNC_FILE_NAME = "anki-sync";
+
+    private final BackupRunRepository backupRunRepository;
+
+    @PostMapping("/sync-runs")
+    public Mono<ResponseEntity<Void>> recordSyncRun(@RequestBody AnkiSyncRunRequest request) {
+        return Mono.fromRunnable(() -> {
+            BackupRunEntity entity = new BackupRunEntity();
+            entity.setFileName(ANKI_SYNC_FILE_NAME);
+            entity.setStatus(request.status());
+
+            long durationMs = request.durationMs() != null ? request.durationMs() : 0L;
+            LocalDateTime finishedAt = LocalDateTime.now();
+            entity.setFinishedAt(finishedAt);
+            entity.setStartedAt(finishedAt.minus(Duration.ofMillis(durationMs)));
+            entity.setDurationMs(durationMs);
+            entity.setUploadSuccess("SUCCESS".equals(request.status()));
+            entity.setErrorMessage(request.errorMessage());
+
+            backupRunRepository.save(entity);
+        })
+        .subscribeOn(Schedulers.boundedElastic())
+        .thenReturn(ResponseEntity.noContent().<Void>build());
+    }
+}

--- a/vocabulary/src/main/java/com/marvin/vocabulary/dto/AnkiSyncRunRequest.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/dto/AnkiSyncRunRequest.java
@@ -1,0 +1,10 @@
+package com.marvin.vocabulary.dto;
+
+public record AnkiSyncRunRequest(
+        String status,
+        Long durationMs,
+        Integer cardsChanged,
+        String errorMessage
+) {
+
+}


### PR DESCRIPTION
## Summary
- Adds `POST /vocabulary/sync-runs` endpoint in the vocabulary module
- New `SyncRunController` accepts sync run results (status, duration, cards changed, error message) and persists them in the `exports.backup_run` table via `BackupRunRepository`
- New `AnkiSyncRunRequest` record DTO carries the request payload

## Details
Each anki flashcard synchronization now writes an entry to `backup_run` with:
- `fileName = "anki-sync"` to identify the source
- `status`: `SUCCESS` or `FAILED`
- `startedAt` / `finishedAt` / `durationMs`: computed from the client-reported duration
- `uploadSuccess`: derived from status
- `errorMessage`: populated on failure

## Test plan
- [ ] `POST /vocabulary/sync-runs` with `{"status":"SUCCESS","durationMs":1200,"cardsChanged":3}` returns 204 and creates a row in `exports.backup_run`
- [ ] `POST /vocabulary/sync-runs` with `{"status":"FAILED","durationMs":300,"errorMessage":"timeout"}` returns 204 and sets `upload_success=false` and `error_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)