### PR TITLE
feat(grocery): add quantity and single-price columns, fix @Transactional proxy bypass

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/dto/ReceiptItemDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ReceiptItemDTO.java
@@ -6,9 +6,11 @@ import java.math.BigDecimal;
 /**
  * Data Transfer Object representing a single line item on a grocery receipt.
  *
- * @param id    database identifier of the item
- * @param name  name of the purchased item
- * @param price price of the item in euros
+ * @param id          database identifier of the item
+ * @param name        name of the purchased item
+ * @param singlePrice price per unit in euros
+ * @param quantity    number of units purchased
+ * @param price       total line price in euros (singlePrice × quantity)
  */
 @Schema(description = "A single parsed item from a grocery receipt")
 public record ReceiptItemDTO(
@@ -18,7 +20,13 @@ public record ReceiptItemDTO(
         @Schema(description = "Name of the purchased item", example = "Vollmilch 3,5%")
         String name,
 
-        @Schema(description = "Price of the item in euros", example = "1.29")
+        @Schema(description = "Price per unit of the item in euros", example = "1.29")
+        BigDecimal singlePrice,
+
+        @Schema(description = "Number of units purchased", example = "2")
+        int quantity,
+
+        @Schema(description = "Total line price in euros", example = "2.58")
         BigDecimal price
 ) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/entity/ReceiptItemEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ReceiptItemEntity.java
@@ -38,6 +38,12 @@ public class ReceiptItemEntity {
     @Column(name = "price", nullable = false, precision = 10, scale = 2)
     private BigDecimal price;
 
+    @Column(name = "single_price", nullable = false, precision = 10, scale = 2)
+    private BigDecimal singlePrice;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
@@ -9,11 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 /** Claude Vision-backed OCR provider. Sends the receipt image to the Anthropic API for robust text extraction. */

--- a/grocery/src/main/java/com/marvin/grocery/parser/ParsedItem.java
+++ b/grocery/src/main/java/com/marvin/grocery/parser/ParsedItem.java
@@ -5,8 +5,10 @@ import java.math.BigDecimal;
 /**
  * Represents a single parsed item from a raw OCR receipt text.
  *
- * @param name  name of the item as read from the receipt
- * @param price price of the item
+ * @param name        name of the item as read from the receipt
+ * @param singlePrice price per unit of the item
+ * @param quantity    number of units purchased
+ * @param price       total line price (singlePrice × quantity)
  */
-public record ParsedItem(String name, BigDecimal price) {
+public record ParsedItem(String name, BigDecimal singlePrice, int quantity, BigDecimal price) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/parser/ReceiptParserService.java
+++ b/grocery/src/main/java/com/marvin/grocery/parser/ReceiptParserService.java
@@ -19,7 +19,7 @@ public class ReceiptParserService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptParserService.class);
 
     private static final Pattern ITEM_PATTERN =
-            Pattern.compile("^(.+?)\\s{2,}(\\d{1,4}[.,]\\d{2})\\s*[ABab*]?\\s*$");
+            Pattern.compile("^(.+?)\\s{2,}(-?\\d{1,4}[.,]\\d{2})\\s{2,}(\\d{1,4})\\s{2,}(-?\\d{1,4}[.,]\\d{2})\\s*$");
 
     private static final Pattern TOTAL_LINE_PATTERN =
             Pattern.compile("(?i)(summe|gesamt|total|zwischensumme|zu zahlen|bar|ec.karte|mwst|ust)");
@@ -87,7 +87,7 @@ public class ReceiptParserService {
      * Attempts to parse a single receipt line into a ParsedItem.
      *
      * @param line the text line to parse
-     * @return a ParsedItem if the line matches an item pattern, otherwise null
+     * @return a ParsedItem if the line matches the four-column item pattern, otherwise null
      */
     private ParsedItem tryParseItem(String line) {
         if (TOTAL_LINE_PATTERN.matcher(line).find()) {
@@ -100,13 +100,17 @@ public class ReceiptParserService {
         }
 
         final String name = matcher.group(1).trim();
-        final String priceRaw = matcher.group(2).replace(',', '.');
+        final String singlePriceRaw = matcher.group(2).replace(',', '.');
+        final String quantityRaw = matcher.group(3);
+        final String totalPriceRaw = matcher.group(4).replace(',', '.');
 
         try {
-            final BigDecimal price = new BigDecimal(priceRaw);
-            return new ParsedItem(name, price);
+            final BigDecimal singlePrice = new BigDecimal(singlePriceRaw);
+            final int quantity = Integer.parseInt(quantityRaw);
+            final BigDecimal totalPrice = new BigDecimal(totalPriceRaw);
+            return new ParsedItem(name, singlePrice, quantity, totalPrice);
         } catch (NumberFormatException e) {
-            LOGGER.debug("Could not parse price from: {}", priceRaw);
+            LOGGER.debug("Could not parse item fields from line: {}", line);
             return null;
         }
     }

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
@@ -1,0 +1,76 @@
+package com.marvin.grocery.service;
+
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.parser.ParsedItem;
+import com.marvin.grocery.parser.ParsedReceipt;
+import com.marvin.grocery.parser.ReceiptParserService;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import com.marvin.grocery.repository.ReceiptRepository;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Handles transactional persistence of parsed receipts and their line items. */
+@Service
+public class ReceiptPersistenceService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptPersistenceService.class);
+
+    private final ReceiptParserService parserService;
+    private final ReceiptRepository receiptRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+
+    /**
+     * Creates a new ReceiptPersistenceService with all required dependencies.
+     *
+     * @param parserService         the parser for structured item extraction
+     * @param receiptRepository     the JPA repository for receipts
+     * @param receiptItemRepository the JPA repository for receipt items
+     */
+    public ReceiptPersistenceService(
+            ReceiptParserService parserService,
+            ReceiptRepository receiptRepository,
+            ReceiptItemRepository receiptItemRepository) {
+        this.parserService = parserService;
+        this.receiptRepository = receiptRepository;
+        this.receiptItemRepository = receiptItemRepository;
+    }
+
+    /**
+     * Parses the given OCR text, persists the receipt and all its line items in a single transaction,
+     * and returns the UUID of the newly created receipt.
+     *
+     * @param imageBytes raw image bytes to store on the receipt record
+     * @param ocrText    the raw OCR text extracted from the image
+     * @return the UUID of the saved receipt
+     */
+    @Transactional
+    public UUID saveReceipt(byte[] imageBytes, String ocrText) {
+        LOGGER.info("Parsing OCR text ({} chars):\n{}", ocrText.length(), ocrText);
+        final ParsedReceipt parsed = parserService.parse(ocrText);
+        LOGGER.info("Parsed {} items, receiptDate={}", parsed.items().size(), parsed.receiptDate());
+
+        final ReceiptEntity receipt = new ReceiptEntity();
+        receipt.setImageContent(imageBytes);
+        receipt.setRawOcrText(ocrText);
+        receipt.setReceiptDate(parsed.receiptDate());
+
+        final ReceiptEntity saved = receiptRepository.save(receipt);
+        LOGGER.info("Saved receipt {} with {} items", saved.getId(), parsed.items().size());
+
+        for (final ParsedItem item : parsed.items()) {
+            final ReceiptItemEntity itemEntity = new ReceiptItemEntity();
+            itemEntity.setReceipt(saved);
+            itemEntity.setName(item.name());
+            itemEntity.setSinglePrice(item.singlePrice());
+            itemEntity.setQuantity(item.quantity());
+            itemEntity.setPrice(item.price());
+            receiptItemRepository.save(itemEntity);
+        }
+
+        return saved.getId();
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -2,13 +2,9 @@ package com.marvin.grocery.service;
 
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
-import com.marvin.grocery.entity.ReceiptEntity;
 import com.marvin.grocery.entity.ReceiptItemEntity;
 import com.marvin.grocery.mapper.ReceiptMapper;
 import com.marvin.grocery.ocr.OcrProvider;
-import com.marvin.grocery.parser.ParsedItem;
-import com.marvin.grocery.parser.ParsedReceipt;
-import com.marvin.grocery.parser.ReceiptParserService;
 import com.marvin.grocery.repository.ReceiptItemRepository;
 import com.marvin.grocery.repository.ReceiptRepository;
 import java.util.List;
@@ -17,7 +13,6 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -29,7 +24,7 @@ public class ReceiptService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptService.class);
 
     private final OcrProvider ocrProvider;
-    private final ReceiptParserService parserService;
+    private final ReceiptPersistenceService persistenceService;
     private final ReceiptRepository receiptRepository;
     private final ReceiptItemRepository receiptItemRepository;
     private final ReceiptMapper receiptMapper;
@@ -37,20 +32,20 @@ public class ReceiptService {
     /**
      * Creates a new ReceiptService with all required dependencies.
      *
-     * @param ocrProvider           the OCR provider to use for text extraction
-     * @param parserService         the parser for structured item extraction
-     * @param receiptRepository     the JPA repository for receipts
+     * @param ocrProvider        the OCR provider to use for text extraction
+     * @param persistenceService the service responsible for transactional receipt persistence
+     * @param receiptRepository  the JPA repository for receipts
      * @param receiptItemRepository the JPA repository for receipt items
-     * @param receiptMapper         the MapStruct mapper for DTO conversion
+     * @param receiptMapper      the MapStruct mapper for DTO conversion
      */
     public ReceiptService(
             OcrProvider ocrProvider,
-            ReceiptParserService parserService,
+            ReceiptPersistenceService persistenceService,
             ReceiptRepository receiptRepository,
             ReceiptItemRepository receiptItemRepository,
             ReceiptMapper receiptMapper) {
         this.ocrProvider = ocrProvider;
-        this.parserService = parserService;
+        this.persistenceService = persistenceService;
         this.receiptRepository = receiptRepository;
         this.receiptItemRepository = receiptItemRepository;
         this.receiptMapper = receiptMapper;
@@ -66,7 +61,7 @@ public class ReceiptService {
         LOGGER.info("Starting receipt processing for image of {} bytes", imageBytes.length);
         return ocrProvider.extractText(imageBytes)
                 .doOnError(e -> LOGGER.error("OCR extraction failed", e))
-                .flatMap(ocrText -> Mono.fromCallable(() -> saveReceipt(imageBytes, ocrText))
+                .flatMap(ocrText -> Mono.fromCallable(() -> persistenceService.saveReceipt(imageBytes, ocrText))
                         .subscribeOn(Schedulers.boundedElastic()));
     }
 
@@ -97,37 +92,5 @@ public class ReceiptService {
             final List<ReceiptItemEntity> items = receiptItemRepository.findByReceiptId(receiptId);
             return Optional.of(receiptMapper.toReceiptItemDTOList(items));
         }).subscribeOn(Schedulers.boundedElastic());
-    }
-
-    /**
-     * Saves the receipt and its parsed items transactionally.
-     *
-     * @param imageBytes raw image bytes to store
-     * @param ocrText    the raw OCR text extracted from the image
-     * @return the UUID of the saved receipt
-     */
-    @Transactional
-    protected UUID saveReceipt(byte[] imageBytes, String ocrText) {
-        LOGGER.info("Parsing OCR text ({} chars):\n{}", ocrText.length(), ocrText);
-        final ParsedReceipt parsed = parserService.parse(ocrText);
-        LOGGER.info("Parsed {} items, receiptDate={}", parsed.items().size(), parsed.receiptDate());
-
-        final ReceiptEntity receipt = new ReceiptEntity();
-        receipt.setImageContent(imageBytes);
-        receipt.setRawOcrText(ocrText);
-        receipt.setReceiptDate(parsed.receiptDate());
-
-        final ReceiptEntity saved = receiptRepository.save(receipt);
-        LOGGER.info("Saved receipt {} with {} items", saved.getId(), parsed.items().size());
-
-        for (final ParsedItem item : parsed.items()) {
-            final ReceiptItemEntity itemEntity = new ReceiptItemEntity();
-            itemEntity.setReceipt(saved);
-            itemEntity.setName(item.name());
-            itemEntity.setPrice(item.price());
-            receiptItemRepository.save(itemEntity);
-        }
-
-        return saved.getId();
     }
 }

--- a/grocery/src/main/resources/db/migration/grocery/V1_2__grocery_add_quantity_single_price.sql
+++ b/grocery/src/main/resources/db/migration/grocery/V1_2__grocery_add_quantity_single_price.sql
@@ -1,0 +1,3 @@
+ALTER TABLE grocery.receipt_item
+    ADD COLUMN single_price NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    ADD COLUMN quantity     INTEGER        NOT NULL DEFAULT 1;

--- a/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerTest.java
@@ -50,7 +50,7 @@ class ReceiptControllerTest {
     @BeforeEach
     void setUp() {
         testReceiptId = UUID.randomUUID();
-        testItemDTO = new ReceiptItemDTO(1L, "Vollmilch", new BigDecimal("1.09"));
+        testItemDTO = new ReceiptItemDTO(1L, "Vollmilch", new BigDecimal("1.09"), 1, new BigDecimal("1.09"));
         testReceiptDTO = new ReceiptDTO(
                 testReceiptId,
                 LocalDate.of(2024, 3, 15),

--- a/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
@@ -22,45 +22,54 @@ class ReceiptParserServiceTest {
     }
 
     @Test
-    @DisplayName("Should parse a standard German receipt line")
-    void parse_StandardGermanLine_ReturnsItem() {
-        final String text = "Vollmilch 3,5%  1,09 A";
+    @DisplayName("Should parse a standard four-column receipt line")
+    void parse_StandardFourColumnLine_ReturnsItem() {
+        final String text = "Vollmilch 3,5%  1.09  1  1.09";
 
         final ParsedReceipt result = parserService.parse(text);
 
         assertEquals(1, result.items().size());
-        assertEquals("Vollmilch 3,5%", result.items().get(0).name());
-        assertEquals(new BigDecimal("1.09"), result.items().get(0).price());
+        final ParsedItem item = result.items().get(0);
+        assertEquals("Vollmilch 3,5%", item.name());
+        assertEquals(new BigDecimal("1.09"), item.singlePrice());
+        assertEquals(1, item.quantity());
+        assertEquals(new BigDecimal("1.09"), item.price());
     }
 
     @Test
     @DisplayName("Should parse an item with a multi-word name")
     void parse_MultiWordName_ReturnsItem() {
-        final String text = "Bio Hafer Flocken  2,49 B";
+        final String text = "Bio Hafer Flocken  2.49  1  2.49";
 
         final ParsedReceipt result = parserService.parse(text);
 
         assertEquals(1, result.items().size());
-        assertEquals("Bio Hafer Flocken", result.items().get(0).name());
-        assertEquals(new BigDecimal("2.49"), result.items().get(0).price());
+        final ParsedItem item = result.items().get(0);
+        assertEquals("Bio Hafer Flocken", item.name());
+        assertEquals(new BigDecimal("2.49"), item.singlePrice());
+        assertEquals(1, item.quantity());
+        assertEquals(new BigDecimal("2.49"), item.price());
     }
 
     @Test
-    @DisplayName("Should parse a price with a period decimal separator")
-    void parse_PeriodDecimalSeparator_ReturnsItem() {
-        final String text = "Butter  1.79";
+    @DisplayName("Should parse a line with quantity greater than one")
+    void parse_MultipleQuantity_ReturnsItem() {
+        final String text = "Butter  1.79  3  5.37";
 
         final ParsedReceipt result = parserService.parse(text);
 
         assertEquals(1, result.items().size());
-        assertEquals("Butter", result.items().get(0).name());
-        assertEquals(new BigDecimal("1.79"), result.items().get(0).price());
+        final ParsedItem item = result.items().get(0);
+        assertEquals("Butter", item.name());
+        assertEquals(new BigDecimal("1.79"), item.singlePrice());
+        assertEquals(3, item.quantity());
+        assertEquals(new BigDecimal("5.37"), item.price());
     }
 
     @Test
     @DisplayName("Should exclude total lines from items")
     void parse_TotalLine_IsExcluded() {
-        final String text = "Apfel  0,89 A\nGesamt  0,89\nSumme  0,89";
+        final String text = "Apfel  0.89  1  0.89\nGesamt  0,89\nSumme  0,89";
 
         final ParsedReceipt result = parserService.parse(text);
 
@@ -71,7 +80,7 @@ class ReceiptParserServiceTest {
     @Test
     @DisplayName("Should extract date in DD.MM.YYYY format")
     void parse_DateLine_ExtractsDate() {
-        final String text = "Datum: 15.03.2024\nMilch  0,99 A";
+        final String text = "Datum: 15.03.2024\nMilch  0.99  1  0.99";
 
         final ParsedReceipt result = parserService.parse(text);
 
@@ -100,7 +109,7 @@ class ReceiptParserServiceTest {
     @Test
     @DisplayName("Should parse multiple items from a multi-line receipt")
     void parse_MultipleItems_ReturnsAllItems() {
-        final String text = "15.03.2024\nVollmilch  1,09 A\nButter  1,79 B\nBrot  2,49";
+        final String text = "15.03.2024\nVollmilch  1.09  1  1.09\nButter  1.79  1  1.79\nBrot  2.49  1  2.49";
 
         final ParsedReceipt result = parserService.parse(text);
 
@@ -111,11 +120,43 @@ class ReceiptParserServiceTest {
     @Test
     @DisplayName("Should exclude 'zu zahlen' total line")
     void parse_ZuZahlenLine_IsExcluded() {
-        final String text = "Joghurt  0,79\nZu zahlen  0,79";
+        final String text = "Joghurt  0.79  1  0.79\nZu zahlen  0,79";
 
         final ParsedReceipt result = parserService.parse(text);
 
         assertEquals(1, result.items().size());
         assertEquals("Joghurt", result.items().get(0).name());
+    }
+
+    @Test
+    @DisplayName("Should parse Claude Vision OCR sample with negative prices, quantities, and date")
+    void parse_ClaudeVisionSample_ReturnsAllItemsAndDate() {
+        final String text = "Cherrystrauchtomaten  2.99  2  5.98\n"
+                + "Preisvorteil  -2.00  1  -2.00\n"
+                + "Apfel pink  2.09  1  2.09\n"
+                + "29.05.2026";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(3, result.items().size());
+        assertEquals(LocalDate.of(2026, 5, 29), result.receiptDate());
+
+        final ParsedItem tomaten = result.items().get(0);
+        assertEquals("Cherrystrauchtomaten", tomaten.name());
+        assertEquals(new BigDecimal("2.99"), tomaten.singlePrice());
+        assertEquals(2, tomaten.quantity());
+        assertEquals(new BigDecimal("5.98"), tomaten.price());
+
+        final ParsedItem preisvorteil = result.items().get(1);
+        assertEquals("Preisvorteil", preisvorteil.name());
+        assertEquals(new BigDecimal("-2.00"), preisvorteil.singlePrice());
+        assertEquals(1, preisvorteil.quantity());
+        assertEquals(new BigDecimal("-2.00"), preisvorteil.price());
+
+        final ParsedItem apfel = result.items().get(2);
+        assertEquals("Apfel pink", apfel.name());
+        assertEquals(new BigDecimal("2.09"), apfel.singlePrice());
+        assertEquals(1, apfel.quantity());
+        assertEquals(new BigDecimal("2.09"), apfel.price());
     }
 }


### PR DESCRIPTION
## Summary

- **Parser**: Updated `ITEM_PATTERN` to match the four-column OCR format (`name  singlePrice  quantity  totalPrice`) and `tryParseItem` now populates all four fields on `ParsedItem`.
- **Data model**: Added `singlePrice` (NUMERIC 10,2) and `quantity` (INTEGER) to `receipt_item` via Flyway migration `V1_2`, and mapped them in `ReceiptItemEntity` and `ReceiptItemDTO`.
- **Transactional fix**: Moved `saveReceipt` out of `ReceiptService` into a new `ReceiptPersistenceService` so that Spring's `@Transactional` proxy is honoured — the previous `this.saveReceipt(...)` call inside `Mono.fromCallable` bypassed the proxy entirely.

## Test plan

- [ ] `./gradlew :grocery:build` passes with zero checkstyle warnings
- [ ] `ReceiptParserServiceTest` — all existing tests updated to four-column format; new test `parse_ClaudeVisionSample_ReturnsAllItemsAndDate` validates negative prices, multi-quantity lines, and date extraction
- [ ] `ReceiptControllerTest` — constructor call updated to include `singlePrice` and `quantity`
- [ ] Flyway migration applies cleanly against a fresh local PostgreSQL instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)