### PR TITLE
feat(nutrition): Claude nutrition-label photo reader (#106)

### DIFF
--- a/nutrition/README.md
+++ b/nutrition/README.md
@@ -1,0 +1,28 @@
+# Nutrition Module
+
+Self-contained vertical slice for nutrition tracking: food catalog, daily meal logging, weight tracking, and target calculation.
+
+## Configuration
+
+| Property | Environment variable | Description |
+|---|---|---|
+| `nutrition.claude.api-key` | `NUTRITION_CLAUDE_API_KEY` | Anthropic API key used by `LabelReader` to call Claude Vision |
+
+Example (application.yml / environment):
+
+```yaml
+nutrition:
+  claude:
+    api-key: ${NUTRITION_CLAUDE_API_KEY}
+```
+
+## Nutrition Label Scanner
+
+`POST /nutrition/foods/scan-label` (multipart/form-data, field name `file`)
+
+Sends the uploaded JPEG or PNG image to the Claude Vision API, which reads the nutrition label and returns a **transient draft food** as JSON.
+
+- The draft is **never persisted** — no database row is written and no image is stored.
+- All macronutrient values are normalised to per 100 g (Claude converts from per-serving if needed).
+- Nullable fields (`brand`, `fiberPer100`, `servingG`) are `null` when not present on the label.
+- If Claude returns a response that cannot be parsed as JSON, the endpoint responds with **HTTP 422 Unprocessable Entity**.

--- a/nutrition/README.md
+++ b/nutrition/README.md
@@ -26,3 +26,8 @@ Sends the uploaded JPEG or PNG image to the Claude Vision API, which reads the n
 - All macronutrient values are normalised to per 100 g (Claude converts from per-serving if needed).
 - Nullable fields (`brand`, `fiberPer100`, `servingG`) are `null` when not present on the label.
 - If Claude returns a response that cannot be parsed as JSON, the endpoint responds with **HTTP 422 Unprocessable Entity**.
+
+### Known limitations
+
+- **Image format support**: Only JPEG and PNG are recognised by the media-type sniff. HEIC and WebP images fall back to `image/jpeg` and may be rejected by the Claude Vision API upstream.
+- **Upload size limit**: The WebFlux default in-memory codec limit (256 KB) applies to the uploaded label image, the same constraint that affects the grocery receipt upload. Images larger than 256 KB are rejected before reaching the service.

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -1,7 +1,9 @@
 package com.marvin.nutrition.controller;
 
 import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.dto.FoodDraftDTO;
 import com.marvin.nutrition.service.FoodService;
+import com.marvin.nutrition.service.LabelReader;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -13,8 +15,13 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,30 +30,36 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
  * REST controller for managing the nutrition food catalog.
- * Provides endpoints to create, read, update, delete, and search food entries.
+ * Provides endpoints to create, read, update, delete, search food entries,
+ * and scan a nutrition label photo to produce a transient draft food.
  */
 @RestController
 @RequestMapping("/nutrition/foods")
 @Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
 public class FoodController {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FoodController.class);
     private static final String FOODS_LOCATION_PREFIX = "/nutrition/foods/";
 
     private final FoodService foodService;
+    private final LabelReader labelReader;
 
     /**
-     * Creates a new FoodController with the required service.
+     * Creates a new FoodController with the required services.
      *
      * @param foodService the service handling food catalog operations
+     * @param labelReader the service that reads nutrition labels via Claude
      */
-    public FoodController(FoodService foodService) {
+    public FoodController(FoodService foodService, LabelReader labelReader) {
         this.foodService = foodService;
+        this.labelReader = labelReader;
     }
 
     /**
@@ -177,5 +190,54 @@ public class FoodController {
         return foodService.delete(id)
                 .thenReturn(noContent)
                 .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+
+    /**
+     * Accepts a food packaging photo, sends it to Claude, and returns a transient draft food.
+     * Nothing is persisted — the returned draft is only held in memory.
+     *
+     * @param filePart the multipart file containing the food label image (JPEG or PNG)
+     * @return a Mono with 200 OK and the parsed draft food DTO
+     */
+    @PostMapping(path = "/scan-label", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "Scan a nutrition label photo",
+            description = "Sends the uploaded label image to Claude and returns a transient draft food with parsed values. "
+                    + "All macros are normalised to per 100 g. The draft is never persisted.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Label successfully read; draft food returned",
+                        content = @Content(schema = @Schema(implementation = FoodDraftDTO.class))
+                ),
+                @ApiResponse(responseCode = "422", description = "Label could not be read or parsed")
+            }
+    )
+    public Mono<ResponseEntity<FoodDraftDTO>> scanLabel(
+            @RequestPart("file")
+            @Parameter(description = "Nutrition label image file (JPEG or PNG)") FilePart filePart) {
+        LOGGER.info("Received scan-label request: filename={}", filePart.filename());
+        return extractBytes(filePart)
+                .flatMap(labelReader::readLabel)
+                .map(draft -> ResponseEntity.ok()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(draft));
+    }
+
+    /**
+     * Reads all bytes from the given FilePart reactively.
+     *
+     * @param filePart the file part to read
+     * @return a Mono emitting the complete file bytes
+     */
+    private Mono<byte[]> extractBytes(FilePart filePart) {
+        return DataBufferUtils.join(filePart.content())
+                .map(dataBuffer -> {
+                    final byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(bytes);
+                    DataBufferUtils.release(dataBuffer);
+                    return bytes;
+                })
+                .doOnError(e -> LOGGER.error("Failed to read uploaded label image", e));
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.marvin.nutrition.controller;
 
+import com.marvin.nutrition.service.LabelReadException;
 import com.marvin.nutrition.service.TargetCalculationException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.NoSuchElementException;
@@ -58,6 +59,17 @@ public class NutritionExceptionHandler {
     @ExceptionHandler(TargetCalculationException.class)
     public ResponseEntity<String> handleTargetCalculation(TargetCalculationException ex) {
         return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link LabelReadException} to HTTP 422 Unprocessable Entity.
+     *
+     * @param ex the exception indicating the label image could not be parsed
+     * @return 422 response with the exception message
+     */
+    @ExceptionHandler(LabelReadException.class)
+    public ResponseEntity<String> handleLabelRead(LabelReadException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDraftDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDraftDTO.java
@@ -1,0 +1,48 @@
+package com.marvin.nutrition.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Transient draft food parsed from a nutrition label photo.
+ * This record is never persisted — it represents raw values read by Claude
+ * directly from a packaged food's nutrition label image.
+ *
+ * @param name          food product name
+ * @param brand         optional brand name; null if not visible on label
+ * @param kcalPer100    kilocalories per 100 g, normalised from the label
+ * @param proteinPer100 grams of protein per 100 g, normalised from the label
+ * @param carbsPer100   grams of carbohydrates per 100 g, normalised from the label
+ * @param fatPer100     grams of fat per 100 g, normalised from the label
+ * @param fiberPer100   grams of dietary fibre per 100 g; null if not present on label
+ * @param servingG      suggested serving size in grams; null if not present on label
+ */
+@Schema(description = "Transient food draft parsed from a nutrition label photo — never persisted")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FoodDraftDTO(
+        @Schema(description = "Food product name", example = "Müsli")
+        String name,
+
+        @Schema(description = "Brand name (nullable)", example = "Kellogg's")
+        String brand,
+
+        @Schema(description = "Kilocalories per 100 g, normalised", example = "370.00")
+        BigDecimal kcalPer100,
+
+        @Schema(description = "Grams of protein per 100 g, normalised", example = "8.50")
+        BigDecimal proteinPer100,
+
+        @Schema(description = "Grams of carbohydrates per 100 g, normalised", example = "67.00")
+        BigDecimal carbsPer100,
+
+        @Schema(description = "Grams of fat per 100 g, normalised", example = "6.00")
+        BigDecimal fatPer100,
+
+        @Schema(description = "Grams of dietary fibre per 100 g (nullable)", example = "5.50")
+        BigDecimal fiberPer100,
+
+        @Schema(description = "Suggested serving size in grams (nullable)", example = "45.00")
+        BigDecimal servingG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/LabelReadException.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/LabelReadException.java
@@ -1,0 +1,24 @@
+package com.marvin.nutrition.service;
+
+/** Thrown when a nutrition label image cannot be parsed into a valid {@link com.marvin.nutrition.dto.FoodDraftDTO}. */
+public class LabelReadException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the given explanatory message.
+     *
+     * @param message human-readable reason the label could not be read
+     */
+    public LabelReadException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the given message and root cause.
+     *
+     * @param message human-readable reason the label could not be read
+     * @param cause   the underlying exception
+     */
+    public LabelReadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 /**
@@ -73,6 +74,8 @@ public class LabelReader {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(Map.class)
+                .onErrorMap(WebClientResponseException.class,
+                        e -> new LabelReadException("Claude API request failed: " + e.getStatusCode(), e))
                 .flatMap(this::parseClaudeResponse)
                 .doOnError(e -> LOGGER.error("Label read failed", e));
     }
@@ -88,6 +91,9 @@ public class LabelReader {
         final String text = textObj != null ? textObj.toString().trim() : "";
         try {
             final FoodDraftDTO draft = objectMapper.readValue(text, FoodDraftDTO.class);
+            if (draft.name() == null || draft.name().isBlank() || draft.kcalPer100() == null) {
+                return Mono.error(new LabelReadException("Claude returned no usable nutrition data"));
+            }
             LOGGER.info("Parsed nutrition label draft: name={}", draft.name());
             return Mono.just(draft);
         } catch (Exception e) {

--- a/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
@@ -1,0 +1,119 @@
+package com.marvin.nutrition.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.FoodDraftDTO;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reads nutritional values from a packaged food label photo by calling the Anthropic Claude API.
+ * Returns a transient {@link FoodDraftDTO} — nothing is persisted.
+ */
+@Service
+public class LabelReader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LabelReader.class);
+    private static final String MODEL = "claude-sonnet-4-6";
+    private static final int MAX_TOKENS = 1024;
+    private static final String LABEL_PROMPT = """
+            You are a nutrition label reader. Analyse the food packaging image and return ONLY a strict JSON object.
+            No markdown, no explanation, no code block — just the raw JSON.
+            Use exactly these keys: name, brand, kcalPer100, proteinPer100, carbsPer100, fatPer100, fiberPer100, servingG.
+            All macronutrient values must be normalised to per 100 g (convert from per-serving if necessary).
+            Use null for any field that is not visible on the label.
+            Numbers must be plain decimals without units.""";
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a new LabelReader.
+     *
+     * @param webClientBuilder the Spring WebClient builder
+     * @param apiKey           the Anthropic API key (from {@code nutrition.claude.api-key})
+     * @param objectMapper     Jackson mapper used to parse Claude's JSON response
+     */
+    public LabelReader(
+            WebClient.Builder webClientBuilder,
+            @Value("${nutrition.claude.api-key}") String apiKey,
+            ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", apiKey)
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Sends the image bytes to Claude and returns a parsed {@link FoodDraftDTO}.
+     * Emits {@link LabelReadException} if Claude's response cannot be parsed as JSON
+     * or if the response contains no content.
+     *
+     * @param imageBytes raw bytes of the label image (JPEG or PNG)
+     * @return a Mono emitting the parsed draft food, or an error if parsing fails
+     */
+    public Mono<FoodDraftDTO> readLabel(byte[] imageBytes) {
+        LOGGER.info("Sending nutrition label image ({} bytes) to Claude Vision API", imageBytes.length);
+        final String base64 = Base64.getEncoder().encodeToString(imageBytes);
+        final String mediaType = detectMediaType(imageBytes);
+        final Map<String, Object> request = buildRequest(base64, mediaType);
+
+        return webClient.post()
+                .uri("/v1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .flatMap(this::parseClaudeResponse)
+                .doOnError(e -> LOGGER.error("Label read failed", e));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<FoodDraftDTO> parseClaudeResponse(Map<?, ?> response) {
+        final List<?> content = (List<?>) response.get("content");
+        if (content == null || content.isEmpty()) {
+            return Mono.error(new LabelReadException("Claude returned an empty content list"));
+        }
+        final Map<?, ?> firstBlock = (Map<?, ?>) content.get(0);
+        final Object textObj = firstBlock.get("text");
+        final String text = textObj != null ? textObj.toString().trim() : "";
+        try {
+            final FoodDraftDTO draft = objectMapper.readValue(text, FoodDraftDTO.class);
+            LOGGER.info("Parsed nutrition label draft: name={}", draft.name());
+            return Mono.just(draft);
+        } catch (Exception e) {
+            LOGGER.warn("Claude returned non-JSON text: {}", text);
+            return Mono.error(new LabelReadException("Claude returned a non-JSON response: " + text, e));
+        }
+    }
+
+    private Map<String, Object> buildRequest(String base64, String mediaType) {
+        final Map<String, Object> imageSource = Map.of(
+                "type", "base64",
+                "media_type", mediaType,
+                "data", base64);
+        final Map<String, Object> imageBlock = Map.of("type", "image", "source", imageSource);
+        final Map<String, Object> textBlock = Map.of("type", "text", "text", LABEL_PROMPT);
+        final Map<String, Object> message = Map.of("role", "user", "content", List.of(imageBlock, textBlock));
+        return Map.of("model", MODEL, "max_tokens", MAX_TOKENS, "messages", List.of(message));
+    }
+
+    private String detectMediaType(byte[] bytes) {
+        if (bytes.length >= 4 && bytes[0] == (byte) 0x89 && bytes[1] == 'P' && bytes[2] == 'N' && bytes[3] == 'G') {
+            return "image/png";
+        }
+        if (bytes.length >= 2 && bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8) {
+            return "image/jpeg";
+        }
+        return "image/jpeg";
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
@@ -9,8 +9,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.dto.FoodDraftDTO;
 import com.marvin.nutrition.entity.FoodSource;
 import com.marvin.nutrition.service.FoodService;
+import com.marvin.nutrition.service.LabelReadException;
+import com.marvin.nutrition.service.LabelReader;
 import java.math.BigDecimal;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -21,18 +24,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-/** Unit tests for {@link FoodController} covering all CRUD and search endpoints. */
+/** Unit tests for {@link FoodController} covering all CRUD, search and scan-label endpoints. */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("FoodController Tests")
 class FoodControllerTest {
 
     @Mock
     private FoodService foodService;
+
+    @Mock
+    private LabelReader labelReader;
+
+    @Mock
+    private FilePart filePart;
 
     @InjectMocks
     private FoodController foodController;
@@ -228,5 +241,53 @@ class FoodControllerTest {
                 .verifyComplete();
 
         verify(foodService).delete(unknownId);
+    }
+
+    @Test
+    @DisplayName("scanLabel returns 200 with draft DTO when label reader succeeds")
+    void scanLabel_Success_Returns200WithDraft() {
+        final FoodDraftDTO draft = new FoodDraftDTO(
+                "Müsli", "Kellogg's",
+                new BigDecimal("370.0"), new BigDecimal("8.5"),
+                new BigDecimal("67.0"), new BigDecimal("6.0"),
+                new BigDecimal("5.5"), new BigDecimal("45.0")
+        );
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+        when(labelReader.readLabel(any(byte[].class))).thenReturn(Mono.just(draft));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.scanLabel(filePart);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Müsli", response.getBody().name());
+                    assertEquals("Kellogg's", response.getBody().brand());
+                    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+                })
+                .verifyComplete();
+
+        verify(labelReader).readLabel(any(byte[].class));
+    }
+
+    @Test
+    @DisplayName("scanLabel propagates LabelReadException when label reader fails")
+    void scanLabel_LabelReadException_PropagatesError() {
+        final byte[] imageBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+        when(labelReader.readLabel(any(byte[].class)))
+                .thenReturn(Mono.error(new LabelReadException("Claude returned non-JSON response")));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.scanLabel(filePart);
+
+        StepVerifier.create(result)
+                .expectError(LabelReadException.class)
+                .verify();
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
@@ -1,0 +1,158 @@
+package com.marvin.nutrition.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link LabelReader} covering success and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LabelReaderTest")
+class LabelReaderTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private LabelReader labelReader;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Sets up the WebClient mock chain and creates the service under test. */
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClientBuilder.baseUrl(any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.defaultHeader(any(String.class), any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(webClient);
+
+        labelReader = new LabelReader(webClientBuilder, "test-api-key", objectMapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubWebClientChain(Mono<?> responseMono) {
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(any(String.class))).thenReturn(requestBodySpec);
+        when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
+        doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any());
+        doReturn(responseSpec).when(requestHeadersSpec).retrieve();
+        doReturn(responseMono).when(responseSpec).bodyToMono(any(Class.class));
+    }
+
+    @Test
+    @DisplayName("readLabel returns parsed FoodDraftDTO for valid JSON response")
+    void readLabel_ValidJson_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "name": "Müsli",
+                    "brand": "Kellogg's",
+                    "kcalPer100": 370.0,
+                    "proteinPer100": 8.5,
+                    "carbsPer100": 67.0,
+                    "fatPer100": 6.0,
+                    "fiberPer100": 5.5,
+                    "servingG": 45.0
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(labelReader.readLabel(pngBytes))
+                .assertNext(dto -> {
+                    assert "Müsli".equals(dto.name());
+                    assert "Kellogg's".equals(dto.brand());
+                    assert new BigDecimal("370.0").compareTo(dto.kcalPer100()) == 0;
+                    assert new BigDecimal("8.5").compareTo(dto.proteinPer100()) == 0;
+                    assert new BigDecimal("67.0").compareTo(dto.carbsPer100()) == 0;
+                    assert new BigDecimal("6.0").compareTo(dto.fatPer100()) == 0;
+                    assert new BigDecimal("5.5").compareTo(dto.fiberPer100()) == 0;
+                    assert new BigDecimal("45.0").compareTo(dto.servingG()) == 0;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("readLabel returns FoodDraftDTO with null optional fields when Claude returns nulls")
+    void readLabel_ValidJsonWithNulls_ReturnsDTOWithNullOptionals() {
+        final String jsonText = """
+                {
+                    "name": "Plain Rice",
+                    "brand": null,
+                    "kcalPer100": 130.0,
+                    "proteinPer100": 2.7,
+                    "carbsPer100": 28.0,
+                    "fatPer100": 0.3,
+                    "fiberPer100": null,
+                    "servingG": null
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] jpegBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        StepVerifier.create(labelReader.readLabel(jpegBytes))
+                .assertNext(dto -> {
+                    assert "Plain Rice".equals(dto.name());
+                    assert dto.brand() == null;
+                    assert dto.fiberPer100() == null;
+                    assert dto.servingG() == null;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("readLabel emits LabelReadException when Claude returns non-JSON garbage text")
+    void readLabel_GarbageText_EmitsLabelReadException() {
+        final String garbageText = "Sorry, I cannot read the label in this image.";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", garbageText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(labelReader.readLabel(imageBytes))
+                .expectError(LabelReadException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("readLabel emits LabelReadException when Claude response has empty content list")
+    void readLabel_EmptyContent_EmitsLabelReadException() {
+        final Map<String, Object> claudeResponse = Map.of("content", List.of());
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        StepVerifier.create(labelReader.readLabel(imageBytes))
+                .expectError(LabelReadException.class)
+                .verify();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
@@ -1,5 +1,7 @@
 package com.marvin.nutrition.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -14,7 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -87,14 +91,14 @@ class LabelReaderTest {
         final byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
         StepVerifier.create(labelReader.readLabel(pngBytes))
                 .assertNext(dto -> {
-                    assert "Müsli".equals(dto.name());
-                    assert "Kellogg's".equals(dto.brand());
-                    assert new BigDecimal("370.0").compareTo(dto.kcalPer100()) == 0;
-                    assert new BigDecimal("8.5").compareTo(dto.proteinPer100()) == 0;
-                    assert new BigDecimal("67.0").compareTo(dto.carbsPer100()) == 0;
-                    assert new BigDecimal("6.0").compareTo(dto.fatPer100()) == 0;
-                    assert new BigDecimal("5.5").compareTo(dto.fiberPer100()) == 0;
-                    assert new BigDecimal("45.0").compareTo(dto.servingG()) == 0;
+                    assertEquals("Müsli", dto.name());
+                    assertEquals("Kellogg's", dto.brand());
+                    assertEquals(0, new BigDecimal("370.0").compareTo(dto.kcalPer100()));
+                    assertEquals(0, new BigDecimal("8.5").compareTo(dto.proteinPer100()));
+                    assertEquals(0, new BigDecimal("67.0").compareTo(dto.carbsPer100()));
+                    assertEquals(0, new BigDecimal("6.0").compareTo(dto.fatPer100()));
+                    assertEquals(0, new BigDecimal("5.5").compareTo(dto.fiberPer100()));
+                    assertEquals(0, new BigDecimal("45.0").compareTo(dto.servingG()));
                 })
                 .verifyComplete();
     }
@@ -121,10 +125,10 @@ class LabelReaderTest {
         final byte[] jpegBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
         StepVerifier.create(labelReader.readLabel(jpegBytes))
                 .assertNext(dto -> {
-                    assert "Plain Rice".equals(dto.name());
-                    assert dto.brand() == null;
-                    assert dto.fiberPer100() == null;
-                    assert dto.servingG() == null;
+                    assertEquals("Plain Rice", dto.name());
+                    assertNull(dto.brand());
+                    assertNull(dto.fiberPer100());
+                    assertNull(dto.servingG());
                 })
                 .verifyComplete();
     }
@@ -151,6 +155,33 @@ class LabelReaderTest {
         stubWebClientChain(Mono.just(claudeResponse));
 
         final byte[] imageBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        StepVerifier.create(labelReader.readLabel(imageBytes))
+                .expectError(LabelReadException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("readLabel emits LabelReadException when Claude API returns HTTP 401")
+    void readLabel_ApiReturns401_EmitsLabelReadException() {
+        final WebClientResponseException unauthorizedException = WebClientResponseException.create(
+                401, "Unauthorized", HttpHeaders.EMPTY, new byte[0], null);
+        stubWebClientChain(Mono.error(unauthorizedException));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(labelReader.readLabel(imageBytes))
+                .expectError(LabelReadException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("readLabel emits LabelReadException when Claude returns valid JSON with no usable fields")
+    void readLabel_EmptyJsonObject_EmitsLabelReadException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", "{}"))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
         StepVerifier.create(labelReader.readLabel(imageBytes))
                 .expectError(LabelReadException.class)
                 .verify();


### PR DESCRIPTION
## Summary

Implements **issue #106** — let the user photograph a packaged food's nutrition label and have Claude read the values, returning a **transient draft food** for the user to review and save via the existing food-catalog API.

The uploaded image is processed **in-memory only and never persisted** — the module returns only the parsed raw values (no DB row, no stored image).

## Changes

- **`LabelReader`** service (modeled on `grocery/.../ocr/ClaudeVisionOcrProvider`): `WebClient` → `https://api.anthropic.com/v1/messages`, model `claude-sonnet-4-6`, base64 image block + text block, `anthropic-version: 2023-06-01`, API key from `@Value("${nutrition.claude.api-key}")` (env `NUTRITION_CLAUDE_API_KEY`). Prompt asks Claude for strict JSON normalized to per 100 g; missing fields become null.
- **`FoodDraftDTO`** — transient record `{name, brand?, kcalPer100, proteinPer100, carbsPer100, fatPer100, fiberPer100?, servingG?}`.
- **`POST /nutrition/foods/scan-label`** (multipart `file`) on `FoodController` → returns the draft (200). Reads bytes reactively via `DataBufferUtils`.
- **`LabelReadException`** mapped to **HTTP 422** in `NutritionExceptionHandler` for non-JSON / unreadable responses.
- **`nutrition/README.md`** documents `NUTRITION_CLAUDE_API_KEY` and the endpoint's in-memory-only behavior.

## Acceptance criteria

- ✅ Posting a label photo returns parsed per-100g macros as JSON; no DB row and no image stored.
- ✅ Graceful error (422) if Claude returns non-JSON / unreadable image.

## Testing

- New `LabelReaderTest` (valid JSON, null optionals, garbage text → 422, empty content → 422).
- `FoodControllerTest` extended with scan-label success + error-propagation tests; existing tests unchanged (verified by tdd-test-guardian).
- `./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` — green, zero checkstyle warnings.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)