### PR TITLE
feat(climate): include indoor room sensors in /climate/readings

### DIFF
--- a/climate/src/main/java/com/marvin/climate/service/ClimateService.java
+++ b/climate/src/main/java/com/marvin/climate/service/ClimateService.java
@@ -23,9 +23,19 @@ public class ClimateService {
     private static final String BUCKET = "sensor_data";
     private static final String TEMPERATURE_MEASUREMENT = "°C";
     private static final String HUMIDITY_MEASUREMENT = "%";
+    private static final String TEMPERATURE_SUFFIX = "_temperature";
+    private static final String HUMIDITY_SUFFIX = "_humidity";
     private static final String OUTDOOR_LABEL = "Draußen";
     private static final String OUTDOOR_LOCATION = "outdoor";
+    private static final String INDOOR_LOCATION = "indoor";
     private static final FluxRecord MISSING_RECORD = new FluxRecord(-1);
+    private static final List<Room> INDOOR_ROOMS = List.of(
+            new Room("badezimmer", "Badezimmer"),
+            new Room("flur", "Flur"),
+            new Room("kueche", "Küche"),
+            new Room("schlafzimmer", "Schlafzimmer"),
+            new Room("wohnzimmer", "Wohnzimmer")
+    );
 
     private final InfluxDBClient influxDBClient;
     private final String org;
@@ -53,25 +63,49 @@ public class ClimateService {
     }
 
     /**
-     * Retrieves the current climate readings from all configured sensors, merging
-     * temperature and humidity for the outdoor sensor into a single DTO.
+     * Retrieves the current climate readings from the outdoor sensor and every configured
+     * indoor room sensor. Each emitted reading combines temperature and (when available)
+     * humidity for the corresponding location. Sensors that fail to report any data are
+     * silently skipped so that a single broken sensor does not hide the rest.
      *
-     * @return a Flux emitting one {@link TemperatureReading} per outdoor sensor record found in InfluxDB
+     * @return a Flux emitting one {@link TemperatureReading} per sensor that has data
      */
     public Flux<TemperatureReading> getCurrentReadings() {
         LOGGER.info("Fetching current climate readings from InfluxDB");
 
+        final Mono<TemperatureReading> outdoor = fetchReading(
+                outdoorEntityId, outdoorHumidityEntityId, OUTDOOR_LABEL, OUTDOOR_LOCATION);
+        final Flux<TemperatureReading> indoor = Flux.fromIterable(INDOOR_ROOMS)
+                .concatMap(room -> fetchReading(
+                        room.key() + TEMPERATURE_SUFFIX,
+                        room.key() + HUMIDITY_SUFFIX,
+                        room.label(),
+                        INDOOR_LOCATION));
+
+        return Flux.concat(outdoor.flux(), indoor);
+    }
+
+    private Mono<TemperatureReading> fetchReading(
+            String temperatureEntityId,
+            String humidityEntityId,
+            String label,
+            String location
+    ) {
         final Mono<FluxRecord> temperatureMono = queryLatestRecord(
-                buildFluxQuery(TEMPERATURE_MEASUREMENT, outdoorEntityId), outdoorEntityId);
-        final Mono<FluxRecord> humidityMono = queryLatestRecord(
-                buildFluxQuery(HUMIDITY_MEASUREMENT, outdoorHumidityEntityId), outdoorHumidityEntityId)
+                buildFluxQuery(TEMPERATURE_MEASUREMENT, temperatureEntityId), temperatureEntityId)
                 .onErrorResume(e -> {
-                    LOGGER.warn("Humidity query failed for entity_id '{}' - continuing without humidity", outdoorHumidityEntityId, e);
+                    LOGGER.warn("Temperature query failed for entity_id '{}' - skipping sensor", temperatureEntityId, e);
+                    return Mono.just(MISSING_RECORD);
+                });
+        final Mono<FluxRecord> humidityMono = queryLatestRecord(
+                buildFluxQuery(HUMIDITY_MEASUREMENT, humidityEntityId), humidityEntityId)
+                .onErrorResume(e -> {
+                    LOGGER.warn("Humidity query failed for entity_id '{}' - continuing without humidity", humidityEntityId, e);
                     return Mono.just(MISSING_RECORD);
                 });
 
         return Mono.zip(temperatureMono, humidityMono)
-                .flatMapMany(tuple -> mergeReadings(tuple.getT1(), tuple.getT2()));
+                .flatMap(tuple -> toReading(tuple.getT1(), tuple.getT2(), temperatureEntityId, label, location));
     }
 
     private Mono<FluxRecord> queryLatestRecord(String flux, String entityId) {
@@ -92,18 +126,24 @@ public class ClimateService {
                 .orElse(MISSING_RECORD);
     }
 
-    private Flux<TemperatureReading> mergeReadings(FluxRecord temperature, FluxRecord humidity) {
+    private Mono<TemperatureReading> toReading(
+            FluxRecord temperature,
+            FluxRecord humidity,
+            String sensorId,
+            String label,
+            String location
+    ) {
         if (temperature == MISSING_RECORD) {
-            return Flux.empty();
+            return Mono.empty();
         }
         final double temperatureC = ((Number) temperature.getValue()).doubleValue();
         final Double humidityPct = humidity == MISSING_RECORD
                 ? null
                 : ((Number) humidity.getValue()).doubleValue();
-        return Flux.just(new TemperatureReading(
-                outdoorEntityId,
-                OUTDOOR_LABEL,
-                OUTDOOR_LOCATION,
+        return Mono.just(new TemperatureReading(
+                sensorId,
+                label,
+                location,
                 temperatureC,
                 humidityPct,
                 temperature.getTime()
@@ -118,5 +158,8 @@ public class ClimateService {
                 + " |> last()",
                 BUCKET, measurement, entityId
         );
+    }
+
+    private record Room(String key, String label) {
     }
 }

--- a/climate/src/test/java/com/marvin/climate/service/ClimateServiceTest.java
+++ b/climate/src/test/java/com/marvin/climate/service/ClimateServiceTest.java
@@ -1,6 +1,7 @@
 package com.marvin.climate.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -13,8 +14,10 @@ import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.QueryApi;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
+import com.marvin.climate.dto.TemperatureReading;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,12 +52,12 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should emit merged reading with temperature and humidity when both are present")
+    @DisplayName("Should emit merged outdoor reading with temperature and humidity when both are present")
     void getCurrentReadings_ShouldMergeTemperatureAndHumidity_WhenBothPresent() {
         // Given
         final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
         final Instant humidityAt = Instant.parse("2026-05-16T10:00:05Z");
-        stubQueries(
+        stubOutdoor(
                 List.of(buildTable(TEST_TEMPERATURE, measuredAt)),
                 List.of(buildTable(TEST_HUMIDITY, humidityAt))
         );
@@ -73,11 +76,11 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should emit reading without humidity when humidity query returns no records")
+    @DisplayName("Should emit outdoor reading without humidity when humidity query returns no records")
     void getCurrentReadings_ShouldOmitHumidity_WhenHumidityMissing() {
         // Given
         final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
-        stubQueries(
+        stubOutdoor(
                 List.of(buildTable(TEST_TEMPERATURE, measuredAt)),
                 List.of()
         );
@@ -93,7 +96,7 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should emit reading without humidity when humidity query fails")
+    @DisplayName("Should emit outdoor reading without humidity when humidity query fails")
     void getCurrentReadings_ShouldOmitHumidity_WhenHumidityQueryFails() {
         // Given
         final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
@@ -102,7 +105,10 @@ class ClimateServiceTest {
             if (query.contains(TEST_HUMIDITY_ENTITY_ID)) {
                 throw new RuntimeException("humidity down");
             }
-            return List.of(buildTable(TEST_TEMPERATURE, measuredAt));
+            if (query.contains(TEST_ENTITY_ID)) {
+                return List.of(buildTable(TEST_TEMPERATURE, measuredAt));
+            }
+            return List.of();
         });
 
         // When / Then
@@ -115,10 +121,10 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should emit empty Flux when temperature query returns no records")
-    void getCurrentReadings_ShouldReturnEmpty_WhenTemperatureMissing() {
+    @DisplayName("Should emit empty Flux when no sensors return data")
+    void getCurrentReadings_ShouldReturnEmpty_WhenNoSensorsHaveData() {
         // Given
-        stubQueries(List.of(), List.of(buildTable(TEST_HUMIDITY, Instant.now())));
+        when(queryApi.query(anyString(), eq(TEST_ORG))).thenReturn(List.of());
 
         // When / Then
         StepVerifier.create(climateService.getCurrentReadings())
@@ -126,7 +132,7 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should include configured entity IDs in the Flux queries")
+    @DisplayName("Should include configured outdoor entity IDs in the Flux queries")
     void getCurrentReadings_ShouldPassEntityIdsInQueries() {
         // Given
         when(queryApi.query(anyString(), eq(TEST_ORG))).thenReturn(List.of());
@@ -143,25 +149,95 @@ class ClimateServiceTest {
     }
 
     @Test
-    @DisplayName("Should propagate temperature query errors")
-    void getCurrentReadings_ShouldPropagateError_WhenTemperatureQueryFails() {
+    @DisplayName("Should skip outdoor reading when temperature query fails but still emit other readings")
+    void getCurrentReadings_ShouldSkipOutdoor_WhenTemperatureQueryFails() {
         // Given
-        final RuntimeException influxFailure = new RuntimeException("influx down");
-        when(queryApi.query(anyString(), eq(TEST_ORG))).thenThrow(influxFailure);
+        final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
+        when(queryApi.query(anyString(), eq(TEST_ORG))).thenAnswer(invocation -> {
+            final String query = invocation.getArgument(0);
+            if (query.contains(TEST_ENTITY_ID) || query.contains(TEST_HUMIDITY_ENTITY_ID)) {
+                throw new RuntimeException("outdoor down");
+            }
+            if (query.contains("kueche_temperature")) {
+                return List.of(buildTable(22.2, measuredAt));
+            }
+            return List.of();
+        });
 
         // When / Then
         StepVerifier.create(climateService.getCurrentReadings())
-                .expectErrorMatches(t -> t == influxFailure || t.getCause() == influxFailure)
-                .verify();
+                .assertNext(reading -> {
+                    assertEquals("kueche_temperature", reading.sensorId());
+                    assertEquals("Küche", reading.label());
+                    assertEquals("indoor", reading.location());
+                    assertEquals(22.2, reading.temperatureC());
+                })
+                .verifyComplete();
     }
 
-    private void stubQueries(List<FluxTable> temperatureTables, List<FluxTable> humidityTables) {
+    @Test
+    @DisplayName("Should emit one indoor reading per configured room with data")
+    void getCurrentReadings_ShouldEmitIndoorReadings_ForEachRoom() {
+        // Given
+        final Instant measuredAt = Instant.parse("2026-05-16T10:00:00Z");
+        final Map<String, Double> indoorTemps = Map.of(
+                "badezimmer_temperature", 23.1,
+                "flur_temperature", 21.2,
+                "kueche_temperature", 22.3,
+                "schlafzimmer_temperature", 20.4,
+                "wohnzimmer_temperature", 22.5
+        );
+        final Map<String, Double> indoorHumidities = Map.of(
+                "badezimmer_humidity", 65.0,
+                "flur_humidity", 45.0,
+                "kueche_humidity", 50.0,
+                "schlafzimmer_humidity", 48.0,
+                "wohnzimmer_humidity", 46.0
+        );
+        when(queryApi.query(anyString(), eq(TEST_ORG))).thenAnswer(invocation -> {
+            final String query = invocation.getArgument(0);
+            for (final Map.Entry<String, Double> entry : indoorTemps.entrySet()) {
+                if (query.contains(entry.getKey())) {
+                    return List.of(buildTable(entry.getValue(), measuredAt));
+                }
+            }
+            for (final Map.Entry<String, Double> entry : indoorHumidities.entrySet()) {
+                if (query.contains(entry.getKey())) {
+                    return List.of(buildTable(entry.getValue(), measuredAt));
+                }
+            }
+            return List.of();
+        });
+
+        // When / Then
+        StepVerifier.create(climateService.getCurrentReadings())
+                .recordWith(java.util.ArrayList::new)
+                .expectNextCount(5)
+                .consumeRecordedWith(readings -> {
+                    final List<String> ids = readings.stream().map(TemperatureReading::sensorId).toList();
+                    assertTrue(ids.contains("badezimmer_temperature"));
+                    assertTrue(ids.contains("flur_temperature"));
+                    assertTrue(ids.contains("kueche_temperature"));
+                    assertTrue(ids.contains("schlafzimmer_temperature"));
+                    assertTrue(ids.contains("wohnzimmer_temperature"));
+                    readings.forEach(r -> {
+                        assertEquals("indoor", r.location());
+                        assertNotNull(r.humidityPct());
+                    });
+                })
+                .verifyComplete();
+    }
+
+    private void stubOutdoor(List<FluxTable> temperatureTables, List<FluxTable> humidityTables) {
         when(queryApi.query(anyString(), eq(TEST_ORG))).thenAnswer(invocation -> {
             final String query = invocation.getArgument(0);
             if (query.contains(TEST_HUMIDITY_ENTITY_ID)) {
                 return humidityTables;
             }
-            return temperatureTables;
+            if (query.contains(TEST_ENTITY_ID)) {
+                return temperatureTables;
+            }
+            return List.of();
         });
     }
 


### PR DESCRIPTION
## Summary
- Extend `ClimateService` with a list of five indoor rooms (`badezimmer`, `flur`, `kueche`, `schlafzimmer`, `wohnzimmer`); each is queried for `_temperature` (°C) and `_humidity` (%) from the `sensor_data` bucket alongside the existing outdoor sensor.
- Refactored to a single `fetchReading(temperatureId, humidityId, label, location)` helper; outdoor behaviour is unchanged.
- Per-sensor errors are now swallowed (and the sensor skipped) so one broken room can't hide the rest of the readings.

## Test plan
- [x] `./gradlew :climate:checkstyleMain :climate:checkstyleTest :climate:test` passes locally (added a test that asserts one indoor reading is emitted per configured room, and a test that an outdoor failure still yields an indoor reading).
- [x] Verified against live InfluxDB at `influxdb.home-lab.com` that all five indoor rooms report both `_temperature` and `_humidity` under the expected entity IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)