### PR TITLE
feat(nutrition): profile, weight log & target calculation (#104)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -4,6 +4,7 @@ import com.marvin.nutrition.service.TargetCalculationException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -34,6 +35,18 @@ public class NutritionExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<String> handleEntityNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link DataIntegrityViolationException} to HTTP 409 Conflict.
+     *
+     * @param ex the exception
+     * @return 409 response indicating a duplicate weight entry for the same date
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<String> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body("A weight entry for this date already exists");
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.service.TargetCalculationException;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Global exception handler for the nutrition module REST controllers. */
+@RestControllerAdvice(basePackages = "com.marvin.nutrition")
+public class NutritionExceptionHandler {
+
+    /**
+     * Maps {@link NoSuchElementException} to HTTP 404.
+     *
+     * @param ex the exception
+     * @return 404 response with the exception message
+     */
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNotFound(NoSuchElementException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link EntityNotFoundException} to HTTP 404.
+     *
+     * @param ex the exception
+     * @return 404 response with the exception message
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link TargetCalculationException} to HTTP 400.
+     *
+     * @param ex the exception
+     * @return 400 response with an explanatory message
+     */
+    @ExceptionHandler(TargetCalculationException.class)
+    public ResponseEntity<String> handleTargetCalculation(TargetCalculationException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+    /**
+     * Maps bean-validation failures ({@link MethodArgumentNotValidException}) to HTTP 400.
+     *
+     * @param ex the exception carrying field error details
+     * @return 400 response with comma-separated field error messages
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
+        final String errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest().body(errors);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionProfileController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionProfileController.java
@@ -1,0 +1,87 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.ProfileDTO;
+import com.marvin.nutrition.service.NutritionProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.NoSuchElementException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for managing the user's nutrition profile.
+ * There is at most one profile row; PUT upserts it.
+ */
+@RestController
+@RequestMapping("/nutrition/profile")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class NutritionProfileController {
+
+    private final NutritionProfileService profileService;
+
+    /**
+     * Creates a new NutritionProfileController.
+     *
+     * @param profileService the service handling profile reads and upserts
+     */
+    public NutritionProfileController(NutritionProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    /**
+     * Returns the current nutrition profile, or 404 if none has been created.
+     *
+     * @return a Mono with 200 and the profile DTO, or 404 if not found
+     */
+    @GetMapping
+    @Operation(
+            summary = "Get nutrition profile",
+            description = "Returns the current nutrition profile.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Profile returned",
+                        content = @Content(schema = @Schema(implementation = ProfileDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "No profile set yet")
+            }
+    )
+    public Mono<ResponseEntity<ProfileDTO>> getProfile() {
+        return profileService.getProfile()
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates or replaces the nutrition profile.
+     *
+     * @param dto the profile data to persist
+     * @return a Mono with 200 and the saved profile DTO
+     */
+    @PutMapping
+    @Operation(
+            summary = "Upsert nutrition profile",
+            description = "Creates or replaces the single nutrition profile row.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Profile saved",
+                        content = @Content(schema = @Schema(implementation = ProfileDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed")
+            }
+    )
+    public Mono<ResponseEntity<ProfileDTO>> upsertProfile(@Valid @RequestBody ProfileDTO dto) {
+        return profileService.upsertProfile(dto)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionTargetController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionTargetController.java
@@ -1,0 +1,59 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.service.NutritionTargetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for computing and returning daily nutrition targets.
+ * Returns 400 with an explanatory message when profile or weight data is missing.
+ */
+@RestController
+@RequestMapping("/nutrition/targets")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class NutritionTargetController {
+
+    private final NutritionTargetService nutritionTargetService;
+
+    /**
+     * Creates a new NutritionTargetController.
+     *
+     * @param nutritionTargetService the service that computes targets
+     */
+    public NutritionTargetController(NutritionTargetService nutritionTargetService) {
+        this.nutritionTargetService = nutritionTargetService;
+    }
+
+    /**
+     * Returns the computed daily nutrition targets based on the current profile and latest weight.
+     * Returns 400 with an explanatory message if the profile or a weight entry is missing.
+     *
+     * @return a Mono with 200 and the targets DTO
+     */
+    @GetMapping
+    @Operation(
+            summary = "Get daily nutrition targets",
+            description = "Computes and returns daily kcal and macro targets from the current profile and latest weight.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Targets computed",
+                        content = @Content(schema = @Schema(implementation = TargetsDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Profile or weight data is missing")
+            }
+    )
+    public Mono<ResponseEntity<TargetsDTO>> getTargets() {
+        return nutritionTargetService.getTargets()
+                .map(ResponseEntity::ok);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/WeightController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/WeightController.java
@@ -1,0 +1,150 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.CreateWeightEntryRequest;
+import com.marvin.nutrition.dto.WeightEntryDTO;
+import com.marvin.nutrition.service.WeightService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.NoSuchElementException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for body-weight log management.
+ * Supports listing, creating, updating and deleting weight entries.
+ */
+@RestController
+@RequestMapping("/nutrition/weight")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class WeightController {
+
+    private static final String WEIGHT_LOCATION_PREFIX = "/nutrition/weight/";
+
+    private final WeightService weightService;
+
+    /**
+     * Creates a new WeightController.
+     *
+     * @param weightService the service handling weight entry operations
+     */
+    public WeightController(WeightService weightService) {
+        this.weightService = weightService;
+    }
+
+    /**
+     * Returns all weight entries ordered by date descending.
+     *
+     * @return a Flux emitting all weight entry DTOs
+     */
+    @GetMapping
+    @Operation(
+            summary = "List weight entries",
+            description = "Returns all body-weight measurements ordered by date descending.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Weight entries returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = WeightEntryDTO.class)))
+                )
+            }
+    )
+    public Flux<WeightEntryDTO> listWeightEntries() {
+        return weightService.findAll();
+    }
+
+    /**
+     * Creates a new weight entry and returns 201 Created with the new resource URI.
+     *
+     * @param request the entry date and weight in kg
+     * @return a Mono with 201 Created and the created DTO
+     */
+    @PostMapping
+    @Operation(
+            summary = "Log a weight measurement",
+            description = "Records a new body-weight measurement for the given date.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Weight entry created",
+                        content = @Content(schema = @Schema(implementation = WeightEntryDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed")
+            }
+    )
+    public Mono<ResponseEntity<WeightEntryDTO>> createWeightEntry(@Valid @RequestBody CreateWeightEntryRequest request) {
+        return weightService.create(request)
+                .map(dto -> {
+                    final URI location = URI.create(WEIGHT_LOCATION_PREFIX + dto.id());
+                    return ResponseEntity.created(location).body(dto);
+                });
+    }
+
+    /**
+     * Updates an existing weight entry, or returns 404 if it does not exist.
+     *
+     * @param id      the id of the entry to update
+     * @param request the new entry date and weight
+     * @return a Mono with 200 and the updated DTO, or 404 if not found
+     */
+    @PutMapping("/{id}")
+    @Operation(
+            summary = "Update a weight entry",
+            description = "Replaces the date and weight of an existing entry.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Entry updated",
+                        content = @Content(schema = @Schema(implementation = WeightEntryDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Entry not found"),
+                @ApiResponse(responseCode = "400", description = "Validation failed")
+            }
+    )
+    public Mono<ResponseEntity<WeightEntryDTO>> updateWeightEntry(
+            @PathVariable @Parameter(description = "Id of the weight entry") Long id,
+            @Valid @RequestBody CreateWeightEntryRequest request) {
+        return weightService.update(id, request)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes a weight entry, or returns 404 if it does not exist.
+     *
+     * @param id the id of the entry to delete
+     * @return a Mono with 204 No Content on success, or 404 if not found
+     */
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a weight entry",
+            description = "Permanently removes the weight measurement with the given id.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Entry deleted"),
+                @ApiResponse(responseCode = "404", description = "Entry not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteWeightEntry(
+            @PathVariable @Parameter(description = "Id of the weight entry to delete") Long id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return weightService.delete(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition REST controllers. */
-package com.marvin.nutrition.controller;

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateWeightEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateWeightEntryRequest.java
@@ -1,0 +1,26 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Request body for creating or replacing a body-weight entry.
+ *
+ * @param entryDate date the weight was measured
+ * @param weightKg  body weight in kilograms, must be positive
+ */
+@Schema(description = "Request to record a body-weight measurement")
+public record CreateWeightEntryRequest(
+        @NotNull
+        @Schema(description = "Date the weight was measured", example = "2024-06-01")
+        LocalDate entryDate,
+
+        @NotNull
+        @Positive
+        @Schema(description = "Body weight in kilograms", example = "80.5")
+        BigDecimal weightKg
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
@@ -1,0 +1,63 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.ActivityLevel;
+import com.marvin.nutrition.entity.Goal;
+import com.marvin.nutrition.entity.Sex;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Data Transfer Object for the user's nutrition profile.
+ *
+ * @param id             surrogate identifier
+ * @param sex            biological sex (MALE or FEMALE)
+ * @param birthDate      date of birth used to compute age
+ * @param heightCm       height in centimetres
+ * @param activityLevel  physical activity level
+ * @param goal           dietary goal (CUT, MAINTAIN, or BULK)
+ * @param proteinPerKg   grams of protein per kilogram of body weight
+ * @param fatPct         fraction of target calories to allocate to fat (0–1)
+ * @param basalKcal      optional manual override for BMR in kcal; null uses Mifflin–St Jeor
+ */
+@Schema(description = "User nutrition profile")
+public record ProfileDTO(
+        @Schema(description = "Profile identifier")
+        Long id,
+
+        @NotNull
+        @Schema(description = "Biological sex", example = "MALE")
+        Sex sex,
+
+        @NotNull
+        @Schema(description = "Date of birth", example = "1990-05-15")
+        LocalDate birthDate,
+
+        @NotNull
+        @Positive
+        @Schema(description = "Height in centimetres", example = "175")
+        BigDecimal heightCm,
+
+        @NotNull
+        @Schema(description = "Physical activity level", example = "MODERATE")
+        ActivityLevel activityLevel,
+
+        @NotNull
+        @Schema(description = "Dietary goal", example = "MAINTAIN")
+        Goal goal,
+
+        @Positive
+        @Schema(description = "Grams of protein per kg body weight", example = "2.0")
+        BigDecimal proteinPerKg,
+
+        @Positive
+        @Schema(description = "Fraction of target calories allocated to fat (0–1)", example = "0.30")
+        BigDecimal fatPct,
+
+        @Positive
+        @Schema(description = "Manual BMR override in kcal; null uses Mifflin–St Jeor formula", example = "1800")
+        Integer basalKcal
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/TargetsDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/TargetsDTO.java
@@ -1,0 +1,39 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object for computed daily nutrition targets.
+ *
+ * @param bmr             basal metabolic rate in kcal
+ * @param maintenanceKcal maintenance calories (BMR × activity factor)
+ * @param targetKcal      daily target calories after goal adjustment
+ * @param proteinG        daily protein target in grams
+ * @param fatG            daily fat target in grams
+ * @param carbsG          daily carbohydrate target in grams
+ * @param basis           how BMR was derived: BASAL_KCAL or MIFFLIN_ST_JEOR
+ */
+@Schema(description = "Computed daily nutrition targets")
+public record TargetsDTO(
+        @Schema(description = "Basal metabolic rate in kcal", example = "1750")
+        int bmr,
+
+        @Schema(description = "Maintenance calories (BMR × activity factor)", example = "2713")
+        int maintenanceKcal,
+
+        @Schema(description = "Daily target calories after goal adjustment", example = "2213")
+        int targetKcal,
+
+        @Schema(description = "Daily protein target in grams", example = "160")
+        int proteinG,
+
+        @Schema(description = "Daily fat target in grams", example = "74")
+        int fatG,
+
+        @Schema(description = "Daily carbohydrate target in grams", example = "248")
+        int carbsG,
+
+        @Schema(description = "How BMR was derived", example = "MIFFLIN_ST_JEOR")
+        String basis
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/WeightEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/WeightEntryDTO.java
@@ -1,0 +1,25 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Data Transfer Object for a body-weight measurement.
+ *
+ * @param id          surrogate identifier
+ * @param entryDate   date the weight was recorded
+ * @param weightKg    body weight in kilograms
+ */
+@Schema(description = "A single body-weight measurement")
+public record WeightEntryDTO(
+        @Schema(description = "Weight entry identifier")
+        Long id,
+
+        @Schema(description = "Date the weight was recorded", example = "2024-06-01")
+        LocalDate entryDate,
+
+        @Schema(description = "Body weight in kilograms", example = "80.5")
+        BigDecimal weightKg
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition data transfer objects. */
-package com.marvin.nutrition.dto;

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/ActivityLevel.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/ActivityLevel.java
@@ -1,0 +1,15 @@
+package com.marvin.nutrition.entity;
+
+/** Physical activity level used to derive maintenance calories from BMR. */
+public enum ActivityLevel {
+    /** Little or no exercise. */
+    SEDENTARY,
+    /** Light exercise 1–3 days per week. */
+    LIGHT,
+    /** Moderate exercise 3–5 days per week. */
+    MODERATE,
+    /** Hard exercise 6–7 days per week. */
+    ACTIVE,
+    /** Very hard exercise or a physically demanding job. */
+    VERY_ACTIVE
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/Goal.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/Goal.java
@@ -1,0 +1,11 @@
+package com.marvin.nutrition.entity;
+
+/** Dietary goal that adjusts target calories relative to maintenance. */
+public enum Goal {
+    /** Caloric deficit for fat loss. */
+    CUT,
+    /** Calories at maintenance level. */
+    MAINTAIN,
+    /** Caloric surplus for muscle gain. */
+    BULK
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/ProfileEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/ProfileEntity.java
@@ -1,0 +1,70 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing the user's nutrition profile. There is at most one row. */
+@Getter
+@Setter
+@Entity
+@Table(name = "profile", schema = "nutrition")
+public class ProfileEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sex", nullable = false, length = 10)
+    private Sex sex;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "height_cm", nullable = false, precision = 5, scale = 1)
+    private BigDecimal heightCm;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_level", nullable = false, length = 20)
+    private ActivityLevel activityLevel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "goal", nullable = false, length = 10)
+    private Goal goal;
+
+    @Column(name = "protein_per_kg", nullable = false, precision = 4, scale = 2)
+    private BigDecimal proteinPerKg;
+
+    @Column(name = "fat_pct", nullable = false, precision = 4, scale = 2)
+    private BigDecimal fatPct;
+
+    @Column(name = "basal_kcal")
+    private Integer basalKcal;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ProfileEntity that = (ProfileEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/Sex.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/Sex.java
@@ -1,0 +1,7 @@
+package com.marvin.nutrition.entity;
+
+/** Biological sex used for BMR calculation via the Mifflin–St Jeor formula. */
+public enum Sex {
+    MALE,
+    FEMALE
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/WeightEntryEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/WeightEntryEntity.java
@@ -1,0 +1,47 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single body-weight measurement for a given date. */
+@Getter
+@Setter
+@Entity
+@Table(name = "weight_entry", schema = "nutrition")
+public class WeightEntryEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "entry_date", nullable = false, unique = true)
+    private LocalDate entryDate;
+
+    @Column(name = "weight_kg", nullable = false, precision = 5, scale = 2)
+    private BigDecimal weightKg;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final WeightEntryEntity that = (WeightEntryEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition JPA entities. */
-package com.marvin.nutrition.entity;

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/ProfileMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/ProfileMapper.java
@@ -1,0 +1,26 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.ProfileDTO;
+import com.marvin.nutrition.entity.ProfileEntity;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between {@link ProfileEntity} and {@link ProfileDTO}. */
+@Mapper(componentModel = "spring")
+public interface ProfileMapper {
+
+    /**
+     * Maps a profile entity to its DTO representation.
+     *
+     * @param entity the profile entity to map
+     * @return the corresponding DTO
+     */
+    ProfileDTO toDTO(ProfileEntity entity);
+
+    /**
+     * Maps a profile DTO to an entity.
+     *
+     * @param dto the DTO to map
+     * @return the corresponding entity (id will be null for new entities)
+     */
+    ProfileEntity toEntity(ProfileDTO dto);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/WeightEntryMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/WeightEntryMapper.java
@@ -1,0 +1,18 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.WeightEntryDTO;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between {@link WeightEntryEntity} and {@link WeightEntryDTO}. */
+@Mapper(componentModel = "spring")
+public interface WeightEntryMapper {
+
+    /**
+     * Maps a weight entry entity to its DTO representation.
+     *
+     * @param entity the weight entry entity to map
+     * @return the corresponding DTO
+     */
+    WeightEntryDTO toDTO(WeightEntryEntity entity);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition MapStruct mappers. */
-package com.marvin.nutrition.mapper;

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/ProfileRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/ProfileRepository.java
@@ -1,0 +1,8 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.ProfileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Spring Data JPA repository for the single-row nutrition profile. */
+public interface ProfileRepository extends JpaRepository<ProfileEntity, Long> {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
@@ -1,0 +1,24 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Spring Data JPA repository for body-weight measurements. */
+public interface WeightEntryRepository extends JpaRepository<WeightEntryEntity, Long> {
+
+    /**
+     * Returns the most recent weight entry ordered by entry date descending.
+     *
+     * @return an Optional containing the latest entry, or empty if no entries exist
+     */
+    Optional<WeightEntryEntity> findTopByOrderByEntryDateDesc();
+
+    /**
+     * Returns all weight entries ordered by entry date descending.
+     *
+     * @return list of all weight entries, newest first
+     */
+    List<WeightEntryEntity> findAllByOrderByEntryDateDesc();
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition Spring Data repositories. */
-package com.marvin.nutrition.repository;

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
@@ -1,0 +1,72 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.ProfileDTO;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.mapper.ProfileMapper;
+import com.marvin.nutrition.repository.ProfileRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates reads and upserts of the single-row nutrition profile. */
+@Service
+public class NutritionProfileService {
+
+    private final ProfileRepository profileRepository;
+    private final ProfileMapper profileMapper;
+
+    /**
+     * Creates a new NutritionProfileService.
+     *
+     * @param profileRepository JPA repository for the profile row
+     * @param profileMapper     MapStruct mapper for entity/DTO conversion
+     */
+    public NutritionProfileService(ProfileRepository profileRepository, ProfileMapper profileMapper) {
+        this.profileRepository = profileRepository;
+        this.profileMapper = profileMapper;
+    }
+
+    /**
+     * Returns the current profile, or a {@link NoSuchElementException} if none has been created yet.
+     *
+     * @return a Mono emitting the profile DTO
+     */
+    public Mono<ProfileDTO> getProfile() {
+        return Mono.fromCallable(() -> {
+            final List<ProfileEntity> all = profileRepository.findAll();
+            if (all.isEmpty()) {
+                throw new NoSuchElementException("No nutrition profile has been created yet.");
+            }
+            return profileMapper.toDTO(all.get(0));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Creates or replaces the single nutrition profile row.
+     *
+     * @param dto the profile data to persist
+     * @return a Mono emitting the saved profile DTO
+     */
+    public Mono<ProfileDTO> upsertProfile(ProfileDTO dto) {
+        return Mono.fromCallable(() -> {
+            final List<ProfileEntity> all = profileRepository.findAll();
+            final ProfileEntity entity;
+            if (all.isEmpty()) {
+                entity = new ProfileEntity();
+            } else {
+                entity = all.get(0);
+            }
+            entity.setSex(dto.sex());
+            entity.setBirthDate(dto.birthDate());
+            entity.setHeightCm(dto.heightCm());
+            entity.setActivityLevel(dto.activityLevel());
+            entity.setGoal(dto.goal());
+            entity.setProteinPerKg(dto.proteinPerKg() != null ? dto.proteinPerKg() : java.math.BigDecimal.valueOf(2.0));
+            entity.setFatPct(dto.fatPct() != null ? dto.fatPct() : java.math.BigDecimal.valueOf(0.30));
+            entity.setBasalKcal(dto.basalKcal());
+            return profileMapper.toDTO(profileRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
@@ -1,0 +1,51 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import com.marvin.nutrition.repository.ProfileRepository;
+import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrating service that loads profile and latest weight, then delegates to {@link TargetService}. */
+@Service
+public class NutritionTargetService {
+
+    private final ProfileRepository profileRepository;
+    private final WeightEntryRepository weightEntryRepository;
+    private final TargetService targetService;
+
+    /**
+     * Creates a new NutritionTargetService.
+     *
+     * @param profileRepository     JPA repository for the profile row
+     * @param weightEntryRepository JPA repository for weight entries
+     * @param targetService         pure calculation service
+     */
+    public NutritionTargetService(
+            ProfileRepository profileRepository,
+            WeightEntryRepository weightEntryRepository,
+            TargetService targetService) {
+        this.profileRepository = profileRepository;
+        this.weightEntryRepository = weightEntryRepository;
+        this.targetService = targetService;
+    }
+
+    /**
+     * Loads the current profile and latest weight entry, computes and returns daily nutrition targets.
+     * Emits {@link TargetCalculationException} if profile or weight data is missing.
+     *
+     * @return a Mono emitting the computed targets DTO
+     */
+    public Mono<TargetsDTO> getTargets() {
+        return Mono.fromCallable(() -> {
+            final List<ProfileEntity> profiles = profileRepository.findAll();
+            final ProfileEntity profile = profiles.isEmpty() ? null : profiles.get(0);
+            final WeightEntryEntity latestWeight = weightEntryRepository.findTopByOrderByEntryDateDesc().orElse(null);
+            return targetService.computeTargets(profile, latestWeight);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetBasis.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetBasis.java
@@ -1,0 +1,9 @@
+package com.marvin.nutrition.service;
+
+/** Indicates the source used to derive the basal metabolic rate. */
+public enum TargetBasis {
+    /** BMR was supplied directly as a manual override via {@code basal_kcal}. */
+    BASAL_KCAL,
+    /** BMR was calculated using the Mifflin–St Jeor formula. */
+    MIFFLIN_ST_JEOR
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetCalculationException.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetCalculationException.java
@@ -1,0 +1,14 @@
+package com.marvin.nutrition.service;
+
+/** Thrown when target calories cannot be computed due to missing or invalid profile/weight data. */
+public class TargetCalculationException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the given explanatory message.
+     *
+     * @param message human-readable reason the calculation failed
+     */
+    public TargetCalculationException(String message) {
+        super(message);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
@@ -63,13 +63,13 @@ public class TargetService {
         final int targetKcal = maintenanceKcal + goalAdjustment(profile.getGoal());
 
         final int proteinG = (int) Math.round(profile.getProteinPerKg().doubleValue() * weightKg);
-        final int fatG = (int) (profile.getFatPct()
+        final int fatG = profile.getFatPct()
                 .multiply(BigDecimal.valueOf(targetKcal))
                 .divide(BigDecimal.valueOf(KCAL_PER_GRAM_FAT), 4, RoundingMode.HALF_UP)
-                .intValue());
+                .intValue();
         final int proteinKcal = proteinG * KCAL_PER_GRAM_PROTEIN;
         final int fatKcal = fatG * KCAL_PER_GRAM_FAT;
-        final int remaining = targetKcal - proteinKcal - fatKcal;
+        final int remaining = Math.max(0, targetKcal - proteinKcal - fatKcal);
         final int carbsG = remaining / KCAL_PER_GRAM_CARBS;
 
         final String basis = profile.getBasalKcal() != null

--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
@@ -1,0 +1,147 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.ActivityLevel;
+import com.marvin.nutrition.entity.Goal;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.entity.Sex;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.Period;
+import org.springframework.stereotype.Service;
+
+/**
+ * Pure calculation service for daily nutrition targets.
+ *
+ * <p>All I/O is handled by the orchestrating services; this class only contains
+ * deterministic, side-effect-free logic and is therefore easy to unit-test.</p>
+ */
+@Service
+public class TargetService {
+
+    private static final double ACTIVITY_SEDENTARY = 1.2;
+    private static final double ACTIVITY_LIGHT = 1.375;
+    private static final double ACTIVITY_MODERATE = 1.55;
+    private static final double ACTIVITY_ACTIVE = 1.725;
+    private static final double ACTIVITY_VERY_ACTIVE = 1.9;
+
+    private static final int GOAL_CUT_ADJUSTMENT = -500;
+    private static final int GOAL_MAINTAIN_ADJUSTMENT = 0;
+    private static final int GOAL_BULK_ADJUSTMENT = 300;
+
+    private static final int KCAL_PER_GRAM_PROTEIN = 4;
+    private static final int KCAL_PER_GRAM_FAT = 9;
+    private static final int KCAL_PER_GRAM_CARBS = 4;
+
+    private static final double MIFFLIN_WEIGHT_FACTOR = 10.0;
+    private static final double MIFFLIN_HEIGHT_FACTOR = 6.25;
+    private static final double MIFFLIN_AGE_FACTOR = 5.0;
+    private static final double MIFFLIN_MALE_CONSTANT = 5.0;
+    private static final double MIFFLIN_FEMALE_CONSTANT = -161.0;
+
+    /**
+     * Computes daily nutrition targets from the given profile and the latest weight entry.
+     *
+     * @param profile     the user's nutrition profile; must not be null
+     * @param latestWeight the most recent weight entry; must not be null
+     * @return a {@link TargetsDTO} with all computed targets
+     * @throws TargetCalculationException if profile or latestWeight is null
+     */
+    public TargetsDTO computeTargets(ProfileEntity profile, WeightEntryEntity latestWeight) {
+        if (profile == null) {
+            throw new TargetCalculationException("No nutrition profile found. Please create a profile first.");
+        }
+        if (latestWeight == null) {
+            throw new TargetCalculationException("No weight entry found. Please log your weight first.");
+        }
+
+        final double weightKg = latestWeight.getWeightKg().doubleValue();
+        final int bmr = resolveBmr(profile, weightKg);
+        final int maintenanceKcal = computeMaintenance(bmr, profile.getActivityLevel());
+        final int targetKcal = maintenanceKcal + goalAdjustment(profile.getGoal());
+
+        final int proteinG = (int) Math.round(profile.getProteinPerKg().doubleValue() * weightKg);
+        final int fatG = (int) (profile.getFatPct()
+                .multiply(BigDecimal.valueOf(targetKcal))
+                .divide(BigDecimal.valueOf(KCAL_PER_GRAM_FAT), 4, RoundingMode.HALF_UP)
+                .intValue());
+        final int proteinKcal = proteinG * KCAL_PER_GRAM_PROTEIN;
+        final int fatKcal = fatG * KCAL_PER_GRAM_FAT;
+        final int remaining = targetKcal - proteinKcal - fatKcal;
+        final int carbsG = remaining / KCAL_PER_GRAM_CARBS;
+
+        final String basis = profile.getBasalKcal() != null
+                ? TargetBasis.BASAL_KCAL.name()
+                : TargetBasis.MIFFLIN_ST_JEOR.name();
+
+        return new TargetsDTO(bmr, maintenanceKcal, targetKcal, proteinG, fatG, carbsG, basis);
+    }
+
+    /**
+     * Resolves BMR: uses the manual override when set, otherwise computes Mifflin–St Jeor.
+     *
+     * @param profile  the user profile containing optional {@code basalKcal} override
+     * @param weightKg current body weight in kilograms
+     * @return BMR rounded to the nearest whole kcal
+     */
+    private int resolveBmr(ProfileEntity profile, double weightKg) {
+        if (profile.getBasalKcal() != null) {
+            return profile.getBasalKcal();
+        }
+        return computeMifflinBmr(profile, weightKg);
+    }
+
+    /**
+     * Computes BMR using the Mifflin–St Jeor formula.
+     *
+     * @param profile  the user profile supplying sex, birth date and height
+     * @param weightKg current body weight in kilograms
+     * @return BMR rounded to the nearest whole kcal
+     */
+    private int computeMifflinBmr(ProfileEntity profile, double weightKg) {
+        final int age = Period.between(profile.getBirthDate(), LocalDate.now()).getYears();
+        final double heightCm = profile.getHeightCm().doubleValue();
+        final double sexConstant = profile.getSex() == Sex.MALE
+                ? MIFFLIN_MALE_CONSTANT
+                : MIFFLIN_FEMALE_CONSTANT;
+        final double bmrRaw = MIFFLIN_WEIGHT_FACTOR * weightKg
+                + MIFFLIN_HEIGHT_FACTOR * heightCm
+                - MIFFLIN_AGE_FACTOR * age
+                + sexConstant;
+        return (int) Math.round(bmrRaw);
+    }
+
+    /**
+     * Applies the activity multiplier to BMR to obtain maintenance calories.
+     *
+     * @param bmr           basal metabolic rate in kcal
+     * @param activityLevel the user's physical activity level
+     * @return maintenance calories rounded to the nearest whole number
+     */
+    private int computeMaintenance(int bmr, ActivityLevel activityLevel) {
+        final double factor = switch (activityLevel) {
+            case SEDENTARY -> ACTIVITY_SEDENTARY;
+            case LIGHT -> ACTIVITY_LIGHT;
+            case MODERATE -> ACTIVITY_MODERATE;
+            case ACTIVE -> ACTIVITY_ACTIVE;
+            case VERY_ACTIVE -> ACTIVITY_VERY_ACTIVE;
+        };
+        return (int) Math.round(bmr * factor);
+    }
+
+    /**
+     * Returns the kcal adjustment for the given dietary goal.
+     *
+     * @param goal the dietary goal
+     * @return positive, zero, or negative integer kcal adjustment
+     */
+    private int goalAdjustment(Goal goal) {
+        return switch (goal) {
+            case CUT -> GOAL_CUT_ADJUSTMENT;
+            case MAINTAIN -> GOAL_MAINTAIN_ADJUSTMENT;
+            case BULK -> GOAL_BULK_ADJUSTMENT;
+        };
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
@@ -1,0 +1,95 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateWeightEntryRequest;
+import com.marvin.nutrition.dto.WeightEntryDTO;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import com.marvin.nutrition.mapper.WeightEntryMapper;
+import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates CRUD operations for body-weight entries. */
+@Service
+public class WeightService {
+
+    private final WeightEntryRepository weightEntryRepository;
+    private final WeightEntryMapper weightEntryMapper;
+
+    /**
+     * Creates a new WeightService.
+     *
+     * @param weightEntryRepository JPA repository for weight entries
+     * @param weightEntryMapper     MapStruct mapper for entity/DTO conversion
+     */
+    public WeightService(WeightEntryRepository weightEntryRepository, WeightEntryMapper weightEntryMapper) {
+        this.weightEntryRepository = weightEntryRepository;
+        this.weightEntryMapper = weightEntryMapper;
+    }
+
+    /**
+     * Returns all weight entries ordered by entry date descending.
+     *
+     * @return a Flux emitting all weight entry DTOs
+     */
+    public Flux<WeightEntryDTO> findAll() {
+        return Mono.fromCallable(() -> {
+            final List<WeightEntryEntity> entries = weightEntryRepository.findAllByOrderByEntryDateDesc();
+            return entries.stream().map(weightEntryMapper::toDTO).toList();
+        }).subscribeOn(Schedulers.boundedElastic())
+                .flatMapIterable(list -> list);
+    }
+
+    /**
+     * Creates a new weight entry.
+     *
+     * @param request the entry date and weight in kg
+     * @return a Mono emitting the created weight entry DTO
+     */
+    public Mono<WeightEntryDTO> create(CreateWeightEntryRequest request) {
+        return Mono.fromCallable(() -> {
+            final WeightEntryEntity entity = new WeightEntryEntity();
+            entity.setEntryDate(request.entryDate());
+            entity.setWeightKg(request.weightKg());
+            return weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates an existing weight entry.
+     * Emits {@link NoSuchElementException} if no entry with the given id exists.
+     *
+     * @param id      the id of the entry to update
+     * @param request the new entry date and weight
+     * @return a Mono emitting the updated weight entry DTO
+     */
+    public Mono<WeightEntryDTO> update(Long id, CreateWeightEntryRequest request) {
+        return Mono.fromCallable(() -> {
+            final WeightEntryEntity entity = weightEntryRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Weight entry not found: " + id));
+            entity.setEntryDate(request.entryDate());
+            entity.setWeightKg(request.weightKg());
+            return weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Deletes the weight entry with the given id.
+     * Emits {@link NoSuchElementException} if no entry with the given id exists.
+     *
+     * @param id the id of the entry to delete
+     * @return an empty Mono on success
+     */
+    public Mono<Void> delete(Long id) {
+        return Mono.fromCallable(() -> {
+            if (!weightEntryRepository.existsById(id)) {
+                throw new NoSuchElementException("Weight entry not found: " + id);
+            }
+            weightEntryRepository.deleteById(id);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/package-info.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/package-info.java
@@ -1,2 +1,0 @@
-/** Nutrition service layer. */
-package com.marvin.nutrition.service;

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_2__nutrition_profile_weight.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_2__nutrition_profile_weight.sql
@@ -1,0 +1,23 @@
+CREATE TABLE nutrition.profile
+(
+    id               BIGSERIAL PRIMARY KEY,
+    sex              VARCHAR(10)    NOT NULL,
+    birth_date       DATE           NOT NULL,
+    height_cm        NUMERIC(5, 1)  NOT NULL,
+    activity_level   VARCHAR(20)    NOT NULL,
+    goal             VARCHAR(10)    NOT NULL,
+    protein_per_kg   NUMERIC(4, 2)  NOT NULL DEFAULT 2.0,
+    fat_pct          NUMERIC(4, 2)  NOT NULL DEFAULT 0.30,
+    basal_kcal       INT,
+    creation_date    TIMESTAMP      NOT NULL,
+    last_modified    TIMESTAMP      NOT NULL
+);
+
+CREATE TABLE nutrition.weight_entry
+(
+    id            BIGSERIAL PRIMARY KEY,
+    entry_date    DATE           NOT NULL UNIQUE,
+    weight_kg     NUMERIC(5, 2)  NOT NULL,
+    creation_date TIMESTAMP      NOT NULL,
+    last_modified TIMESTAMP      NOT NULL
+);

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -265,6 +265,30 @@ class TargetServiceTest {
     }
 
     // -----------------------------------------------------------------------
+    // Carbs clamp
+    // -----------------------------------------------------------------------
+
+    /**
+     * Very low weight + aggressive CUT + high protein/fat can push proteinKcal + fatKcal above targetKcal.
+     * basalKcal = 1400, weight = 45 kg, SEDENTARY → maintenance = round(1400 * 1.2) = 1680, CUT target = 1180.
+     * protein = round(3.5 * 45) = 158 g → 158 * 4 = 632 kcal.
+     * fat = floor(0.55 * 1180 / 9) = floor(72.11) = 72 g → 72 * 9 = 648 kcal.
+     * remaining = 1180 - 632 - 648 = -100 kcal → clamped to 0, carbsG must be 0.
+     */
+    @Test
+    @DisplayName("Carbs are clamped to 0 when protein+fat kcal exceeds targetKcal")
+    void compute_HighProteinFatExceedsTarget_CarbsClampedToZero() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.FEMALE, birthDate, 160.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 3.5, 0.55, 1400);
+        final WeightEntryEntity w = weight(45.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(0, result.carbsG());
+    }
+
+    // -----------------------------------------------------------------------
     // Error cases
     // -----------------------------------------------------------------------
 

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -1,0 +1,290 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.ActivityLevel;
+import com.marvin.nutrition.entity.Goal;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.entity.Sex;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link TargetService} covering Mifflin–St Jeor, basal_kcal override, activity factors, goals and macros. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TargetService Tests")
+class TargetServiceTest {
+
+    private TargetService targetService;
+
+    @BeforeEach
+    void setUp() {
+        targetService = new TargetService();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper builders
+    // -----------------------------------------------------------------------
+
+    private ProfileEntity profile(Sex sex, LocalDate birthDate, double heightCm,
+            ActivityLevel activityLevel, Goal goal,
+            double proteinPerKg, double fatPct, Integer basalKcal) {
+        final ProfileEntity p = new ProfileEntity();
+        p.setSex(sex);
+        p.setBirthDate(birthDate);
+        p.setHeightCm(BigDecimal.valueOf(heightCm));
+        p.setActivityLevel(activityLevel);
+        p.setGoal(goal);
+        p.setProteinPerKg(BigDecimal.valueOf(proteinPerKg));
+        p.setFatPct(BigDecimal.valueOf(fatPct));
+        p.setBasalKcal(basalKcal);
+        return p;
+    }
+
+    private WeightEntryEntity weight(double kg) {
+        final WeightEntryEntity w = new WeightEntryEntity();
+        w.setWeightKg(BigDecimal.valueOf(kg));
+        return w;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mifflin–St Jeor: MALE
+    // -----------------------------------------------------------------------
+
+    /**
+     * Male, 30 years, 175 cm, 80 kg → BMR = 10*80 + 6.25*175 - 5*30 + 5 = 800+1093.75-150+5 = 1748.75 → 1749.
+     * MODERATE activity: 1749 * 1.55 = 2710.95 → 2711.
+     * MAINTAIN goal: 2711 + 0 = 2711.
+     * protein = 2.0 * 80 = 160 g, fat = 0.30 * 2711 / 9 = 813.3 / 9 = 90.37 → 90 g,
+     * carbs = (2711 - 160*4 - 90*9) / 4 = (2711 - 640 - 810) / 4 = 1261 / 4 = 315.25 → 315 g.
+     */
+    @Test
+    @DisplayName("MALE MODERATE MAINTAIN uses Mifflin–St Jeor and returns correct macros")
+    void compute_MaleModerateMaintain_MifflinFormula() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.MODERATE, Goal.MAINTAIN, 2.0, 0.30, null);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(1749, result.bmr());
+        assertEquals(2711, result.maintenanceKcal());
+        assertEquals(2711, result.targetKcal());
+        assertEquals(160, result.proteinG());
+        assertEquals(90, result.fatG());
+        assertEquals(315, result.carbsG());
+        assertEquals(TargetBasis.MIFFLIN_ST_JEOR.name(), result.basis());
+    }
+
+    // -----------------------------------------------------------------------
+    // Mifflin–St Jeor: FEMALE
+    // -----------------------------------------------------------------------
+
+    /**
+     * Female, 25 years, 165 cm, 60 kg → BMR = 10*60 + 6.25*165 - 5*25 - 161 = 600+1031.25-125-161 = 1345.25 → 1345.
+     * LIGHT activity: 1345 * 1.375 = 1849.375 → 1849.
+     * CUT goal: 1849 - 500 = 1349.
+     * protein = 2.0 * 60 = 120 g, fat = 0.30 * 1349 / 9 = 404.7 / 9 = 44.97 → 44 g,
+     * carbs = (1349 - 120*4 - 44*9) / 4 = (1349 - 480 - 396) / 4 = 473 / 4 = 118.25 → 118 g.
+     */
+    @Test
+    @DisplayName("FEMALE LIGHT CUT uses Mifflin–St Jeor and returns correct macros")
+    void compute_FemaleLightCut_MifflinFormula() {
+        final LocalDate birthDate = LocalDate.now().minusYears(25);
+        final ProfileEntity p = profile(Sex.FEMALE, birthDate, 165.0,
+                ActivityLevel.LIGHT, Goal.CUT, 2.0, 0.30, null);
+        final WeightEntryEntity w = weight(60.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(1345, result.bmr());
+        assertEquals(1849, result.maintenanceKcal());
+        assertEquals(1349, result.targetKcal());
+        assertEquals(120, result.proteinG());
+        assertEquals(44, result.fatG());
+        assertEquals(118, result.carbsG());
+        assertEquals(TargetBasis.MIFFLIN_ST_JEOR.name(), result.basis());
+    }
+
+    // -----------------------------------------------------------------------
+    // basal_kcal override
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Manual basal_kcal overrides Mifflin–St Jeor formula")
+    void compute_BasalKcalOverride_UsesMeasuredBmr() {
+        final LocalDate birthDate = LocalDate.now().minusYears(35);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 180.0,
+                ActivityLevel.SEDENTARY, Goal.MAINTAIN, 2.0, 0.25, 2000);
+        final WeightEntryEntity w = weight(90.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(2000, result.bmr());
+        assertEquals(TargetBasis.BASAL_KCAL.name(), result.basis());
+    }
+
+    @Test
+    @DisplayName("Clearing basal_kcal (null) falls back to Mifflin–St Jeor")
+    void compute_BasalKcalCleared_FallsBackToFormula() {
+        final LocalDate birthDate = LocalDate.now().minusYears(35);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 180.0,
+                ActivityLevel.SEDENTARY, Goal.MAINTAIN, 2.0, 0.25, null);
+        final WeightEntryEntity w = weight(90.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(TargetBasis.MIFFLIN_ST_JEOR.name(), result.basis());
+    }
+
+    // -----------------------------------------------------------------------
+    // Activity factors
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("SEDENTARY activity factor 1.2 is applied correctly")
+    void compute_Sedentary_AppliesCorrectFactor() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.MAINTAIN, 2.0, 0.30, 1800);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(1800 * 1.2) = 2160
+        assertEquals(2160, result.maintenanceKcal());
+    }
+
+    @Test
+    @DisplayName("LIGHT activity factor 1.375 is applied correctly")
+    void compute_Light_AppliesCorrectFactor() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.LIGHT, Goal.MAINTAIN, 2.0, 0.30, 1800);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(1800 * 1.375) = 2475
+        assertEquals(2475, result.maintenanceKcal());
+    }
+
+    @Test
+    @DisplayName("ACTIVE activity factor 1.725 is applied correctly")
+    void compute_Active_AppliesCorrectFactor() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.ACTIVE, Goal.MAINTAIN, 2.0, 0.30, 1800);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(1800 * 1.725) = 3105
+        assertEquals(3105, result.maintenanceKcal());
+    }
+
+    @Test
+    @DisplayName("VERY_ACTIVE activity factor 1.9 is applied correctly")
+    void compute_VeryActive_AppliesCorrectFactor() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.VERY_ACTIVE, Goal.MAINTAIN, 2.0, 0.30, 1800);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(1800 * 1.9) = 3420
+        assertEquals(3420, result.maintenanceKcal());
+    }
+
+    // -----------------------------------------------------------------------
+    // Goal adjustments
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CUT goal subtracts 500 kcal from maintenance")
+    void compute_CutGoal_Subtracts500() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 2.0, 0.30, 2000);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(2000 * 1.2) = 2400; target = 2400 - 500 = 1900
+        assertEquals(2400, result.maintenanceKcal());
+        assertEquals(1900, result.targetKcal());
+    }
+
+    @Test
+    @DisplayName("BULK goal adds 300 kcal to maintenance")
+    void compute_BulkGoal_Adds300() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.BULK, 2.0, 0.30, 2000);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // maintenance = round(2000 * 1.2) = 2400; target = 2400 + 300 = 2700
+        assertEquals(2400, result.maintenanceKcal());
+        assertEquals(2700, result.targetKcal());
+    }
+
+    // -----------------------------------------------------------------------
+    // Macro math
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Macro grams are rounded to whole numbers and carbs fill remaining kcal")
+    void compute_MacroCarbsRemainder() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.MAINTAIN, 1.8, 0.28, 2000);
+        final WeightEntryEntity w = weight(75.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        // targetKcal = round(2000 * 1.2) = 2400
+        // protein = round(1.8 * 75) = 135 g → 135 * 4 = 540 kcal
+        // fat = floor(0.28 * 2400 / 9) = floor(74.666...) = 74 g → 74 * 9 = 666 kcal
+        // remaining = 2400 - 540 - 666 = 1194 kcal
+        // carbs = floor(1194 / 4) = 298 g
+        assertEquals(2400, result.targetKcal());
+        assertEquals(135, result.proteinG());
+        assertEquals(74, result.fatG());
+        assertEquals(298, result.carbsG());
+    }
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Throws TargetCalculationException when profile is null")
+    void compute_NullProfile_ThrowsException() {
+        final WeightEntryEntity w = weight(80.0);
+
+        assertThrows(TargetCalculationException.class,
+                () -> targetService.computeTargets(null, w));
+    }
+
+    @Test
+    @DisplayName("Throws TargetCalculationException when weight entry is null")
+    void compute_NullWeight_ThrowsException() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.MODERATE, Goal.MAINTAIN, 2.0, 0.30, null);
+
+        assertThrows(TargetCalculationException.class,
+                () -> targetService.computeTargets(p, null));
+    }
+}


### PR DESCRIPTION
## Summary

Adds bodyweight tracking and personalized daily calorie + macro targets (full TDEE auto-calc that recomputes as weight changes). Builds on the nutrition scaffold (#103).

## Data model (schema `nutrition`, migration `V1_2`)
- **profile** (single row): sex, birth_date, height_cm, activity_level, goal, protein_per_kg (default 2.0), fat_pct (default 0.30), basal_kcal (nullable) + audit.
- **weight_entry**: entry_date (unique), weight_kg + audit.

## Target calculation (`TargetService`, pure & synchronous)
1. BMR = `basal_kcal` if set, else Mifflin–St Jeor (`10·kg + 6.25·cm − 5·age + s`, s=+5 M / −161 F; age from birth_date, weight = latest entry).
2. Maintenance = BMR × activity factor (1.2 / 1.375 / 1.55 / 1.725 / 1.9).
3. Target kcal = maintenance + goal adj (CUT −500 / MAINTAIN 0 / BULK +300).
4. Protein = protein_per_kg × latest weight; Fat = fat_pct × kcal / 9; Carbs = remaining / 4.
5. `basis` flags BASAL_KCAL vs MIFFLIN_ST_JEOR.

## API
| Method | Path | |
|---|---|---|
| GET/PUT | `/nutrition/profile` | ProfileDTO (404 if unset) |
| GET | `/nutrition/weight` | entries desc |
| POST | `/nutrition/weight` | `{entryDate, weightKg}` → 201 |
| PUT/DELETE | `/nutrition/weight/{id}` | update / remove |
| GET | `/nutrition/targets` | `{bmr, maintenanceKcal, targetKcal, proteinG, fatG, carbsG, basis}` (400 if no profile/weight) |

Bodies are bean-validated; a `@RestControllerAdvice` maps missing-data → 400 and not-found → 404.

## Testing (TDD)
`TargetServiceTest` — 13 unit tests: both sexes, basal_kcal override + fallback to formula, every activity factor, each goal adjustment, macro rounding, and error cases for missing profile/weight. tdd-test-guardian confirmed no existing tests were modified.

## Verification
`./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` — BUILD SUCCESSFUL.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)