### PR TITLE
feat(it-news): add scheduled cleanup of old read articles

### DIFF
--- a/it-news/src/main/java/com/marvin/itnews/configuration/SchedulerConfig.java
+++ b/it-news/src/main/java/com/marvin/itnews/configuration/SchedulerConfig.java
@@ -1,0 +1,29 @@
+package com.marvin.itnews.configuration;
+
+import com.marvin.itnews.repository.ArticleRepository;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Configuration
+public class SchedulerConfig {
+
+    private final ArticleRepository articleRepository;
+
+    public SchedulerConfig(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanUpOldReadArticles() {
+        final LocalDateTime cutoff = LocalDateTime.now().minusMonths(1);
+        log.info("Cleaning up read articles older than {}", cutoff);
+        final int deleted = articleRepository.deleteReadArticlesOlderThan(cutoff);
+        log.info("Deleted {} old read articles", deleted);
+    }
+
+}

--- a/it-news/src/main/java/com/marvin/itnews/repository/ArticleRepository.java
+++ b/it-news/src/main/java/com/marvin/itnews/repository/ArticleRepository.java
@@ -1,9 +1,12 @@
 package com.marvin.itnews.repository;
 
 import com.marvin.itnews.entity.Article;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,5 +31,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findByCategoryAndSourceAndIsRead(
             String category, String source, boolean isRead, Pageable pageable
     );
+
+    @Modifying
+    @Query("DELETE FROM Article a WHERE a.isRead = true AND a.fetchedAt < :cutoff")
+    int deleteReadArticlesOlderThan(LocalDateTime cutoff);
 
 }


### PR DESCRIPTION
## Summary
- Add a daily scheduled task (runs at 3:00 AM) that deletes articles which are marked as read and older than one month
- Add `deleteReadArticlesOlderThan` query method to `ArticleRepository`
- New `SchedulerConfig` in the it-news module, following the existing pattern from the plants module

## Test plan
- [ ] Verify the application starts without errors
- [ ] Verify the scheduler triggers correctly (can temporarily adjust cron for testing)
- [ ] Verify only articles with `is_read = true` and `fetched_at` older than one month are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)