### PR TITLE
feat(grocery): add Claude Vision as primary OCR provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM eclipse-temurin:21
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    tesseract-ocr-deu \
+    tesseract-ocr-eng \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 RUN mkdir -p /app/camt/done

--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -69,8 +69,10 @@ public class ReceiptController {
     public Mono<ResponseEntity<Object>> uploadReceipt(
             @RequestPart("file")
             @Parameter(description = "Receipt image file (JPEG, PNG, etc.)") FilePart filePart) {
+        LOGGER.info("Received receipt upload: filename={}", filePart.filename());
         return extractBytes(filePart)
                 .flatMap(receiptService::processAndSave)
+                .doOnError(e -> LOGGER.error("Receipt processing failed for file '{}'", filePart.filename(), e))
                 .map(uuid -> {
                     final URI location = URI.create(RECEIPTS_LOCATION_PREFIX + uuid);
                     return ResponseEntity.created(location).build();

--- a/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
@@ -1,0 +1,100 @@
+package com.marvin.grocery.ocr;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/** Claude Vision-backed OCR provider. Sends the receipt image to the Anthropic API for robust text extraction. */
+@Service
+@Primary
+public class ClaudeVisionOcrProvider implements OcrProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClaudeVisionOcrProvider.class);
+    private static final String MODEL = "claude-sonnet-4-6";
+    private static final int MAX_TOKENS = 1024;
+    private static final String RECEIPT_PROMPT = """
+            Extract all purchased items from this German grocery receipt.
+            For each item output it on its own line as: item name  price
+            Use exactly two spaces between the item name and the price.
+            Format prices with a period as decimal separator (e.g. 1.09).
+            Include the receipt date on its own line in DD.MM.YYYY format if visible.
+            Skip totals, taxes, payment method lines, and store header information.
+            Output only the extracted lines, nothing else.""";
+
+    private final WebClient webClient;
+
+    /**
+     * Creates a new ClaudeVisionOcrProvider.
+     *
+     * @param webClientBuilder the Spring WebClient builder
+     * @param apiKey           the Anthropic API key (from {@code grocery.claude.api-key})
+     */
+    public ClaudeVisionOcrProvider(
+            WebClient.Builder webClientBuilder,
+            @Value("${grocery.claude.api-key}") String apiKey) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", apiKey)
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .build();
+    }
+
+    @Override
+    public Mono<String> extractText(byte[] imageBytes) {
+        LOGGER.info("Sending receipt image ({} bytes) to Claude Vision API", imageBytes.length);
+        final String base64 = Base64.getEncoder().encodeToString(imageBytes);
+        final String mediaType = detectMediaType(imageBytes);
+        final Map<String, Object> request = buildRequest(base64, mediaType);
+
+        return webClient.post()
+                .uri("/v1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ClaudeResponse.class)
+                .map(response -> {
+                    final String text = response.content().get(0).text();
+                    LOGGER.info("Claude Vision extracted {} characters", text.length());
+                    return text;
+                })
+                .doOnError(e -> LOGGER.error("Claude Vision API call failed", e));
+    }
+
+    private Map<String, Object> buildRequest(String base64, String mediaType) {
+        final Map<String, Object> imageSource = Map.of(
+                "type", "base64",
+                "media_type", mediaType,
+                "data", base64);
+        final Map<String, Object> imageBlock = Map.of("type", "image", "source", imageSource);
+        final Map<String, Object> textBlock = Map.of("type", "text", "text", RECEIPT_PROMPT);
+        final Map<String, Object> message = Map.of("role", "user", "content", List.of(imageBlock, textBlock));
+        return Map.of("model", MODEL, "max_tokens", MAX_TOKENS, "messages", List.of(message));
+    }
+
+    private String detectMediaType(byte[] bytes) {
+        if (bytes.length >= 4 && bytes[0] == (byte) 0x89 && bytes[1] == 'P' && bytes[2] == 'N' && bytes[3] == 'G') {
+            return "image/png";
+        }
+        if (bytes.length >= 2 && bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8) {
+            return "image/jpeg";
+        }
+        return "image/jpeg";
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ClaudeResponse(@JsonProperty("content") List<ContentBlock> content) {
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        record ContentBlock(@JsonProperty("text") String text) { }
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/ocr/TesseractOcrProvider.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/TesseractOcrProvider.java
@@ -9,14 +9,12 @@ import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 /** Tesseract-backed OCR provider. Runs OCR on the bounded-elastic scheduler to avoid blocking the event loop. */
 @Service
-@Primary
 public class TesseractOcrProvider implements OcrProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TesseractOcrProvider.class);
@@ -53,8 +51,10 @@ public class TesseractOcrProvider implements OcrProvider {
         tesseract.setLanguage("deu");
         tesseract.setPageSegMode(6);
 
+        LOGGER.info("Running Tesseract OCR on image of {} bytes (datapath={})", imageBytes.length, tesseractDatapath);
         final BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageBytes));
-        LOGGER.debug("Running Tesseract OCR on image of size {} bytes", imageBytes.length);
-        return tesseract.doOCR(image);
+        final String result = tesseract.doOCR(image);
+        LOGGER.info("Tesseract OCR completed, extracted {} characters", result.length());
+        return result;
     }
 }

--- a/grocery/src/main/java/com/marvin/grocery/repository/ReceiptRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ReceiptRepository.java
@@ -1,11 +1,21 @@
 package com.marvin.grocery.repository;
 
 import com.marvin.grocery.entity.ReceiptEntity;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 /** Spring Data JPA repository for {@link ReceiptEntity}. */
 @Repository
 public interface ReceiptRepository extends JpaRepository<ReceiptEntity, UUID> {
+
+    /**
+     * Returns all receipts with their items eagerly fetched to avoid lazy-load issues.
+     *
+     * @return list of all receipt entities with items initialized
+     */
+    @Query("SELECT DISTINCT r FROM ReceiptEntity r LEFT JOIN FETCH r.items")
+    List<ReceiptEntity> findAllWithItems();
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -63,7 +63,9 @@ public class ReceiptService {
      * @return a Mono emitting the UUID of the newly created receipt
      */
     public Mono<UUID> processAndSave(byte[] imageBytes) {
+        LOGGER.info("Starting receipt processing for image of {} bytes", imageBytes.length);
         return ocrProvider.extractText(imageBytes)
+                .doOnError(e -> LOGGER.error("OCR extraction failed", e))
                 .flatMap(ocrText -> Mono.fromCallable(() -> saveReceipt(imageBytes, ocrText))
                         .subscribeOn(Schedulers.boundedElastic()));
     }
@@ -74,8 +76,11 @@ public class ReceiptService {
      * @return a Flux emitting all stored receipts
      */
     public Flux<ReceiptDTO> findAll() {
-        return Flux.fromIterable(receiptRepository.findAll())
-                .map(receiptMapper::toReceiptDTO);
+        return Mono.fromCallable(() -> receiptRepository.findAllWithItems().stream()
+                        .map(receiptMapper::toReceiptDTO)
+                        .toList())
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMapIterable(list -> list);
     }
 
     /**
@@ -103,7 +108,9 @@ public class ReceiptService {
      */
     @Transactional
     private UUID saveReceipt(byte[] imageBytes, String ocrText) {
+        LOGGER.info("Parsing OCR text ({} chars):\n{}", ocrText.length(), ocrText);
         final ParsedReceipt parsed = parserService.parse(ocrText);
+        LOGGER.info("Parsed {} items, receiptDate={}", parsed.items().size(), parsed.receiptDate());
 
         final ReceiptEntity receipt = new ReceiptEntity();
         receipt.setImageContent(imageBytes);
@@ -111,7 +118,7 @@ public class ReceiptService {
         receipt.setReceiptDate(parsed.receiptDate());
 
         final ReceiptEntity saved = receiptRepository.save(receipt);
-        LOGGER.debug("Saved receipt {} with {} items", saved.getId(), parsed.items().size());
+        LOGGER.info("Saved receipt {} with {} items", saved.getId(), parsed.items().size());
 
         for (final ParsedItem item : parsed.items()) {
             final ReceiptItemEntity itemEntity = new ReceiptItemEntity();


### PR DESCRIPTION
## Summary

- Adds `ClaudeVisionOcrProvider` as the `@Primary` OCR implementation, using the Anthropic Claude Vision API for more robust receipt text extraction
- Demotes `TesseractOcrProvider` to a fallback (removes `@Primary`) while keeping Tesseract installed in the Dockerfile
- Fixes a lazy-loading issue in `ReceiptService.findAll()` by adding a `findAllWithItems()` JPQL fetch-join query and subscribing on the bounded-elastic scheduler
- Adds structured `INFO`-level logging throughout the receipt processing pipeline for better observability

## Test plan

- [ ] Upload a receipt image via `POST /api/receipts` and verify it is processed by the Claude Vision provider (check logs)
- [ ] Call `GET /api/receipts` and verify all items are returned without lazy-load exceptions
- [ ] Confirm the Docker image builds successfully with Tesseract installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)