### PR TITLE
fix(backups): cast nullable JPQL params to resolve PostgreSQL type inference error

### DIFF
--- a/database/src/main/java/com/marvin/database/repository/BackupRunRepository.java
+++ b/database/src/main/java/com/marvin/database/repository/BackupRunRepository.java
@@ -11,9 +11,9 @@ import org.springframework.data.repository.query.Param;
 public interface BackupRunRepository extends JpaRepository<BackupRunEntity, Long> {
 
     @Query("SELECT b FROM BackupRunEntity b WHERE " +
-            "(:from IS NULL OR b.startedAt >= :from) AND " +
-            "(:to IS NULL OR b.startedAt <= :to) AND " +
-            "(:status IS NULL OR b.status = :status)")
+            "(cast(:from as LocalDateTime) IS NULL OR b.startedAt >= :from) AND " +
+            "(cast(:to as LocalDateTime) IS NULL OR b.startedAt <= :to) AND " +
+            "(cast(:status as String) IS NULL OR b.status = :status)")
     Page<BackupRunEntity> findByFilters(
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,


### PR DESCRIPTION
## Summary
- PostgreSQL throws `could not determine data type of parameter $1` when a null value is passed to a `(:param IS NULL OR ...)` JPQL expression
- Fixed by using Hibernate 6's `cast(:param as Type)` syntax in `BackupRunRepository.findByFilters`, giving the JDBC driver explicit type information even when the value is `null`
- Resolves the 500 error on `GET /backups`

## Test plan
- [ ] Call `GET /backups?limit=20&offset=0` without any filter params and verify 200 response
- [ ] Call with `from`, `to`, and `status` filters and verify correct filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)