### PR TITLE
feat(nutrition): food catalog API (#105)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -1,0 +1,181 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.service.FoodService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for managing the nutrition food catalog.
+ * Provides endpoints to create, read, update, delete, and search food entries.
+ */
+@RestController
+@RequestMapping("/nutrition/foods")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class FoodController {
+
+    private static final String FOODS_LOCATION_PREFIX = "/nutrition/foods/";
+
+    private final FoodService foodService;
+
+    /**
+     * Creates a new FoodController with the required service.
+     *
+     * @param foodService the service handling food catalog operations
+     */
+    public FoodController(FoodService foodService) {
+        this.foodService = foodService;
+    }
+
+    /**
+     * Lists all food entries, optionally filtered by a name search query.
+     *
+     * @param q optional case-insensitive name contains filter
+     * @return a Flux emitting matching food DTOs ordered by name
+     */
+    @GetMapping
+    @Operation(
+            summary = "List food entries",
+            description = "Returns all food catalog entries, or those whose name contains the given query string (case-insensitive).",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Food list returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = FoodDTO.class)))
+                )
+            }
+    )
+    public Flux<FoodDTO> listFoods(
+            @RequestParam(required = false)
+            @Parameter(description = "Optional name search query (case-insensitive contains)") String q) {
+        return foodService.findAll(q);
+    }
+
+    /**
+     * Returns the food entry with the given id, or 404 if not found.
+     *
+     * @param id the UUID of the food entry
+     * @return a Mono with 200 and the food DTO, or 404 if not found
+     */
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a food entry by id",
+            description = "Returns a single food catalog entry by its UUID.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Food entry returned",
+                        content = @Content(schema = @Schema(implementation = FoodDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Food entry not found")
+            }
+    )
+    public Mono<ResponseEntity<FoodDTO>> getFoodById(
+            @PathVariable @Parameter(description = "UUID of the food entry") UUID id) {
+        return foodService.findById(id)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates a new food entry and returns 201 Created with a Location header.
+     *
+     * @param dto the food data to create
+     * @return a Mono with 201 Created, Location header, and the created food DTO
+     */
+    @PostMapping
+    @Operation(
+            summary = "Create a food entry",
+            description = "Adds a new entry to the food catalog. Source defaults to MANUAL if not specified.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Food entry created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = FoodDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed")
+            }
+    )
+    public Mono<ResponseEntity<FoodDTO>> createFood(@Valid @RequestBody FoodDTO dto) {
+        return foodService.create(dto)
+                .map(created -> {
+                    final URI location = URI.create(FOODS_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                });
+    }
+
+    /**
+     * Updates an existing food entry, or returns 404 if not found.
+     *
+     * @param id  the UUID of the food entry to update
+     * @param dto the updated food data
+     * @return a Mono with 200 and the updated food DTO, or 404 if not found
+     */
+    @PutMapping("/{id}")
+    @Operation(
+            summary = "Update a food entry",
+            description = "Replaces an existing food catalog entry with the provided data.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Food entry updated",
+                        content = @Content(schema = @Schema(implementation = FoodDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Food entry not found")
+            }
+    )
+    public Mono<ResponseEntity<FoodDTO>> updateFood(
+            @PathVariable @Parameter(description = "UUID of the food entry to update") UUID id,
+            @Valid @RequestBody FoodDTO dto) {
+        return foodService.update(id, dto)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes the food entry with the given id, or returns 404 if not found.
+     *
+     * @param id the UUID of the food entry to delete
+     * @return a Mono with 204 No Content on success, or 404 if not found
+     */
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a food entry",
+            description = "Permanently removes the food entry from the catalog.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Food entry deleted"),
+                @ApiResponse(responseCode = "404", description = "Food entry not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteFood(
+            @PathVariable @Parameter(description = "UUID of the food entry to delete") UUID id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return foodService.delete(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDTO.java
@@ -1,0 +1,68 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.FoodSource;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a food item in the nutrition catalog.
+ *
+ * @param id              server-assigned unique identifier
+ * @param name            food name (required)
+ * @param brand           optional brand name
+ * @param kcalPer100      kilocalories per 100 g (required, non-negative)
+ * @param proteinPer100   grams of protein per 100 g (required, non-negative)
+ * @param carbsPer100     grams of carbohydrates per 100 g (required, non-negative)
+ * @param fatPer100       grams of fat per 100 g (required, non-negative)
+ * @param fiberPer100     grams of dietary fibre per 100 g (optional, non-negative if present)
+ * @param defaultServingG default serving size in grams (optional, non-negative if present)
+ * @param source          origin of the food entry
+ */
+@Schema(description = "Food catalog entry")
+public record FoodDTO(
+        @Schema(description = "Food identifier")
+        UUID id,
+
+        @NotBlank
+        @Schema(description = "Food name", example = "Chicken Breast")
+        String name,
+
+        @Schema(description = "Brand name", example = "Freshness Farm")
+        String brand,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "Kilocalories per 100 g", example = "165.00")
+        BigDecimal kcalPer100,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "Grams of protein per 100 g", example = "31.00")
+        BigDecimal proteinPer100,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "Grams of carbohydrates per 100 g", example = "0.00")
+        BigDecimal carbsPer100,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "Grams of fat per 100 g", example = "3.60")
+        BigDecimal fatPer100,
+
+        @PositiveOrZero
+        @Schema(description = "Grams of dietary fibre per 100 g (optional)", example = "0.00")
+        BigDecimal fiberPer100,
+
+        @PositiveOrZero
+        @Schema(description = "Default serving size in grams (optional)", example = "100.00")
+        BigDecimal defaultServingG,
+
+        @Schema(description = "How the entry was sourced", example = "MANUAL")
+        FoodSource source
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/FoodEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/FoodEntity.java
@@ -1,0 +1,71 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a food item in the nutrition food catalog. */
+@Getter
+@Setter
+@Entity
+@Table(name = "food", schema = "nutrition")
+public class FoodEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "brand", length = 255)
+    private String brand;
+
+    @Column(name = "kcal_per_100", nullable = false, precision = 10, scale = 2)
+    private BigDecimal kcalPer100;
+
+    @Column(name = "protein_per_100", nullable = false, precision = 10, scale = 2)
+    private BigDecimal proteinPer100;
+
+    @Column(name = "carbs_per_100", nullable = false, precision = 10, scale = 2)
+    private BigDecimal carbsPer100;
+
+    @Column(name = "fat_per_100", nullable = false, precision = 10, scale = 2)
+    private BigDecimal fatPer100;
+
+    @Column(name = "fiber_per_100", precision = 10, scale = 2)
+    private BigDecimal fiberPer100;
+
+    @Column(name = "default_serving_g", precision = 10, scale = 2)
+    private BigDecimal defaultServingG;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false, length = 20)
+    private FoodSource source;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FoodEntity that = (FoodEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/FoodSource.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/FoodSource.java
@@ -1,0 +1,13 @@
+package com.marvin.nutrition.entity;
+
+/** Indicates how a food entry was created or sourced. */
+public enum FoodSource {
+    /** Entry was created manually by the user. */
+    MANUAL,
+    /** Entry was parsed from a photo of a nutrition label. */
+    PHOTO,
+    /** Entry is an estimated approximation. */
+    ESTIMATE,
+    /** Entry was looked up via a barcode scan. */
+    BARCODE
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/FoodMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/FoodMapper.java
@@ -4,6 +4,7 @@ import com.marvin.nutrition.dto.FoodDTO;
 import com.marvin.nutrition.entity.FoodEntity;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /** MapStruct mapper for converting between {@link FoodEntity} and {@link FoodDTO}. */
 @Mapper(componentModel = "spring")
@@ -18,11 +19,13 @@ public interface FoodMapper {
     FoodDTO toDTO(FoodEntity entity);
 
     /**
-     * Maps a food DTO to an entity.
+     * Maps a food DTO to an entity. The {@code id} field is always ignored so that
+     * the database-generated value is used; a client-supplied id is never honoured.
      *
      * @param dto the DTO to map
-     * @return the corresponding entity (id will be null for new entities)
+     * @return the corresponding entity with a null id (assigned by {@code @GeneratedValue})
      */
+    @Mapping(target = "id", ignore = true)
     FoodEntity toEntity(FoodDTO dto);
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/FoodMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/FoodMapper.java
@@ -1,0 +1,35 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.entity.FoodEntity;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between {@link FoodEntity} and {@link FoodDTO}. */
+@Mapper(componentModel = "spring")
+public interface FoodMapper {
+
+    /**
+     * Maps a food entity to its DTO representation.
+     *
+     * @param entity the food entity to map
+     * @return the corresponding DTO
+     */
+    FoodDTO toDTO(FoodEntity entity);
+
+    /**
+     * Maps a food DTO to an entity.
+     *
+     * @param dto the DTO to map
+     * @return the corresponding entity (id will be null for new entities)
+     */
+    FoodEntity toEntity(FoodDTO dto);
+
+    /**
+     * Maps a list of food entities to their DTO representations.
+     *
+     * @param entities the list of food entities to map
+     * @return the list of corresponding DTOs
+     */
+    List<FoodDTO> toDTOList(List<FoodEntity> entities);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
@@ -1,0 +1,23 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.FoodEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link FoodEntity}. */
+@Repository
+public interface FoodRepository extends JpaRepository<FoodEntity, UUID> {
+
+    /**
+     * Searches for food entries whose name contains the given query string, case-insensitively,
+     * ordered alphabetically by name.
+     *
+     * @param q the substring to search for within food names
+     * @return list of matching food entities ordered by name
+     */
+    @Query("SELECT f FROM FoodEntity f WHERE LOWER(f.name) LIKE LOWER(CONCAT('%', :q, '%')) ORDER BY f.name")
+    List<FoodEntity> searchByName(String q);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
@@ -13,11 +13,12 @@ public interface FoodRepository extends JpaRepository<FoodEntity, UUID> {
 
     /**
      * Searches for food entries whose name contains the given query string, case-insensitively,
-     * ordered alphabetically by name.
+     * ordered alphabetically by name. The caller must pre-escape LIKE special characters
+     * ({@code \}, {@code %}, {@code _}) using {@code ESCAPE '\\'}.
      *
-     * @param q the substring to search for within food names
+     * @param q the pre-escaped substring to search for within food names
      * @return list of matching food entities ordered by name
      */
-    @Query("SELECT f FROM FoodEntity f WHERE LOWER(f.name) LIKE LOWER(CONCAT('%', :q, '%')) ORDER BY f.name")
+    @Query("SELECT f FROM FoodEntity f WHERE LOWER(f.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\\\' ORDER BY f.name")
     List<FoodEntity> searchByName(String q);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
@@ -8,6 +8,7 @@ import com.marvin.nutrition.repository.FoodRepository;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -35,6 +36,8 @@ public class FoodService {
      * Returns all food entries, or those matching the given name query.
      * If {@code q} is null or blank, all foods ordered by name are returned.
      * Otherwise, a case-insensitive name-contains search is performed.
+     * LIKE special characters ({@code \}, {@code %}, {@code _}) in the query are
+     * escaped before being passed to the repository.
      *
      * @param q optional search string to filter by name
      * @return a Flux emitting matching food DTOs
@@ -43,10 +46,9 @@ public class FoodService {
         return Mono.fromCallable(() -> {
             final List<FoodEntity> entities;
             if (q == null || q.isBlank()) {
-                entities = foodRepository.findAll(
-                        org.springframework.data.domain.Sort.by("name"));
+                entities = foodRepository.findAll(Sort.by("name"));
             } else {
-                entities = foodRepository.searchByName(q);
+                entities = foodRepository.searchByName(escapeLike(q));
             }
             return foodMapper.toDTOList(entities);
         }).subscribeOn(Schedulers.boundedElastic())
@@ -77,15 +79,14 @@ public class FoodService {
     public Mono<FoodDTO> create(FoodDTO dto) {
         return Mono.fromCallable(() -> {
             final FoodEntity entity = foodMapper.toEntity(dto);
-            if (entity.getSource() == null) {
-                entity.setSource(FoodSource.MANUAL);
-            }
+            entity.setSource(resolveSource(dto.source()));
             return foodMapper.toDTO(foodRepository.save(entity));
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
-     * Updates an existing food entry.
+     * Updates an existing food entry. All fields are replaced unconditionally;
+     * if {@code source} is null in the DTO it defaults to {@link FoodSource#MANUAL}.
      * Emits {@link NoSuchElementException} if no entry with that id exists.
      *
      * @param id  the UUID of the food entry to update
@@ -104,9 +105,7 @@ public class FoodService {
             entity.setFatPer100(dto.fatPer100());
             entity.setFiberPer100(dto.fiberPer100());
             entity.setDefaultServingG(dto.defaultServingG());
-            if (dto.source() != null) {
-                entity.setSource(dto.source());
-            }
+            entity.setSource(resolveSource(dto.source()));
             return foodMapper.toDTO(foodRepository.save(entity));
         }).subscribeOn(Schedulers.boundedElastic());
     }
@@ -126,5 +125,29 @@ public class FoodService {
             foodRepository.deleteById(id);
             return null;
         }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    /**
+     * Returns the given source if non-null, otherwise {@link FoodSource#MANUAL}.
+     *
+     * @param source the source value from the DTO, may be null
+     * @return a non-null FoodSource
+     */
+    private FoodSource resolveSource(FoodSource source) {
+        return source != null ? source : FoodSource.MANUAL;
+    }
+
+    /**
+     * Escapes LIKE special characters ({@code \}, {@code %}, {@code _}) in the given string
+     * so that they are matched literally by the repository query.
+     * Backslash is escaped first to avoid double-escaping.
+     *
+     * @param q the raw user query
+     * @return the escaped query safe for use in a LIKE pattern with {@code ESCAPE '\\'}
+     */
+    private String escapeLike(String q) {
+        return q.replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
@@ -1,0 +1,130 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.FoodSource;
+import com.marvin.nutrition.mapper.FoodMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates CRUD and search operations for the food catalog. */
+@Service
+public class FoodService {
+
+    private final FoodRepository foodRepository;
+    private final FoodMapper foodMapper;
+
+    /**
+     * Creates a new FoodService with the required dependencies.
+     *
+     * @param foodRepository JPA repository for food entries
+     * @param foodMapper     MapStruct mapper for entity/DTO conversion
+     */
+    public FoodService(FoodRepository foodRepository, FoodMapper foodMapper) {
+        this.foodRepository = foodRepository;
+        this.foodMapper = foodMapper;
+    }
+
+    /**
+     * Returns all food entries, or those matching the given name query.
+     * If {@code q} is null or blank, all foods ordered by name are returned.
+     * Otherwise, a case-insensitive name-contains search is performed.
+     *
+     * @param q optional search string to filter by name
+     * @return a Flux emitting matching food DTOs
+     */
+    public Flux<FoodDTO> findAll(String q) {
+        return Mono.fromCallable(() -> {
+            final List<FoodEntity> entities;
+            if (q == null || q.isBlank()) {
+                entities = foodRepository.findAll(
+                        org.springframework.data.domain.Sort.by("name"));
+            } else {
+                entities = foodRepository.searchByName(q);
+            }
+            return foodMapper.toDTOList(entities);
+        }).subscribeOn(Schedulers.boundedElastic())
+                .flatMapIterable(list -> list);
+    }
+
+    /**
+     * Returns the food entry with the given id.
+     * Emits {@link NoSuchElementException} if no entry with that id exists.
+     *
+     * @param id the UUID of the food entry
+     * @return a Mono emitting the food DTO
+     */
+    public Mono<FoodDTO> findById(UUID id) {
+        return Mono.fromCallable(() -> {
+            final FoodEntity entity = foodRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Food not found: " + id));
+            return foodMapper.toDTO(entity);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Creates a new food entry. If no source is specified, defaults to {@link FoodSource#MANUAL}.
+     *
+     * @param dto the food data to persist
+     * @return a Mono emitting the created food DTO
+     */
+    public Mono<FoodDTO> create(FoodDTO dto) {
+        return Mono.fromCallable(() -> {
+            final FoodEntity entity = foodMapper.toEntity(dto);
+            if (entity.getSource() == null) {
+                entity.setSource(FoodSource.MANUAL);
+            }
+            return foodMapper.toDTO(foodRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates an existing food entry.
+     * Emits {@link NoSuchElementException} if no entry with that id exists.
+     *
+     * @param id  the UUID of the food entry to update
+     * @param dto the updated food data
+     * @return a Mono emitting the updated food DTO
+     */
+    public Mono<FoodDTO> update(UUID id, FoodDTO dto) {
+        return Mono.fromCallable(() -> {
+            final FoodEntity entity = foodRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Food not found: " + id));
+            entity.setName(dto.name());
+            entity.setBrand(dto.brand());
+            entity.setKcalPer100(dto.kcalPer100());
+            entity.setProteinPer100(dto.proteinPer100());
+            entity.setCarbsPer100(dto.carbsPer100());
+            entity.setFatPer100(dto.fatPer100());
+            entity.setFiberPer100(dto.fiberPer100());
+            entity.setDefaultServingG(dto.defaultServingG());
+            if (dto.source() != null) {
+                entity.setSource(dto.source());
+            }
+            return foodMapper.toDTO(foodRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Deletes the food entry with the given id.
+     * Emits {@link NoSuchElementException} if no entry with that id exists.
+     *
+     * @param id the UUID of the food entry to delete
+     * @return an empty Mono on success
+     */
+    public Mono<Void> delete(UUID id) {
+        return Mono.fromCallable(() -> {
+            if (!foodRepository.existsById(id)) {
+                throw new NoSuchElementException("Food not found: " + id);
+            }
+            foodRepository.deleteById(id);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+}

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_3__nutrition_food.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_3__nutrition_food.sql
@@ -1,0 +1,15 @@
+CREATE TABLE nutrition.food
+(
+    id                  UUID           PRIMARY KEY,
+    name                VARCHAR(255)   NOT NULL,
+    brand               VARCHAR(255),
+    kcal_per_100        NUMERIC(10, 2) NOT NULL,
+    protein_per_100     NUMERIC(10, 2) NOT NULL,
+    carbs_per_100       NUMERIC(10, 2) NOT NULL,
+    fat_per_100         NUMERIC(10, 2) NOT NULL,
+    fiber_per_100       NUMERIC(10, 2),
+    default_serving_g   NUMERIC(10, 2),
+    source              VARCHAR(20)    NOT NULL,
+    creation_date       TIMESTAMP      NOT NULL,
+    last_modified       TIMESTAMP      NOT NULL
+);

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
@@ -1,0 +1,232 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.entity.FoodSource;
+import com.marvin.nutrition.service.FoodService;
+import java.math.BigDecimal;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link FoodController} covering all CRUD and search endpoints. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FoodController Tests")
+class FoodControllerTest {
+
+    @Mock
+    private FoodService foodService;
+
+    @InjectMocks
+    private FoodController foodController;
+
+    private UUID testId;
+    private FoodDTO testFoodDTO;
+
+    /** Sets up test fixtures shared across all test methods. */
+    @BeforeEach
+    void setUp() {
+        testId = UUID.randomUUID();
+        testFoodDTO = new FoodDTO(
+                testId,
+                "Chicken Breast",
+                "Brand A",
+                new BigDecimal("165.00"),
+                new BigDecimal("31.00"),
+                new BigDecimal("0.00"),
+                new BigDecimal("3.60"),
+                null,
+                new BigDecimal("100.00"),
+                FoodSource.MANUAL
+        );
+    }
+
+    @Test
+    @DisplayName("Should return all foods as Flux when no query parameter is given")
+    void listFoods_NoQuery_ReturnsAllFoods() {
+        final FoodDTO second = new FoodDTO(
+                UUID.randomUUID(), "Oats", null,
+                new BigDecimal("389.00"), new BigDecimal("17.00"),
+                new BigDecimal("66.00"), new BigDecimal("7.00"),
+                new BigDecimal("10.00"), new BigDecimal("40.00"),
+                FoodSource.MANUAL
+        );
+        when(foodService.findAll(null)).thenReturn(Flux.just(testFoodDTO, second));
+
+        final Flux<FoodDTO> result = foodController.listFoods(null);
+
+        StepVerifier.create(result)
+                .expectNext(testFoodDTO)
+                .expectNext(second)
+                .verifyComplete();
+
+        verify(foodService).findAll(null);
+    }
+
+    @Test
+    @DisplayName("Should return matching foods as Flux when query parameter is provided")
+    void listFoods_WithQuery_ReturnsMatchingFoods() {
+        when(foodService.findAll("chicken")).thenReturn(Flux.just(testFoodDTO));
+
+        final Flux<FoodDTO> result = foodController.listFoods("chicken");
+
+        StepVerifier.create(result)
+                .expectNext(testFoodDTO)
+                .verifyComplete();
+
+        verify(foodService).findAll("chicken");
+    }
+
+    @Test
+    @DisplayName("Should return empty Flux when no foods match the query")
+    void listFoods_NoMatch_ReturnsEmptyFlux() {
+        when(foodService.findAll("xyz")).thenReturn(Flux.empty());
+
+        final Flux<FoodDTO> result = foodController.listFoods("xyz");
+
+        StepVerifier.create(result)
+                .verifyComplete();
+
+        verify(foodService).findAll("xyz");
+    }
+
+    @Test
+    @DisplayName("Should return 200 with food DTO when food exists")
+    void getFoodById_Found_Returns200WithDTO() {
+        when(foodService.findById(testId)).thenReturn(Mono.just(testFoodDTO));
+
+        final Mono<ResponseEntity<FoodDTO>> result = foodController.getFoodById(testId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Chicken Breast", response.getBody().name());
+                })
+                .verifyComplete();
+
+        verify(foodService).findById(testId);
+    }
+
+    @Test
+    @DisplayName("Should return 404 when food is not found by id")
+    void getFoodById_NotFound_Returns404() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodService.findById(unknownId))
+                .thenReturn(Mono.error(new NoSuchElementException("Food not found: " + unknownId)));
+
+        final Mono<ResponseEntity<FoodDTO>> result = foodController.getFoodById(unknownId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(foodService).findById(unknownId);
+    }
+
+    @Test
+    @DisplayName("Should return 201 Created with Location header after creating a food")
+    void createFood_Valid_Returns201WithLocation() {
+        when(foodService.create(any(FoodDTO.class))).thenReturn(Mono.just(testFoodDTO));
+
+        final Mono<ResponseEntity<FoodDTO>> result = foodController.createFood(testFoodDTO);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString()
+                            .contains(testId.toString()));
+                })
+                .verifyComplete();
+
+        verify(foodService).create(any(FoodDTO.class));
+    }
+
+    @Test
+    @DisplayName("Should return 200 with updated DTO after updating a food")
+    void updateFood_Found_Returns200WithUpdatedDTO() {
+        final FoodDTO updated = new FoodDTO(
+                testId, "Chicken Breast Grilled", "Brand A",
+                new BigDecimal("165.00"), new BigDecimal("31.00"),
+                new BigDecimal("0.00"), new BigDecimal("3.60"),
+                null, new BigDecimal("150.00"), FoodSource.MANUAL
+        );
+        when(foodService.update(eq(testId), any(FoodDTO.class))).thenReturn(Mono.just(updated));
+
+        final Mono<ResponseEntity<FoodDTO>> result = foodController.updateFood(testId, updated);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Chicken Breast Grilled", response.getBody().name());
+                })
+                .verifyComplete();
+
+        verify(foodService).update(eq(testId), any(FoodDTO.class));
+    }
+
+    @Test
+    @DisplayName("Should return 404 when food to update does not exist")
+    void updateFood_NotFound_Returns404() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodService.update(eq(unknownId), any(FoodDTO.class)))
+                .thenReturn(Mono.error(new NoSuchElementException("Food not found: " + unknownId)));
+
+        final Mono<ResponseEntity<FoodDTO>> result = foodController.updateFood(unknownId, testFoodDTO);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(foodService).update(eq(unknownId), any(FoodDTO.class));
+    }
+
+    @Test
+    @DisplayName("Should return 204 No Content after successfully deleting a food")
+    void deleteFood_Exists_Returns204() {
+        when(foodService.delete(testId)).thenReturn(Mono.empty());
+
+        final Mono<ResponseEntity<Void>> result = foodController.deleteFood(testId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(204, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(foodService).delete(testId);
+    }
+
+    @Test
+    @DisplayName("Should return 404 when food to delete does not exist")
+    void deleteFood_NotFound_Returns404() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodService.delete(unknownId))
+                .thenReturn(Mono.error(new NoSuchElementException("Food not found: " + unknownId)));
+
+        final Mono<ResponseEntity<Void>> result = foodController.deleteFood(unknownId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(foodService).delete(unknownId);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/FoodServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/FoodServiceTest.java
@@ -1,0 +1,406 @@
+package com.marvin.nutrition.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.FoodSource;
+import com.marvin.nutrition.mapper.FoodMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link FoodService} covering CRUD, source defaulting, wildcard escaping, and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FoodService Tests")
+class FoodServiceTest {
+
+    @Mock
+    private FoodRepository foodRepository;
+
+    @Mock
+    private FoodMapper foodMapper;
+
+    @InjectMocks
+    private FoodService foodService;
+
+    private UUID testId;
+    private FoodEntity testEntity;
+    private FoodDTO testDTO;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        testId = UUID.randomUUID();
+
+        testEntity = new FoodEntity();
+        testEntity.setName("Chicken Breast");
+        testEntity.setBrand("Brand A");
+        testEntity.setKcalPer100(new BigDecimal("165.00"));
+        testEntity.setProteinPer100(new BigDecimal("31.00"));
+        testEntity.setCarbsPer100(new BigDecimal("0.00"));
+        testEntity.setFatPer100(new BigDecimal("3.60"));
+        testEntity.setFiberPer100(null);
+        testEntity.setDefaultServingG(new BigDecimal("100.00"));
+        testEntity.setSource(FoodSource.MANUAL);
+
+        testDTO = new FoodDTO(
+                testId,
+                "Chicken Breast",
+                "Brand A",
+                new BigDecimal("165.00"),
+                new BigDecimal("31.00"),
+                new BigDecimal("0.00"),
+                new BigDecimal("3.60"),
+                null,
+                new BigDecimal("100.00"),
+                FoodSource.MANUAL
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // create — source defaulting
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create defaults source to MANUAL when DTO source is null")
+    void create_NullSource_DefaultsToManual() {
+        final FoodDTO dtoWithNullSource = new FoodDTO(
+                null, "Rice", null,
+                new BigDecimal("130.00"), new BigDecimal("2.70"),
+                new BigDecimal("28.00"), new BigDecimal("0.30"),
+                null, new BigDecimal("100.00"), null
+        );
+        final FoodEntity entityWithNullSource = new FoodEntity();
+        entityWithNullSource.setName("Rice");
+        entityWithNullSource.setSource(null);
+
+        final FoodEntity savedEntity = new FoodEntity();
+        savedEntity.setName("Rice");
+        savedEntity.setSource(FoodSource.MANUAL);
+
+        when(foodMapper.toEntity(dtoWithNullSource)).thenReturn(entityWithNullSource);
+        when(foodRepository.save(any(FoodEntity.class))).thenReturn(savedEntity);
+        when(foodMapper.toDTO(savedEntity)).thenReturn(
+                new FoodDTO(UUID.randomUUID(), "Rice", null,
+                        new BigDecimal("130.00"), new BigDecimal("2.70"),
+                        new BigDecimal("28.00"), new BigDecimal("0.30"),
+                        null, new BigDecimal("100.00"), FoodSource.MANUAL)
+        );
+
+        StepVerifier.create(foodService.create(dtoWithNullSource))
+                .assertNext(result -> {
+                    assert result.source() == FoodSource.MANUAL;
+                })
+                .verifyComplete();
+
+        verify(foodRepository).save(argThat(e -> e.getSource() == FoodSource.MANUAL));
+    }
+
+    @Test
+    @DisplayName("create preserves a supplied source (PHOTO)")
+    void create_SuppliedSource_Preserved() {
+        final FoodDTO dtoWithPhoto = new FoodDTO(
+                null, "Yogurt", "Danone",
+                new BigDecimal("59.00"), new BigDecimal("10.00"),
+                new BigDecimal("3.60"), new BigDecimal("0.10"),
+                null, new BigDecimal("150.00"), FoodSource.PHOTO
+        );
+        final FoodEntity entityWithPhoto = new FoodEntity();
+        entityWithPhoto.setName("Yogurt");
+        entityWithPhoto.setSource(FoodSource.PHOTO);
+
+        when(foodMapper.toEntity(dtoWithPhoto)).thenReturn(entityWithPhoto);
+        when(foodRepository.save(entityWithPhoto)).thenReturn(entityWithPhoto);
+        when(foodMapper.toDTO(entityWithPhoto)).thenReturn(
+                new FoodDTO(UUID.randomUUID(), "Yogurt", "Danone",
+                        new BigDecimal("59.00"), new BigDecimal("10.00"),
+                        new BigDecimal("3.60"), new BigDecimal("0.10"),
+                        null, new BigDecimal("150.00"), FoodSource.PHOTO)
+        );
+
+        StepVerifier.create(foodService.create(dtoWithPhoto))
+                .assertNext(result -> {
+                    assert result.source() == FoodSource.PHOTO;
+                })
+                .verifyComplete();
+
+        verify(foodRepository).save(argThat(e -> e.getSource() == FoodSource.PHOTO));
+    }
+
+    // -----------------------------------------------------------------------
+    // create — id never propagated from client
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create passes entity with null id to save (mapper must ignore client id)")
+    void create_ClientId_NotPropagatedToSave() {
+        final FoodDTO dtoWithId = new FoodDTO(
+                UUID.randomUUID(), "Oats", null,
+                new BigDecimal("389.00"), new BigDecimal("17.00"),
+                new BigDecimal("66.00"), new BigDecimal("7.00"),
+                new BigDecimal("10.00"), new BigDecimal("40.00"), FoodSource.MANUAL
+        );
+        // Mapper correctly ignores the id (as enforced by @Mapping(target="id", ignore=true))
+        final FoodEntity entityWithNullId = new FoodEntity();
+        entityWithNullId.setSource(FoodSource.MANUAL);
+        // id is null — mapper does not propagate it
+
+        when(foodMapper.toEntity(dtoWithId)).thenReturn(entityWithNullId);
+        when(foodRepository.save(entityWithNullId)).thenReturn(entityWithNullId);
+        when(foodMapper.toDTO(entityWithNullId)).thenReturn(dtoWithId);
+
+        StepVerifier.create(foodService.create(dtoWithId))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        // The entity reaching save must have a null id
+        verify(foodRepository).save(argThat(e -> e.getId() == null));
+    }
+
+    // -----------------------------------------------------------------------
+    // update — full field replacement
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("update copies all fields and replaces source, saves and returns DTO")
+    void update_AllFields_CopiedAndSaved() {
+        final FoodDTO updateDTO = new FoodDTO(
+                null, "Chicken Breast Grilled", "Brand B",
+                new BigDecimal("155.00"), new BigDecimal("32.00"),
+                new BigDecimal("0.00"), new BigDecimal("3.00"),
+                new BigDecimal("0.00"), new BigDecimal("120.00"), FoodSource.BARCODE
+        );
+        final FoodEntity existingEntity = new FoodEntity();
+        existingEntity.setName("Chicken Breast");
+        existingEntity.setSource(FoodSource.MANUAL);
+
+        final FoodEntity savedEntity = new FoodEntity();
+        savedEntity.setName("Chicken Breast Grilled");
+        savedEntity.setSource(FoodSource.BARCODE);
+
+        final FoodDTO savedDTO = new FoodDTO(
+                testId, "Chicken Breast Grilled", "Brand B",
+                new BigDecimal("155.00"), new BigDecimal("32.00"),
+                new BigDecimal("0.00"), new BigDecimal("3.00"),
+                new BigDecimal("0.00"), new BigDecimal("120.00"), FoodSource.BARCODE
+        );
+
+        when(foodRepository.findById(testId)).thenReturn(Optional.of(existingEntity));
+        when(foodRepository.save(existingEntity)).thenReturn(savedEntity);
+        when(foodMapper.toDTO(savedEntity)).thenReturn(savedDTO);
+
+        StepVerifier.create(foodService.update(testId, updateDTO))
+                .assertNext(result -> {
+                    assert "Chicken Breast Grilled".equals(result.name());
+                    assert result.source() == FoodSource.BARCODE;
+                })
+                .verifyComplete();
+
+        verify(foodRepository).save(argThat(e ->
+                "Chicken Breast Grilled".equals(e.getName())
+                        && "Brand B".equals(e.getBrand())
+                        && e.getSource() == FoodSource.BARCODE
+        ));
+    }
+
+    @Test
+    @DisplayName("update replaces source with MANUAL when incoming source is null")
+    void update_NullSource_DefaultsToManual() {
+        final FoodDTO updateDTO = new FoodDTO(
+                null, "Oats", null,
+                new BigDecimal("389.00"), new BigDecimal("17.00"),
+                new BigDecimal("66.00"), new BigDecimal("7.00"),
+                new BigDecimal("10.00"), new BigDecimal("40.00"), null
+        );
+        final FoodEntity existingEntity = new FoodEntity();
+        existingEntity.setName("Oats Old");
+        existingEntity.setSource(FoodSource.BARCODE);
+
+        final FoodEntity savedEntity = new FoodEntity();
+        savedEntity.setSource(FoodSource.MANUAL);
+
+        when(foodRepository.findById(testId)).thenReturn(Optional.of(existingEntity));
+        when(foodRepository.save(existingEntity)).thenReturn(savedEntity);
+        when(foodMapper.toDTO(savedEntity)).thenReturn(
+                new FoodDTO(testId, "Oats", null,
+                        new BigDecimal("389.00"), new BigDecimal("17.00"),
+                        new BigDecimal("66.00"), new BigDecimal("7.00"),
+                        new BigDecimal("10.00"), new BigDecimal("40.00"), FoodSource.MANUAL)
+        );
+
+        StepVerifier.create(foodService.update(testId, updateDTO))
+                .assertNext(result -> {
+                    assert result.source() == FoodSource.MANUAL;
+                })
+                .verifyComplete();
+
+        verify(foodRepository).save(argThat(e -> e.getSource() == FoodSource.MANUAL));
+    }
+
+    @Test
+    @DisplayName("update throws NoSuchElementException when id is absent")
+    void update_NotFound_ThrowsNoSuchElement() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(foodService.update(unknownId, testDTO))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(foodRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // delete
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("delete throws NoSuchElementException when id is absent")
+    void delete_NotFound_ThrowsNoSuchElement() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodRepository.existsById(unknownId)).thenReturn(false);
+
+        StepVerifier.create(foodService.delete(unknownId))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(foodRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("delete removes entity and completes when present")
+    void delete_Exists_DeletesAndCompletes() {
+        when(foodRepository.existsById(testId)).thenReturn(true);
+
+        StepVerifier.create(foodService.delete(testId))
+                .verifyComplete();
+
+        verify(foodRepository).deleteById(testId);
+    }
+
+    // -----------------------------------------------------------------------
+    // findById
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findById throws NoSuchElementException when id is absent")
+    void findById_NotFound_ThrowsNoSuchElement() {
+        final UUID unknownId = UUID.randomUUID();
+        when(foodRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(foodService.findById(unknownId))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("findById returns DTO when entity exists")
+    void findById_Found_ReturnsDTO() {
+        when(foodRepository.findById(testId)).thenReturn(Optional.of(testEntity));
+        when(foodMapper.toDTO(testEntity)).thenReturn(testDTO);
+
+        StepVerifier.create(foodService.findById(testId))
+                .expectNext(testDTO)
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // findAll — routing and wildcard escaping
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findAll with null q calls findAll(Sort), not searchByName")
+    void findAll_NullQuery_CallsFindAllSort() {
+        when(foodRepository.findAll(any(Sort.class))).thenReturn(List.of(testEntity));
+        when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
+
+        StepVerifier.create(foodService.findAll(null))
+                .expectNext(testDTO)
+                .verifyComplete();
+
+        verify(foodRepository).findAll(any(Sort.class));
+        verify(foodRepository, never()).searchByName(any());
+    }
+
+    @Test
+    @DisplayName("findAll with blank q calls findAll(Sort), not searchByName")
+    void findAll_BlankQuery_CallsFindAllSort() {
+        when(foodRepository.findAll(any(Sort.class))).thenReturn(List.of(testEntity));
+        when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
+
+        StepVerifier.create(foodService.findAll("   "))
+                .expectNext(testDTO)
+                .verifyComplete();
+
+        verify(foodRepository).findAll(any(Sort.class));
+        verify(foodRepository, never()).searchByName(any());
+    }
+
+    @Test
+    @DisplayName("findAll with non-blank q calls searchByName with LIKE-escaped string")
+    void findAll_NonBlankQuery_CallsSearchByName() {
+        when(foodRepository.searchByName("chicken")).thenReturn(List.of(testEntity));
+        when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
+
+        StepVerifier.create(foodService.findAll("chicken"))
+                .expectNext(testDTO)
+                .verifyComplete();
+
+        verify(foodRepository).searchByName("chicken");
+        verify(foodRepository, never()).findAll(any(Sort.class));
+    }
+
+    @Test
+    @DisplayName("findAll escapes percent wildcard in query before passing to searchByName")
+    void findAll_QueryWithPercent_EscapesPercent() {
+        when(foodRepository.searchByName(eq("50\\%"))).thenReturn(List.of());
+        when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
+
+        StepVerifier.create(foodService.findAll("50%"))
+                .verifyComplete();
+
+        verify(foodRepository).searchByName("50\\%");
+    }
+
+    @Test
+    @DisplayName("findAll escapes underscore wildcard in query before passing to searchByName")
+    void findAll_QueryWithUnderscore_EscapesUnderscore() {
+        when(foodRepository.searchByName(eq("fat\\_free"))).thenReturn(List.of());
+        when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
+
+        StepVerifier.create(foodService.findAll("fat_free"))
+                .verifyComplete();
+
+        verify(foodRepository).searchByName("fat\\_free");
+    }
+
+    @Test
+    @DisplayName("findAll escapes backslash in query before passing to searchByName")
+    void findAll_QueryWithBackslash_EscapesBackslash() {
+        when(foodRepository.searchByName(eq("a\\\\b"))).thenReturn(List.of());
+        when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
+
+        StepVerifier.create(foodService.findAll("a\\b"))
+                .verifyComplete();
+
+        verify(foodRepository).searchByName("a\\\\b");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a reusable catalog of foods with per-100g macros, to be referenced when logging meals (and populated manually now, by label scan / estimate / barcode later). Builds on the nutrition scaffold (#103). Full CRUD + case-insensitive name search.

## Data model (schema `nutrition`, migration `V1_3`)
**food**: `id` (UUID), `name`, `brand` (nullable), `kcal_per_100`, `protein_per_100`, `carbs_per_100`, `fat_per_100`, `fiber_per_100` (nullable), `default_serving_g` (nullable), `source` (MANUAL/PHOTO/ESTIMATE/BARCODE) + audit. **No image column.**

## API
| Method | Path | Notes |
|---|---|---|
| GET | `/nutrition/foods?q=` | list / search by name (case-insensitive contains); `q` optional |
| GET | `/nutrition/foods/{id}` | single (404 if missing) |
| POST | `/nutrition/foods` | create, 201 + Location (default `source=MANUAL`) |
| PUT | `/nutrition/foods/{id}` | update (404 if missing) |
| DELETE | `/nutrition/foods/{id}` | delete, 204 (404 if missing) |

## Implementation
`FoodEntity`, `FoodSource` enum, `FoodRepository` (JPQL search), reactive `FoodService` (blocking JPA on `boundedElastic`), `FoodController` (WebFlux Mono/Flux), `FoodDTO` + MapStruct `FoodMapper`. Reuses the existing module `@RestControllerAdvice` for 404/400/409 mapping.

## Validation
`name` `@NotBlank`; required macros `@NotNull @PositiveOrZero`; optional fiber/serving `@PositiveOrZero`.

## Testing (TDD)
`FoodControllerTest` (10 tests): list, search, get found/404, create 201, update found/404, delete 204/404. tdd-test-guardian confirmed no existing tests were modified.

## Verification
`./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` — BUILD SUCCESSFUL.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)