### PR TITLE
fix(grocery): remove imageContent from ReceiptEntity to prevent OOM

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/entity/ReceiptEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ReceiptEntity.java
@@ -33,9 +33,6 @@ public class ReceiptEntity extends BasicEntity {
     @Column(name = "receipt_date")
     private LocalDate receiptDate;
 
-    @Column(name = "image_content")
-    private byte[] imageContent;
-
     @Column(name = "raw_ocr_text", columnDefinition = "TEXT")
     private String rawOcrText;
 

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
@@ -43,18 +43,16 @@ public class ReceiptPersistenceService {
      * Parses the given OCR text, persists the receipt and all its line items in a single transaction,
      * and returns the UUID of the newly created receipt.
      *
-     * @param imageBytes raw image bytes to store on the receipt record
-     * @param ocrText    the raw OCR text extracted from the image
+     * @param ocrText the raw OCR text extracted from the image
      * @return the UUID of the saved receipt
      */
     @Transactional
-    public UUID saveReceipt(byte[] imageBytes, String ocrText) {
+    public UUID saveReceipt(String ocrText) {
         LOGGER.info("Parsing OCR text ({} chars):\n{}", ocrText.length(), ocrText);
         final ParsedReceipt parsed = parserService.parse(ocrText);
         LOGGER.info("Parsed {} items, receiptDate={}", parsed.items().size(), parsed.receiptDate());
 
         final ReceiptEntity receipt = new ReceiptEntity();
-        receipt.setImageContent(imageBytes);
         receipt.setRawOcrText(ocrText);
         receipt.setReceiptDate(parsed.receiptDate());
 

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -61,7 +61,7 @@ public class ReceiptService {
         LOGGER.info("Starting receipt processing for image of {} bytes", imageBytes.length);
         return ocrProvider.extractText(imageBytes)
                 .doOnError(e -> LOGGER.error("OCR extraction failed", e))
-                .flatMap(ocrText -> Mono.fromCallable(() -> persistenceService.saveReceipt(imageBytes, ocrText))
+                .flatMap(ocrText -> Mono.fromCallable(() -> persistenceService.saveReceipt(ocrText))
                         .subscribeOn(Schedulers.boundedElastic()));
     }
 

--- a/grocery/src/main/resources/db/migration/grocery/V1_3__grocery_drop_image_content.sql
+++ b/grocery/src/main/resources/db/migration/grocery/V1_3__grocery_drop_image_content.sql
@@ -1,0 +1,1 @@
+ALTER TABLE grocery.receipt DROP COLUMN IF EXISTS image_content;


### PR DESCRIPTION
## Summary
- Removes `imageContent` (`byte[]`) from `ReceiptEntity` — the field was stored but never read back via any API endpoint
- Drops the `image_content` column via Flyway migration `V1_3`
- Removes the `imageBytes` parameter from `ReceiptPersistenceService.saveReceipt()`

## Root cause
Hibernate's dirty-checking deep-copies every `byte[]` field via `ArrayMutabilityPlan.deepCopyNotNull` when loading entities in a list query. With multi-megabyte receipt images stored per row, this exhausted heap space (`OutOfMemoryError: Java heap space` on `[oundedElastic-1]`).

## Test plan
- [ ] Upload a receipt image — OCR and item parsing still work
- [ ] `GET /receipts` no longer triggers OOM
- [ ] Flyway migration applies cleanly on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)