### PR TITLE
feat(grocery): add PATCH /receipts/{id}/supermarket endpoint

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -4,6 +4,7 @@ import com.marvin.grocery.dto.AddReceiptItemRequest;
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
 import com.marvin.grocery.dto.UpdateReceiptItemRequest;
+import com.marvin.grocery.dto.UpdateSupermarketRequest;
 import com.marvin.grocery.service.ReceiptService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -188,6 +190,34 @@ public class ReceiptController {
             @PathVariable @Parameter(description = "Id of the item") Long itemId,
             @RequestBody UpdateReceiptItemRequest request) {
         return receiptService.updateItem(receiptId, itemId, request)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates the supermarket field of the given receipt.
+     *
+     * @param id      the UUID of the receipt to update
+     * @param request the supermarket selection
+     * @return a Mono with 200 OK and the updated receipt DTO, or 404 if not found
+     */
+    @PatchMapping("/{id}/supermarket")
+    @Operation(
+            summary = "Set the supermarket for a receipt",
+            description = "Updates the supermarket field on an existing receipt.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Supermarket updated",
+                        content = @Content(schema = @Schema(implementation = ReceiptDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Receipt not found")
+            }
+    )
+    public Mono<ResponseEntity<ReceiptDTO>> updateSupermarket(
+            @PathVariable @Parameter(description = "UUID of the receipt") UUID id,
+            @RequestBody UpdateSupermarketRequest request) {
+        return receiptService.updateSupermarket(id, request.supermarket())
                 .map(ResponseEntity::ok)
                 .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }

--- a/grocery/src/main/java/com/marvin/grocery/dto/ReceiptDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ReceiptDTO.java
@@ -1,5 +1,6 @@
 package com.marvin.grocery.dto;
 
+import com.marvin.grocery.entity.Supermarket;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,6 +16,7 @@ import java.util.UUID;
  * @param totalAmount  total amount computed as sum of all items
  * @param creationDate timestamp when the receipt was created in the system
  * @param items        parsed line items; null when listing receipts without items
+ * @param supermarket  supermarket where the receipt was issued; null if not yet set
  */
 @Schema(description = "A scanned and parsed grocery receipt")
 public record ReceiptDTO(
@@ -31,6 +33,9 @@ public record ReceiptDTO(
         LocalDateTime creationDate,
 
         @Schema(description = "Parsed line items; null when listing receipts without items")
-        List<ReceiptItemDTO> items
+        List<ReceiptItemDTO> items,
+
+        @Schema(description = "Supermarket where the receipt was issued; null if not yet set")
+        Supermarket supermarket
 ) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/dto/UpdateSupermarketRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/UpdateSupermarketRequest.java
@@ -1,0 +1,17 @@
+package com.marvin.grocery.dto;
+
+import com.marvin.grocery.entity.Supermarket;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating the supermarket on a receipt.
+ *
+ * @param supermarket the supermarket where the receipt was issued
+ */
+@Schema(description = "Supermarket update payload")
+public record UpdateSupermarketRequest(
+
+        @Schema(description = "Supermarket enum value", example = "LIDL")
+        Supermarket supermarket
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/entity/ReceiptEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ReceiptEntity.java
@@ -4,6 +4,8 @@ import com.marvin.costs.entity.BasicEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,6 +37,10 @@ public class ReceiptEntity extends BasicEntity {
 
     @Column(name = "raw_ocr_text", columnDefinition = "TEXT")
     private String rawOcrText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "supermarket")
+    private Supermarket supermarket;
 
     @OneToMany(mappedBy = "receipt", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ReceiptItemEntity> items = new ArrayList<>();

--- a/grocery/src/main/java/com/marvin/grocery/entity/Supermarket.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/Supermarket.java
@@ -1,0 +1,8 @@
+package com.marvin.grocery.entity;
+
+/** Supermarket where the receipt was issued. */
+public enum Supermarket {
+    LIDL,
+    EDEKA,
+    REWE
+}

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -6,6 +6,7 @@ import com.marvin.grocery.dto.ReceiptItemDTO;
 import com.marvin.grocery.dto.UpdateReceiptItemRequest;
 import com.marvin.grocery.entity.ReceiptEntity;
 import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.entity.Supermarket;
 import com.marvin.grocery.mapper.ReceiptMapper;
 import com.marvin.grocery.ocr.OcrProvider;
 import com.marvin.grocery.repository.ReceiptItemRepository;
@@ -139,6 +140,24 @@ public class ReceiptService {
             item.setSinglePrice(request.singlePrice());
             item.setPrice(request.singlePrice().multiply(BigDecimal.valueOf(request.quantity())));
             return receiptMapper.toReceiptItemDTO(receiptItemRepository.save(item));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates the supermarket field on the given receipt.
+     * Emits {@link NoSuchElementException} if the receipt does not exist.
+     *
+     * @param receiptId   the UUID of the receipt to update
+     * @param supermarket the supermarket to set
+     * @return a Mono emitting the updated receipt DTO
+     */
+    public Mono<ReceiptDTO> updateSupermarket(UUID receiptId, Supermarket supermarket) {
+        return Mono.fromCallable(() -> {
+            final ReceiptEntity receipt = receiptRepository.findById(receiptId)
+                    .orElseThrow(() -> new NoSuchElementException("Receipt not found: " + receiptId));
+            receipt.setSupermarket(supermarket);
+            final ReceiptEntity saved = receiptRepository.save(receipt);
+            return receiptMapper.toReceiptDTO(saved);
         }).subscribeOn(Schedulers.boundedElastic());
     }
 

--- a/grocery/src/main/resources/db/migration/grocery/V1_4__grocery_add_supermarket.sql
+++ b/grocery/src/main/resources/db/migration/grocery/V1_4__grocery_add_supermarket.sql
@@ -1,0 +1,1 @@
+ALTER TABLE grocery.receipt ADD COLUMN supermarket VARCHAR(20);

--- a/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
+import com.marvin.grocery.dto.UpdateSupermarketRequest;
+import com.marvin.grocery.entity.Supermarket;
 import com.marvin.grocery.service.ReceiptService;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -57,6 +60,7 @@ class ReceiptControllerTest {
                 LocalDate.of(2024, 3, 15),
                 new BigDecimal("1.09"),
                 LocalDateTime.now(),
+                null,
                 null
         );
     }
@@ -87,7 +91,7 @@ class ReceiptControllerTest {
     @DisplayName("Should return all receipts as Flux")
     void listReceipts_ReturnsFluxOfReceipts() {
         final ReceiptDTO second = new ReceiptDTO(
-                UUID.randomUUID(), LocalDate.of(2024, 4, 1), new BigDecimal("5.00"), LocalDateTime.now(), null);
+                UUID.randomUUID(), LocalDate.of(2024, 4, 1), new BigDecimal("5.00"), LocalDateTime.now(), null, null);
         when(receiptService.findAll()).thenReturn(Flux.just(testReceiptDTO, second));
 
         final Flux<ReceiptDTO> result = receiptController.listReceipts();
@@ -176,5 +180,45 @@ class ReceiptControllerTest {
                 .verifyComplete();
 
         verify(receiptService).deleteReceipt(unknownId);
+    }
+
+    @Test
+    @DisplayName("Should return 200 with updated DTO after supermarket update")
+    void updateSupermarket_Exists_Returns200() {
+        final ReceiptDTO updated = new ReceiptDTO(
+                testReceiptId, LocalDate.of(2024, 3, 15),
+                new BigDecimal("1.09"), LocalDateTime.now(), null, Supermarket.LIDL);
+        when(receiptService.updateSupermarket(eq(testReceiptId), eq(Supermarket.LIDL)))
+                .thenReturn(Mono.just(updated));
+
+        final Mono<ResponseEntity<ReceiptDTO>> result =
+                receiptController.updateSupermarket(testReceiptId, new UpdateSupermarketRequest(Supermarket.LIDL));
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(Supermarket.LIDL, response.getBody().supermarket());
+                })
+                .verifyComplete();
+
+        verify(receiptService).updateSupermarket(testReceiptId, Supermarket.LIDL);
+    }
+
+    @Test
+    @DisplayName("Should return 404 when receipt does not exist for supermarket update")
+    void updateSupermarket_NotFound_Returns404() {
+        final UUID unknownId = UUID.randomUUID();
+        when(receiptService.updateSupermarket(eq(unknownId), any()))
+                .thenReturn(Mono.error(new NoSuchElementException("Receipt not found: " + unknownId)));
+
+        final Mono<ResponseEntity<ReceiptDTO>> result =
+                receiptController.updateSupermarket(unknownId, new UpdateSupermarketRequest(Supermarket.REWE));
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(receiptService).updateSupermarket(unknownId, Supermarket.REWE);
     }
 }


### PR DESCRIPTION
Adds the ability to set the supermarket on an existing grocery receipt.

## Changes
- New `Supermarket` enum (`LIDL`, `EDEKA`, `REWE`)
- `supermarket` column on `ReceiptEntity` (stored as `EnumType.STRING`) + Flyway migration `V1_4__grocery_add_supermarket.sql`
- `PATCH /receipts/{id}/supermarket` endpoint with `UpdateSupermarketRequest` body; returns the updated `ReceiptDTO` or 404
- `supermarket` field surfaced on `ReceiptDTO`
- Controller test coverage for the new endpoint

## Verification
`:grocery:test`, `:grocery:checkstyleMain`, `:grocery:checkstyleTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)