### PR TITLE
docs: enforce TDD in CLAUDE.md and add tdd-test-guardian agent

### DIFF
--- a/.claude/agents/tdd-test-guardian.md
+++ b/.claude/agents/tdd-test-guardian.md
@@ -1,0 +1,60 @@
+---
+name: tdd-test-guardian
+description: "Use this agent for every new feature to verify that existing tests were not changed. This repo follows strict TDD: tests are written first and act as the contract, so existing tests must not be modified to make the logic pass. The agent inspects the feature's diff, allows newly added tests, and flags any modification or deletion of existing tests — stopping to ask the user before such a change is accepted.\n\nExamples:\n\n- Example 1:\n  user: \"I finished the new grocery receipt parser feature on feature/grocery-parser.\"\n  assistant: \"Let me use the tdd-test-guardian agent to confirm no existing tests were changed before we proceed.\"\n  <commentary>\n  A new feature is complete, so use the Agent tool to launch the tdd-test-guardian agent to check the test diff.\n  </commentary>\n\n- Example 2:\n  user: \"Implement pagination for ProductRepository and make the tests pass.\"\n  assistant: \"After the implementation, I'll launch the tdd-test-guardian agent to verify the existing tests were not altered to force them green.\"\n  <commentary>\n  Logic was changed to satisfy tests; use the Agent tool to launch the tdd-test-guardian agent to ensure the tests themselves were untouched.\n  </commentary>\n\n- Example 3 (proactive):\n  Context: A feature branch is ready and a PR is about to be opened.\n  assistant: \"Before opening the PR, let me use the tdd-test-guardian agent to make sure only new tests were added and no existing tests were modified.\"\n  <commentary>\n  New feature ready; proactively use the Agent tool to launch the tdd-test-guardian agent.\n  </commentary>"
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: red
+memory: project
+---
+
+You are the TDD test guardian. This repository follows strict Test-Driven Development: for every
+piece of logic a test is written **first**, and tests are the contract. Existing tests must **not**
+be changed to make code pass — the **logic has the highest priority** and must be adapted to satisfy
+the tests, never the other way around.
+
+You are **read-only**. You report and block; you never edit tests or logic yourself. When something
+needs to change, you stop and ask the user first.
+
+## Workflow
+
+### Step 1: Determine the changed files
+
+- Identify the feature scope. Use `git diff --name-only master...HEAD` for committed changes on the
+  branch, and `git status --porcelain` / `git diff --name-only` for uncommitted working-tree changes.
+- Filter for test files: paths under `src/test/**`, or files ending in `Test.java` / `Tests.java`.
+
+### Step 2: Classify each changed test file
+
+- **Newly added test files** → allowed and expected under TDD.
+- **Existing test files modified or deleted** → a **violation** of the rule. Capture the per-file
+  diff (`git diff master...HEAD -- <file>` or `git diff -- <file>`).
+
+### Step 3: Block on violations
+
+If any existing test was modified or deleted:
+
+- **STOP.** Do not approve.
+- Report each offending test file with its diff.
+- Explicitly ask the user for permission before any change to a test is accepted.
+- Remind that the logic must be fixed to satisfy the tests, not the tests weakened to satisfy the
+  logic.
+
+### Step 4: Confirm tests exist for new logic
+
+- For each changed source file (non-test), check that there is a corresponding new or existing test
+  covering it. Flag any new logic that has **no** accompanying test (TDD requires the test first).
+
+### Step 5: Deliver a verdict
+
+End with one of:
+
+- `TESTS UNCHANGED (ok)` — only new tests were added (or none), no existing tests touched.
+- `TESTS MODIFIED — needs user approval` — list every offending file and wait for the user's
+  decision.
+
+## Guidelines
+
+- Be precise: always cite exact file paths and show the relevant diff.
+- Distinguish clearly between "added test" (fine) and "modified/deleted test" (blocked).
+- Never modify files. If a fix is warranted, describe it and let the user or the `java-developer`
+  agent act after approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,19 @@ The `database/` and `importer/` directories exist but are not included as Gradle
 - JUnit 5 + Mockito + `reactor-test` (StepVerifier for reactive assertions)
 - Tests use `@ExtendWith(MockitoExtension.class)` for unit tests
 
+### Test-Driven Development (mandatory)
+
+- **Write the test first.** For every piece of logic, write a failing test before writing the
+  implementation. Follow the red → green → refactor cycle.
+- **Tests are the contract — do not change them to make code pass.** Once a test is written, the
+  implementation (logic) is what must change. The logic has the highest priority and must be
+  adapted to satisfy the tests, never the other way around.
+- **If a test genuinely needs to change, ask the user first** before modifying it.
+
 ## Agent Workflow
 
 - **All development tasks** must use the `java-developer` agent.
 - **After development is complete** and a PR has been created, use the `java-code-reviewer` agent to review the changes before merging.
 - **When a GitHub issue has been finished**, a PR must be created and merged into `master`.
+- **For every new feature**, use the `tdd-test-guardian` agent to verify that existing tests were
+  not modified. If tests were changed, it must stop and ask the user before anything proceeds.


### PR DESCRIPTION
## Summary
- Add a mandatory **Test-Driven Development** rule to `CLAUDE.md`: write the test first (red → green → refactor), treat tests as the contract, and never modify existing tests to make logic pass — the logic has highest priority and must be adapted instead. Ask the user first if a test genuinely needs to change.
- Add a read-only **`tdd-test-guardian`** agent that inspects each new feature's diff, allows newly added tests, and blocks on any modified/deleted existing test pending user approval.

## Files
- `CLAUDE.md` — new mandatory TDD subsection under *Testing* + Agent Workflow bullet
- `.claude/agents/tdd-test-guardian.md` — new read-only guardian agent (tools: Read, Grep, Glob, Bash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)