### PR TITLE
feat(climate): add humidity to GET /climate/readings

### DIFF
--- a/api_documentation.md
+++ b/api_documentation.md
@@ -329,7 +329,7 @@ APIs are configured via application.yaml with environment variables for database
 Exposes current climate sensor readings sourced from InfluxDB.
 
 #### GET /climate/readings
-Returns the most recent temperature reading for each configured climate sensor.
+Returns the most recent temperature reading for each configured climate sensor, optionally enriched with the matching humidity reading.
 
 **Request:**
 - Method: GET
@@ -349,17 +349,20 @@ Returns the most recent temperature reading for each configured climate sensor.
     "label": "Draußen",
     "location": "outdoor",
     "temperatureC": 21.5,
+    "humidityPct": 55.0,
     "measuredAt": "2026-05-16T10:00:00Z"
   }
 ]
 ```
+
+`humidityPct` is optional and is omitted from the JSON payload when the humidity sensor has no recent record.
 
 **Sample curl:**
 ```bash
 curl -s http://localhost:9001/climate/readings | jq .
 ```
 
-**Description:** Queries the `sensor_data` InfluxDB bucket for the latest `°C` measurement matching the configured `entity_id` (default `draussen_temperature`). Returns an empty JSON array when no data is available. The entity ID is configurable via the `CLIMATE_OUTDOOR_ENTITY_ID` environment variable.
+**Description:** Queries the `sensor_data` InfluxDB bucket for the latest `°C` measurement matching the configured temperature `entity_id` (default `draussen_temperature`) and the latest `%` measurement matching the humidity `entity_id` (default `draussen_humidity`). Temperature and humidity are queried in parallel and merged into a single reading; a missing humidity record does not block the response. Returns an empty JSON array when no temperature data is available. The entity IDs are configurable via the `CLIMATE_OUTDOOR_ENTITY_ID` and `CLIMATE_OUTDOOR_HUMIDITY_ENTITY_ID` environment variables.
 
 ## Reactive Programming
 

--- a/boot/src/main/resources/application.yaml
+++ b/boot/src/main/resources/application.yaml
@@ -71,3 +71,4 @@ rss:
 climate:
   outdoor:
     entity-id: ${CLIMATE_OUTDOOR_ENTITY_ID:draussen_temperature}
+    humidity-entity-id: ${CLIMATE_OUTDOOR_HUMIDITY_ENTITY_ID:draussen_humidity}

--- a/climate/src/main/java/com/marvin/climate/dto/TemperatureReading.java
+++ b/climate/src/main/java/com/marvin/climate/dto/TemperatureReading.java
@@ -1,21 +1,25 @@
 package com.marvin.climate.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
 
 /**
- * Represents a single temperature reading from a climate sensor.
+ * Represents a single climate sensor reading combining temperature and (optionally) humidity.
  *
- * @param sensorId     the unique identifier of the sensor
+ * @param sensorId     the unique identifier of the temperature sensor
  * @param label        the human-readable label for the sensor
  * @param location     the physical location of the sensor
  * @param temperatureC the measured temperature in degrees Celsius
- * @param measuredAt   the instant at which the measurement was taken
+ * @param humidityPct  the measured relative humidity in percent, or {@code null} when unavailable
+ * @param measuredAt   the instant at which the temperature measurement was taken
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TemperatureReading(
         String sensorId,
         String label,
         String location,
         double temperatureC,
+        Double humidityPct,
         Instant measuredAt
 ) {
 }

--- a/climate/src/main/java/com/marvin/climate/service/ClimateService.java
+++ b/climate/src/main/java/com/marvin/climate/service/ClimateService.java
@@ -21,74 +21,102 @@ public class ClimateService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClimateService.class);
     private static final String BUCKET = "sensor_data";
-    private static final String MEASUREMENT = "°C";
+    private static final String TEMPERATURE_MEASUREMENT = "°C";
+    private static final String HUMIDITY_MEASUREMENT = "%";
     private static final String OUTDOOR_LABEL = "Draußen";
     private static final String OUTDOOR_LOCATION = "outdoor";
+    private static final FluxRecord MISSING_RECORD = new FluxRecord(-1);
 
     private final InfluxDBClient influxDBClient;
     private final String org;
     private final String outdoorEntityId;
+    private final String outdoorHumidityEntityId;
 
     /**
      * Constructs a ClimateService with required dependencies and configuration.
      *
-     * @param influxDBClient  the InfluxDB client used to query sensor data
-     * @param org             the InfluxDB organisation name
-     * @param outdoorEntityId the entity ID for the outdoor temperature sensor
+     * @param influxDBClient          the InfluxDB client used to query sensor data
+     * @param org                     the InfluxDB organisation name
+     * @param outdoorEntityId         the entity ID for the outdoor temperature sensor
+     * @param outdoorHumidityEntityId the entity ID for the outdoor humidity sensor
      */
     public ClimateService(
             InfluxDBClient influxDBClient,
             @Value("${influxdb.org}") String org,
-            @Value("${climate.outdoor.entity-id:draussen_temperature}") String outdoorEntityId
+            @Value("${climate.outdoor.entity-id:draussen_temperature}") String outdoorEntityId,
+            @Value("${climate.outdoor.humidity-entity-id:draussen_humidity}") String outdoorHumidityEntityId
     ) {
         this.influxDBClient = influxDBClient;
         this.org = org;
         this.outdoorEntityId = outdoorEntityId;
+        this.outdoorHumidityEntityId = outdoorHumidityEntityId;
     }
 
     /**
-     * Retrieves the current temperature readings from all configured climate sensors.
+     * Retrieves the current climate readings from all configured sensors, merging
+     * temperature and humidity for the outdoor sensor into a single DTO.
      *
-     * @return a Flux emitting one {@link TemperatureReading} per sensor record found in InfluxDB
+     * @return a Flux emitting one {@link TemperatureReading} per outdoor sensor record found in InfluxDB
      */
     public Flux<TemperatureReading> getCurrentReadings() {
         LOGGER.info("Fetching current climate readings from InfluxDB");
-        final String flux = buildFluxQuery();
 
-        return Mono.fromCallable(() -> influxDBClient.getQueryApi().query(flux, org))
-                .subscribeOn(Schedulers.boundedElastic())
-                .flatMapMany(this::mapTablesToReadings)
-                .doOnError(e -> LOGGER.error("Failed to fetch climate readings from InfluxDB for entity_id '{}'", outdoorEntityId, e));
+        final Mono<FluxRecord> temperatureMono = queryLatestRecord(
+                buildFluxQuery(TEMPERATURE_MEASUREMENT, outdoorEntityId), outdoorEntityId);
+        final Mono<FluxRecord> humidityMono = queryLatestRecord(
+                buildFluxQuery(HUMIDITY_MEASUREMENT, outdoorHumidityEntityId), outdoorHumidityEntityId)
+                .onErrorResume(e -> {
+                    LOGGER.warn("Humidity query failed for entity_id '{}' - continuing without humidity", outdoorHumidityEntityId, e);
+                    return Mono.just(MISSING_RECORD);
+                });
+
+        return Mono.zip(temperatureMono, humidityMono)
+                .flatMapMany(tuple -> mergeReadings(tuple.getT1(), tuple.getT2()));
     }
 
-    private String buildFluxQuery() {
+    private Mono<FluxRecord> queryLatestRecord(String flux, String entityId) {
+        return Mono.fromCallable(() -> influxDBClient.getQueryApi().query(flux, org))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(tables -> extractFirstRecord(tables, entityId))
+                .doOnError(e -> LOGGER.error("Failed to fetch climate reading from InfluxDB for entity_id '{}'", entityId, e));
+    }
+
+    private FluxRecord extractFirstRecord(List<FluxTable> tables, String entityId) {
+        if (tables.isEmpty()) {
+            LOGGER.warn("InfluxDB query returned no records for entity_id '{}'", entityId);
+            return MISSING_RECORD;
+        }
+        return tables.stream()
+                .flatMap(table -> table.getRecords().stream())
+                .findFirst()
+                .orElse(MISSING_RECORD);
+    }
+
+    private Flux<TemperatureReading> mergeReadings(FluxRecord temperature, FluxRecord humidity) {
+        if (temperature == MISSING_RECORD) {
+            return Flux.empty();
+        }
+        final double temperatureC = ((Number) temperature.getValue()).doubleValue();
+        final Double humidityPct = humidity == MISSING_RECORD
+                ? null
+                : ((Number) humidity.getValue()).doubleValue();
+        return Flux.just(new TemperatureReading(
+                outdoorEntityId,
+                OUTDOOR_LABEL,
+                OUTDOOR_LOCATION,
+                temperatureC,
+                humidityPct,
+                temperature.getTime()
+        ));
+    }
+
+    private String buildFluxQuery(String measurement, String entityId) {
         return String.format(
                 "from(bucket: \"%s\")"
                 + " |> range(start: -15m)"
                 + " |> filter(fn: (r) => r._measurement == \"%s\" and r.entity_id == \"%s\" and r._field == \"value\")"
                 + " |> last()",
-                BUCKET, MEASUREMENT, outdoorEntityId
-        );
-    }
-
-    private Flux<TemperatureReading> mapTablesToReadings(List<FluxTable> tables) {
-        if (tables.isEmpty()) {
-            LOGGER.warn("InfluxDB query returned no records for entity_id '{}'", outdoorEntityId);
-            return Flux.empty();
-        }
-        return Flux.fromIterable(tables)
-                .flatMap(table -> Flux.fromIterable(table.getRecords()))
-                .map(this::toTemperatureReading);
-    }
-
-    private TemperatureReading toTemperatureReading(FluxRecord record) {
-        final double temperatureC = ((Number) record.getValue()).doubleValue();
-        return new TemperatureReading(
-                outdoorEntityId,
-                OUTDOOR_LABEL,
-                OUTDOOR_LOCATION,
-                temperatureC,
-                record.getTime()
+                BUCKET, measurement, entityId
         );
     }
 }

--- a/climate/src/test/java/com/marvin/climate/controller/ClimateControllerTest.java
+++ b/climate/src/test/java/com/marvin/climate/controller/ClimateControllerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 
@@ -29,8 +29,8 @@ class ClimateControllerTest {
     private ClimateService climateService;
 
     @Test
-    @DisplayName("GET /climate/readings returns 200 with a JSON array of readings")
-    void getReadings_ShouldReturn200WithReadings_WhenServiceHasData() {
+    @DisplayName("GET /climate/readings includes humidityPct when present")
+    void getReadings_ShouldReturnReadingWithHumidity_WhenServiceProvidesIt() {
         // Given
         final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
         final TemperatureReading reading = new TemperatureReading(
@@ -38,6 +38,7 @@ class ClimateControllerTest {
                 "Draußen",
                 "outdoor",
                 21.5,
+                55.0,
                 measuredAt
         );
         when(climateService.getCurrentReadings()).thenReturn(Flux.just(reading));
@@ -54,7 +55,34 @@ class ClimateControllerTest {
                 .jsonPath("$[0].label").isEqualTo("Draußen")
                 .jsonPath("$[0].location").isEqualTo("outdoor")
                 .jsonPath("$[0].temperatureC").isEqualTo(21.5)
+                .jsonPath("$[0].humidityPct").isEqualTo(55.0)
                 .jsonPath("$[0].measuredAt").isEqualTo("2026-05-16T10:00:00Z");
+    }
+
+    @Test
+    @DisplayName("GET /climate/readings omits humidityPct when service returns null")
+    void getReadings_ShouldOmitHumidity_WhenServiceReturnsNull() {
+        // Given
+        final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
+        final TemperatureReading reading = new TemperatureReading(
+                "draussen_temperature",
+                "Draußen",
+                "outdoor",
+                21.5,
+                null,
+                measuredAt
+        );
+        when(climateService.getCurrentReadings()).thenReturn(Flux.just(reading));
+
+        // When / Then
+        webTestClient.get()
+                .uri("/climate/readings")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].temperatureC").isEqualTo(21.5)
+                .jsonPath("$[0].humidityPct").doesNotExist();
     }
 
     @Test

--- a/climate/src/test/java/com/marvin/climate/service/ClimateServiceTest.java
+++ b/climate/src/test/java/com/marvin/climate/service/ClimateServiceTest.java
@@ -1,9 +1,11 @@
 package com.marvin.climate.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +30,9 @@ class ClimateServiceTest {
 
     private static final String TEST_ORG = "test_org";
     private static final String TEST_ENTITY_ID = "draussen_temperature";
+    private static final String TEST_HUMIDITY_ENTITY_ID = "draussen_humidity";
     private static final double TEST_TEMPERATURE = 21.5;
+    private static final double TEST_HUMIDITY = 55.0;
 
     @Mock
     private InfluxDBClient influxDBClient;
@@ -40,17 +44,20 @@ class ClimateServiceTest {
 
     @BeforeEach
     void setUp() {
-        climateService = new ClimateService(influxDBClient, TEST_ORG, TEST_ENTITY_ID);
+        climateService = new ClimateService(influxDBClient, TEST_ORG, TEST_ENTITY_ID, TEST_HUMIDITY_ENTITY_ID);
         when(influxDBClient.getQueryApi()).thenReturn(queryApi);
     }
 
     @Test
-    @DisplayName("Should emit one TemperatureReading for a single FluxRecord")
-    void getCurrentReadings_ShouldEmitOneReading_WhenOneRecordReturned() {
+    @DisplayName("Should emit merged reading with temperature and humidity when both are present")
+    void getCurrentReadings_ShouldMergeTemperatureAndHumidity_WhenBothPresent() {
         // Given
         final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
-        final FluxTable table = buildTable(TEST_TEMPERATURE, measuredAt);
-        when(queryApi.query(anyString(), eq(TEST_ORG))).thenReturn(List.of(table));
+        final Instant humidityAt = Instant.parse("2026-05-16T10:00:05Z");
+        stubQueries(
+                List.of(buildTable(TEST_TEMPERATURE, measuredAt)),
+                List.of(buildTable(TEST_HUMIDITY, humidityAt))
+        );
 
         // When / Then
         StepVerifier.create(climateService.getCurrentReadings())
@@ -59,16 +66,59 @@ class ClimateServiceTest {
                     assertEquals("Draußen", reading.label());
                     assertEquals("outdoor", reading.location());
                     assertEquals(TEST_TEMPERATURE, reading.temperatureC());
+                    assertEquals(TEST_HUMIDITY, reading.humidityPct());
                     assertEquals(measuredAt, reading.measuredAt());
                 })
                 .verifyComplete();
     }
 
     @Test
-    @DisplayName("Should emit empty Flux and log warn when InfluxDB returns no tables")
-    void getCurrentReadings_ShouldReturnEmpty_WhenNoTablesReturned() {
+    @DisplayName("Should emit reading without humidity when humidity query returns no records")
+    void getCurrentReadings_ShouldOmitHumidity_WhenHumidityMissing() {
         // Given
-        when(queryApi.query(anyString(), eq(TEST_ORG))).thenReturn(List.of());
+        final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
+        stubQueries(
+                List.of(buildTable(TEST_TEMPERATURE, measuredAt)),
+                List.of()
+        );
+
+        // When / Then
+        StepVerifier.create(climateService.getCurrentReadings())
+                .assertNext(reading -> {
+                    assertEquals(TEST_TEMPERATURE, reading.temperatureC());
+                    assertNull(reading.humidityPct());
+                    assertEquals(measuredAt, reading.measuredAt());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit reading without humidity when humidity query fails")
+    void getCurrentReadings_ShouldOmitHumidity_WhenHumidityQueryFails() {
+        // Given
+        final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
+        when(queryApi.query(anyString(), eq(TEST_ORG))).thenAnswer(invocation -> {
+            final String query = invocation.getArgument(0);
+            if (query.contains(TEST_HUMIDITY_ENTITY_ID)) {
+                throw new RuntimeException("humidity down");
+            }
+            return List.of(buildTable(TEST_TEMPERATURE, measuredAt));
+        });
+
+        // When / Then
+        StepVerifier.create(climateService.getCurrentReadings())
+                .assertNext(reading -> {
+                    assertEquals(TEST_TEMPERATURE, reading.temperatureC());
+                    assertNull(reading.humidityPct());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit empty Flux when temperature query returns no records")
+    void getCurrentReadings_ShouldReturnEmpty_WhenTemperatureMissing() {
+        // Given
+        stubQueries(List.of(), List.of(buildTable(TEST_HUMIDITY, Instant.now())));
 
         // When / Then
         StepVerifier.create(climateService.getCurrentReadings())
@@ -76,8 +126,8 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should include configured entity_id in the Flux query string")
-    void getCurrentReadings_ShouldPassEntityIdInQuery() {
+    @DisplayName("Should include configured entity IDs in the Flux queries")
+    void getCurrentReadings_ShouldPassEntityIdsInQueries() {
         // Given
         when(queryApi.query(anyString(), eq(TEST_ORG))).thenReturn(List.of());
         final ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
@@ -86,13 +136,15 @@ class ClimateServiceTest {
         climateService.getCurrentReadings().blockLast();
 
         // Then
-        verify(queryApi).query(queryCaptor.capture(), eq(TEST_ORG));
-        assertTrue(queryCaptor.getValue().contains(TEST_ENTITY_ID), "Query must contain the configured entity_id");
+        verify(queryApi, atLeast(2)).query(queryCaptor.capture(), eq(TEST_ORG));
+        final List<String> queries = queryCaptor.getAllValues();
+        assertTrue(queries.stream().anyMatch(q -> q.contains(TEST_ENTITY_ID)), "Query must contain the temperature entity_id");
+        assertTrue(queries.stream().anyMatch(q -> q.contains(TEST_HUMIDITY_ENTITY_ID)), "Query must contain the humidity entity_id");
     }
 
     @Test
-    @DisplayName("Should propagate InfluxDB query errors")
-    void getCurrentReadings_ShouldPropagateError_WhenInfluxFails() {
+    @DisplayName("Should propagate temperature query errors")
+    void getCurrentReadings_ShouldPropagateError_WhenTemperatureQueryFails() {
         // Given
         final RuntimeException influxFailure = new RuntimeException("influx down");
         when(queryApi.query(anyString(), eq(TEST_ORG))).thenThrow(influxFailure);
@@ -103,10 +155,20 @@ class ClimateServiceTest {
                 .verify();
     }
 
-    private FluxTable buildTable(double temperature, Instant time) {
+    private void stubQueries(List<FluxTable> temperatureTables, List<FluxTable> humidityTables) {
+        when(queryApi.query(anyString(), eq(TEST_ORG))).thenAnswer(invocation -> {
+            final String query = invocation.getArgument(0);
+            if (query.contains(TEST_HUMIDITY_ENTITY_ID)) {
+                return humidityTables;
+            }
+            return temperatureTables;
+        });
+    }
+
+    private FluxTable buildTable(double value, Instant time) {
         final FluxTable table = new FluxTable();
         final FluxRecord record = new FluxRecord(0);
-        record.getValues().put("_value", temperature);
+        record.getValues().put("_value", value);
         record.getValues().put("_time", time);
         table.getRecords().add(record);
         return table;


### PR DESCRIPTION
## Summary
- Adds optional `humidityPct` field to `TemperatureReading` (omitted from JSON when missing)
- `ClimateService` now runs the temperature and humidity Flux queries in parallel via `Mono.zip` on `Schedulers.boundedElastic()` and merges both into one DTO per outdoor sensor
- A missing or failing humidity record no longer blocks the response - temperature behavior remains backwards compatible
- Adds `climate.outdoor.humidity-entity-id` config (`CLIMATE_OUTDOOR_HUMIDITY_ENTITY_ID`, default `draussen_humidity`)
- Updates `api_documentation.md` with the new field and configuration

Closes #91.

## Test plan
- [x] `./gradlew :climate:build` — climate tests + checkstyle green
- [ ] Manual: `curl http://<backend-host>/climate/readings` returns both `temperatureC` and `humidityPct` when InfluxDB has fresh data
- [ ] Manual: response still works (temperature only) when the humidity sensor is offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)