### PR TITLE
feat(grocery): add POST /receipts/{receiptId}/items endpoint for manual item entry

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -1,5 +1,6 @@
 package com.marvin.grocery.controller;
 
+import com.marvin.grocery.dto.AddReceiptItemRequest;
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
 import com.marvin.grocery.dto.UpdateReceiptItemRequest;
@@ -15,6 +16,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -130,6 +132,34 @@ public class ReceiptController {
                 .map(optItems -> optItems
                         .map(ResponseEntity::ok)
                         .orElse(ResponseEntity.notFound().build()));
+    }
+
+    /**
+     * Manually adds a new item to the given receipt.
+     *
+     * @param receiptId the UUID of the receipt to add the item to
+     * @param request   the new item fields
+     * @return a Mono with 201 Created and the new item, or 404 if the receipt is not found
+     */
+    @PostMapping("/{receiptId}/items")
+    @Operation(
+            summary = "Add an item to a receipt",
+            description = "Manually adds a new line item to the specified receipt.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Item created",
+                        content = @Content(schema = @Schema(implementation = ReceiptItemDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Receipt not found")
+            }
+    )
+    public Mono<ResponseEntity<ReceiptItemDTO>> addItem(
+            @PathVariable @Parameter(description = "UUID of the receipt") UUID receiptId,
+            @RequestBody AddReceiptItemRequest request) {
+        return receiptService.addItem(receiptId, request)
+                .map(item -> ResponseEntity.status(HttpStatus.CREATED).body(item))
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }
 
     /**

--- a/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
@@ -1,0 +1,25 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Request body for manually adding a new item to a receipt.
+ *
+ * @param name        name of the item
+ * @param quantity    number of units
+ * @param singlePrice price per unit in euros
+ */
+@Schema(description = "Fields for a new receipt item")
+public record AddReceiptItemRequest(
+
+        @Schema(description = "Name of the purchased item", example = "Vollmilch 3,5%")
+        String name,
+
+        @Schema(description = "Number of units purchased", example = "2")
+        int quantity,
+
+        @Schema(description = "Price per unit in euros", example = "1.29")
+        BigDecimal singlePrice
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -1,8 +1,10 @@
 package com.marvin.grocery.service;
 
+import com.marvin.grocery.dto.AddReceiptItemRequest;
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
 import com.marvin.grocery.dto.UpdateReceiptItemRequest;
+import com.marvin.grocery.entity.ReceiptEntity;
 import com.marvin.grocery.entity.ReceiptItemEntity;
 import com.marvin.grocery.mapper.ReceiptMapper;
 import com.marvin.grocery.ocr.OcrProvider;
@@ -94,6 +96,28 @@ public class ReceiptService {
             }
             final List<ReceiptItemEntity> items = receiptItemRepository.findByReceiptId(receiptId);
             return Optional.of(receiptMapper.toReceiptItemDTOList(items));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Manually adds a new item to the given receipt and persists it.
+     * Emits {@link NoSuchElementException} if the receipt does not exist.
+     *
+     * @param receiptId the UUID of the parent receipt
+     * @param request   the new item fields
+     * @return a Mono emitting the created item DTO
+     */
+    public Mono<ReceiptItemDTO> addItem(UUID receiptId, AddReceiptItemRequest request) {
+        return Mono.fromCallable(() -> {
+            final ReceiptEntity receipt = receiptRepository.findById(receiptId)
+                    .orElseThrow(() -> new NoSuchElementException("Receipt not found: " + receiptId));
+            final ReceiptItemEntity item = new ReceiptItemEntity();
+            item.setReceipt(receipt);
+            item.setName(request.name());
+            item.setQuantity(request.quantity());
+            item.setSinglePrice(request.singlePrice());
+            item.setPrice(request.singlePrice().multiply(BigDecimal.valueOf(request.quantity())));
+            return receiptMapper.toReceiptItemDTO(receiptItemRepository.save(item));
         }).subscribeOn(Schedulers.boundedElastic());
     }
 


### PR DESCRIPTION
## Summary
- Adds `AddReceiptItemRequest` DTO (name, quantity, singlePrice)
- Adds `addItem(UUID receiptId, AddReceiptItemRequest)` to `ReceiptService` — creates a new `ReceiptItemEntity`, computes `price = singlePrice * quantity`, persists and returns the DTO
- Adds `POST /receipts/{receiptId}/items` endpoint in `ReceiptController` — returns `201 Created` with the new `ReceiptItemDTO`, or `404` if the receipt does not exist

## Test plan
- [ ] `POST /receipts/{id}/items` with valid body returns `201` and a `ReceiptItemDTO`
- [ ] `GET /receipts/{id}/items` now includes the manually added item
- [ ] `POST /receipts/unknown-id/items` returns `404`
- [ ] `./gradlew :grocery:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)