### PR TITLE
Fix blocking event listeners preventing startup tasks

### DIFF
--- a/backup/src/main/java/com/marvin/backup/service/BackupDirectoryWatcher.java
+++ b/backup/src/main/java/com/marvin/backup/service/BackupDirectoryWatcher.java
@@ -49,13 +49,15 @@ public class BackupDirectoryWatcher {
     /** Starts the watch service when the application is ready. */
     @EventListener(ApplicationReadyEvent.class)
     public void startWatchService() {
-        IS_RUNNING.set(true);
-        try {
-            ensureDirectoryExists();
-            watchDirectory();
-        } catch (Exception e) {
-            LOGGER.error("Error starting backup WatchService!", e);
-        }
+        new Thread(() -> {
+            IS_RUNNING.set(true);
+            try {
+                ensureDirectoryExists();
+                watchDirectory();
+            } catch (Exception e) {
+                LOGGER.error("Error starting backup WatchService!", e);
+            }
+        }).start();
     }
 
     /** Stops the watch service on application shutdown. */

--- a/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
+++ b/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
@@ -51,12 +51,14 @@ public class DirectoryWatcher {
     /** Starts the watch service when the application is ready. */
     @EventListener(ApplicationReadyEvent.class)
     public void startUpWatchService() {
-        IS_RUNNING.set(true);
-        try {
-            watchDirectory();
-        } catch (Exception e) {
-            LOGGER.error("Error starting WatchService!", e);
-        }
+        new Thread(() -> {
+            IS_RUNNING.set(true);
+            try {
+                watchDirectory();
+            } catch (Exception e) {
+                LOGGER.error("Error starting WatchService!", e);
+            }
+        }).start();
     }
 
     /** Stops the watch service on application shutdown. */


### PR DESCRIPTION
## Summary
- Fixed ApplicationReadyEvent listeners being blocked by directory watch operations
- Both DirectoryWatcher and BackupDirectoryWatcher now spawn their watch loops on separate threads
- Allows PlantSchedulerConfig and ItNewsSchedulerConfig event listeners to execute at startup

## Test plan
- [ ] Application starts successfully
- [ ] Plant watering/fertilizing notifications are sent on startup
- [ ] IT news article cleanup runs on startup
- [ ] Directory watchers still detect file changes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)