### PR TITLE
feat(grocery): add PUT /receipts/{receiptId}/items/{itemId} endpoint

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -2,6 +2,7 @@ package com.marvin.grocery.controller;
 
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
+import com.marvin.grocery.dto.UpdateReceiptItemRequest;
 import com.marvin.grocery.service.ReceiptService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,6 +25,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -127,6 +130,36 @@ public class ReceiptController {
                 .map(optItems -> optItems
                         .map(ResponseEntity::ok)
                         .orElse(ResponseEntity.notFound().build()));
+    }
+
+    /**
+     * Updates the editable fields of a single receipt item.
+     *
+     * @param receiptId the UUID of the parent receipt
+     * @param itemId    the id of the item to update
+     * @param request   the updated field values
+     * @return a Mono with 200 OK and the updated item, or 404 if not found
+     */
+    @PutMapping("/{receiptId}/items/{itemId}")
+    @Operation(
+            summary = "Update a receipt item",
+            description = "Updates name, quantity, and single price of an item; recalculates the total line price.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Item updated",
+                        content = @Content(schema = @Schema(implementation = ReceiptItemDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Receipt or item not found")
+            }
+    )
+    public Mono<ResponseEntity<ReceiptItemDTO>> updateItem(
+            @PathVariable @Parameter(description = "UUID of the receipt") UUID receiptId,
+            @PathVariable @Parameter(description = "Id of the item") Long itemId,
+            @RequestBody UpdateReceiptItemRequest request) {
+        return receiptService.updateItem(receiptId, itemId, request)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }
 
     /**

--- a/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
@@ -1,0 +1,25 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Request body for updating a receipt item's editable fields.
+ *
+ * @param name        updated name of the item
+ * @param quantity    updated quantity
+ * @param singlePrice updated price per unit in euros
+ */
+@Schema(description = "Fields to update on a receipt item")
+public record UpdateReceiptItemRequest(
+
+        @Schema(description = "Name of the purchased item", example = "Vollmilch 3,5%")
+        String name,
+
+        @Schema(description = "Number of units purchased", example = "2")
+        int quantity,
+
+        @Schema(description = "Price per unit in euros", example = "1.29")
+        BigDecimal singlePrice
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
@@ -2,6 +2,7 @@ package com.marvin.grocery.repository;
 
 import com.marvin.grocery.entity.ReceiptItemEntity;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -17,4 +18,13 @@ public interface ReceiptItemRepository extends JpaRepository<ReceiptItemEntity, 
      * @return list of items for the specified receipt
      */
     List<ReceiptItemEntity> findByReceiptId(UUID receiptId);
+
+    /**
+     * Finds a single item by its id that belongs to the given receipt.
+     *
+     * @param id        the item id
+     * @param receiptId the UUID of the parent receipt
+     * @return an Optional containing the item if it exists and belongs to the receipt
+     */
+    Optional<ReceiptItemEntity> findByIdAndReceiptId(Long id, UUID receiptId);
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -2,11 +2,13 @@ package com.marvin.grocery.service;
 
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
+import com.marvin.grocery.dto.UpdateReceiptItemRequest;
 import com.marvin.grocery.entity.ReceiptItemEntity;
 import com.marvin.grocery.mapper.ReceiptMapper;
 import com.marvin.grocery.ocr.OcrProvider;
 import com.marvin.grocery.repository.ReceiptItemRepository;
 import com.marvin.grocery.repository.ReceiptRepository;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -92,6 +94,27 @@ public class ReceiptService {
             }
             final List<ReceiptItemEntity> items = receiptItemRepository.findByReceiptId(receiptId);
             return Optional.of(receiptMapper.toReceiptItemDTOList(items));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates the editable fields of a receipt item and recalculates its total price.
+     * Emits {@link NoSuchElementException} if the item does not exist or does not belong to the receipt.
+     *
+     * @param receiptId the UUID of the parent receipt
+     * @param itemId    the id of the item to update
+     * @param request   the new field values
+     * @return a Mono emitting the updated item DTO
+     */
+    public Mono<ReceiptItemDTO> updateItem(UUID receiptId, Long itemId, UpdateReceiptItemRequest request) {
+        return Mono.fromCallable(() -> {
+            final ReceiptItemEntity item = receiptItemRepository.findByIdAndReceiptId(itemId, receiptId)
+                    .orElseThrow(() -> new NoSuchElementException("Item not found: " + itemId));
+            item.setName(request.name());
+            item.setQuantity(request.quantity());
+            item.setSinglePrice(request.singlePrice());
+            item.setPrice(request.singlePrice().multiply(BigDecimal.valueOf(request.quantity())));
+            return receiptMapper.toReceiptItemDTO(receiptItemRepository.save(item));
         }).subscribeOn(Schedulers.boundedElastic());
     }
 


### PR DESCRIPTION
## Summary
- Adds `PUT /receipts/{receiptId}/items/{itemId}` to update a receipt item's name, quantity, and single price
- Total line price is recalculated server-side as `singlePrice × quantity`
- Returns 404 if the item doesn't exist or doesn't belong to the given receipt

## Changes
- `UpdateReceiptItemRequest` — new request body DTO
- `ReceiptItemRepository` — new derived query `findByIdAndReceiptId` to scope lookup to parent receipt
- `ReceiptService.updateItem()` — transactional update wrapped in `Mono.fromCallable` + `boundedElastic`
- `ReceiptController` — new `@PutMapping` wired to the service, 200/404 response handling

## Test plan
- [ ] `PUT /receipts/{receiptId}/items/{itemId}` with valid IDs returns 200 with updated item
- [ ] Total price in response equals `singlePrice × quantity`
- [ ] Unknown itemId or mismatched receiptId returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)