### PR TITLE
feat(it-news): add mark-as-read functionality

### DIFF
--- a/it-news/src/main/java/com/marvin/itnews/controller/ArticleController.java
+++ b/it-news/src/main/java/com/marvin/itnews/controller/ArticleController.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,10 +43,11 @@ public class ArticleController {
     /**
      * Retrieves a paginated list of articles with optional filters.
      *
-     * @param category optional category filter
-     * @param source   optional source filter
-     * @param page     page number
-     * @param size     page size
+     * @param category    optional category filter
+     * @param source      optional source filter
+     * @param includeRead whether to include read articles
+     * @param page        page number
+     * @param size        page size
      * @return paginated articles
      */
     @GetMapping("/articles")
@@ -56,13 +59,15 @@ public class ArticleController {
             @Parameter(description = "Filter by category") String category,
             @RequestParam(required = false)
             @Parameter(description = "Filter by source") String source,
+            @RequestParam(defaultValue = "false")
+            @Parameter(description = "Include read articles") boolean includeRead,
             @RequestParam(defaultValue = "0")
             @Parameter(description = "Page number") int page,
             @RequestParam(defaultValue = "20")
             @Parameter(description = "Page size") int size
     ) {
         return Mono.fromCallable(
-                () -> articleService.getArticles(category, source, page, size)
+                () -> articleService.getArticles(category, source, includeRead, page, size)
         ).subscribeOn(Schedulers.boundedElastic());
     }
 
@@ -84,6 +89,24 @@ public class ArticleController {
                 .map(f -> new FeedSourceDTO(
                         f.getName(), f.getUrl(), f.getCategory()))
                 .toList();
+    }
+
+    /**
+     * Marks an article as read.
+     *
+     * @param id article ID
+     * @return empty response
+     */
+    @PatchMapping("/articles/{id}/read")
+    @Operation(summary = "Mark article as read",
+            description = "Marks the specified article as read.")
+    public Mono<ResponseEntity<Void>> markAsRead(
+            @PathVariable @Parameter(description = "Article ID") long id
+    ) {
+        return Mono.fromCallable(() -> {
+            articleService.markAsRead(id);
+            return ResponseEntity.ok().<Void>build();
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     /**

--- a/it-news/src/main/java/com/marvin/itnews/dto/ArticleDTO.java
+++ b/it-news/src/main/java/com/marvin/itnews/dto/ArticleDTO.java
@@ -27,7 +27,10 @@ public record ArticleDTO(
         LocalDateTime publishedAt,
 
         @Schema(description = "When the article was fetched")
-        LocalDateTime fetchedAt
+        LocalDateTime fetchedAt,
+
+        @Schema(description = "Whether the article has been read")
+        boolean isRead
 ) {
 
 }

--- a/it-news/src/main/java/com/marvin/itnews/entity/Article.java
+++ b/it-news/src/main/java/com/marvin/itnews/entity/Article.java
@@ -53,6 +53,9 @@ public class Article {
     @Column(name = "fetched_at", nullable = false)
     private LocalDateTime fetchedAt;
 
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/it-news/src/main/java/com/marvin/itnews/repository/ArticleRepository.java
+++ b/it-news/src/main/java/com/marvin/itnews/repository/ArticleRepository.java
@@ -19,4 +19,14 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             String category, String source, Pageable pageable
     );
 
+    Page<Article> findByIsRead(boolean isRead, Pageable pageable);
+
+    Page<Article> findByCategoryAndIsRead(String category, boolean isRead, Pageable pageable);
+
+    Page<Article> findBySourceAndIsRead(String source, boolean isRead, Pageable pageable);
+
+    Page<Article> findByCategoryAndSourceAndIsRead(
+            String category, String source, boolean isRead, Pageable pageable
+    );
+
 }

--- a/it-news/src/main/java/com/marvin/itnews/service/ArticleService.java
+++ b/it-news/src/main/java/com/marvin/itnews/service/ArticleService.java
@@ -3,11 +3,13 @@ package com.marvin.itnews.service;
 import com.marvin.itnews.dto.ArticleDTO;
 import com.marvin.itnews.mapper.ArticleMapper;
 import com.marvin.itnews.repository.ArticleRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ArticleService {
@@ -26,23 +28,51 @@ public class ArticleService {
     /**
      * Retrieves articles with optional filtering by category and source.
      *
-     * @param category optional category filter
-     * @param source   optional source filter
-     * @param page     page number
-     * @param size     page size
+     * @param category    optional category filter
+     * @param source      optional source filter
+     * @param includeRead whether to include read articles
+     * @param page        page number
+     * @param size        page size
      * @return paginated articles
      */
     public Page<ArticleDTO> getArticles(
-            String category, String source, int page, int size
+            String category, String source, boolean includeRead, int page, int size
     ) {
         final Pageable pageable = PageRequest.of(
                 page, size, Sort.by(Sort.Direction.DESC, "publishedAt")
         );
-        return findArticles(category, source, pageable)
+        return findArticles(category, source, includeRead, pageable)
                 .map(articleMapper::toArticleDTO);
     }
 
-    private org.springframework.data.domain.Page<com.marvin.itnews.entity.Article> findArticles(
+    @Transactional
+    public void markAsRead(long id) {
+        final var article = articleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Article not found: " + id));
+        article.setRead(true);
+        articleRepository.save(article);
+    }
+
+    private Page<com.marvin.itnews.entity.Article> findArticles(
+            String category, String source, boolean includeRead, Pageable pageable
+    ) {
+        if (includeRead) {
+            return findAllArticles(category, source, pageable);
+        }
+        if (category != null && source != null) {
+            return articleRepository
+                    .findByCategoryAndSourceAndIsRead(category, source, false, pageable);
+        } else if (category != null) {
+            return articleRepository
+                    .findByCategoryAndIsRead(category, false, pageable);
+        } else if (source != null) {
+            return articleRepository
+                    .findBySourceAndIsRead(source, false, pageable);
+        }
+        return articleRepository.findByIsRead(false, pageable);
+    }
+
+    private Page<com.marvin.itnews.entity.Article> findAllArticles(
             String category, String source, Pageable pageable
     ) {
         if (category != null && source != null) {

--- a/it-news/src/main/resources/db/migration/it-news/V1_3__add_is_read_flag.sql
+++ b/it-news/src/main/resources/db/migration/it-news/V1_3__add_is_read_flag.sql
@@ -1,0 +1,3 @@
+ALTER TABLE it_news.article ADD COLUMN is_read BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE it_news.article_aud ADD COLUMN is_read BOOLEAN;


### PR DESCRIPTION
## Summary
- Add `is_read` column to `article` table (+ audit table) via Flyway migration
- Add `PATCH /it-news/articles/{id}/read` endpoint to mark articles as read
- Add `includeRead` query parameter to `GET /it-news/articles` to filter out read articles by default

## Test plan
- [ ] Verify Flyway migration runs successfully
- [ ] Call `PATCH /it-news/articles/{id}/read` and confirm article is marked as read
- [ ] Call `GET /it-news/articles` and confirm read articles are excluded by default
- [ ] Call `GET /it-news/articles?includeRead=true` and confirm read articles are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)