### PR TITLE
feat(nutrition): daily meal logging & day summary (#107)

### DIFF
--- a/nutrition/build.gradle
+++ b/nutrition/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
+    // EL implementation required by Hibernate Validator at test time
+    testImplementation 'org.glassfish.expressly:expressly:5.0.0'
+
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.platform:junit-platform-launcher'

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
@@ -1,0 +1,167 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
+import com.marvin.nutrition.dto.DaySummaryDTO;
+import com.marvin.nutrition.dto.MealEntryDTO;
+import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.service.MealEntryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for meal logging and daily nutritional summary.
+ * Provides endpoints to add, update and delete meal entries, and to retrieve the day summary.
+ */
+@RestController
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class MealEntryController {
+
+    private static final String ENTRIES_LOCATION_PREFIX = "/nutrition/entries/";
+
+    private final MealEntryService mealEntryService;
+
+    /**
+     * Creates a new MealEntryController with the required service.
+     *
+     * @param mealEntryService the service handling meal entry operations
+     */
+    public MealEntryController(MealEntryService mealEntryService) {
+        this.mealEntryService = mealEntryService;
+    }
+
+    /**
+     * Logs a new meal entry for the given date and returns 201 Created with a Location header.
+     *
+     * @param date the date to log the entry for
+     * @param req  the create request body
+     * @return a Mono with 201 Created, Location header, and the created meal entry DTO
+     */
+    @PostMapping("/nutrition/days/{date}/entries")
+    @Operation(
+            summary = "Log a meal entry",
+            description = "Adds a meal entry for the given day. "
+                    + "Supply foodId for food-backed entries (macros are snapshotted); "
+                    + "omit foodId and supply description + macros for ad-hoc entries.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Meal entry created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = MealEntryDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed or missing required fields"),
+                @ApiResponse(responseCode = "404", description = "Referenced food not found")
+            }
+    )
+    public Mono<ResponseEntity<MealEntryDTO>> addEntry(
+            @PathVariable
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "Date of the meal entry (ISO-8601)", example = "2026-06-07") LocalDate date,
+            @Valid @RequestBody CreateMealEntryRequest req) {
+        return mealEntryService.addEntry(date, req)
+                .map(created -> {
+                    final URI location = URI.create(ENTRIES_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                });
+    }
+
+    /**
+     * Returns the nutritional summary for the given date, including all entries and totals vs. targets.
+     *
+     * @param date the date to summarise
+     * @return a Mono emitting the day summary DTO with 200 OK
+     */
+    @GetMapping("/nutrition/days/{date}")
+    @Operation(
+            summary = "Get day summary",
+            description = "Returns all meal entries for the given day together with macro totals and, "
+                    + "if a nutrition profile and weight entry exist, targets and remaining macros.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Day summary returned",
+                        content = @Content(schema = @Schema(implementation = DaySummaryDTO.class))
+                )
+            }
+    )
+    public Mono<DaySummaryDTO> getDay(
+            @PathVariable
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "Date to summarise (ISO-8601)", example = "2026-06-07") LocalDate date) {
+        return mealEntryService.getDay(date);
+    }
+
+    /**
+     * Updates the meal entry with the given id, or returns 404 if not found.
+     *
+     * @param id  the UUID of the entry to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated DTO, or 404 if not found
+     */
+    @PutMapping("/nutrition/entries/{id}")
+    @Operation(
+            summary = "Update a meal entry",
+            description = "Applies partial updates to an existing meal entry. "
+                    + "For food-backed entries a new quantityG triggers macro re-snapshotting. "
+                    + "For ad-hoc entries, non-null macro values are applied directly.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal entry updated",
+                        content = @Content(schema = @Schema(implementation = MealEntryDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Meal entry not found")
+            }
+    )
+    public Mono<ResponseEntity<MealEntryDTO>> updateEntry(
+            @PathVariable @Parameter(description = "UUID of the meal entry to update") UUID id,
+            @Valid @RequestBody UpdateMealEntryRequest req) {
+        return mealEntryService.updateEntry(id, req)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes the meal entry with the given id, or returns 404 if not found.
+     *
+     * @param id the UUID of the entry to delete
+     * @return a Mono with 204 No Content on success, or 404 if not found
+     */
+    @DeleteMapping("/nutrition/entries/{id}")
+    @Operation(
+            summary = "Delete a meal entry",
+            description = "Permanently removes the meal entry.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Meal entry deleted"),
+                @ApiResponse(responseCode = "404", description = "Meal entry not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteEntry(
+            @PathVariable @Parameter(description = "UUID of the meal entry to delete") UUID id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return mealEntryService.deleteEntry(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -73,6 +73,17 @@ public class NutritionExceptionHandler {
     }
 
     /**
+     * Maps {@link IllegalArgumentException} to HTTP 400.
+     *
+     * @param ex the exception
+     * @return 400 response with the exception message
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+    /**
      * Maps bean-validation failures ({@link MethodArgumentNotValidException}) to HTTP 400.
      *
      * @param ex the exception carrying field error details

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
@@ -3,6 +3,8 @@ package com.marvin.nutrition.dto;
 import com.marvin.nutrition.entity.MealType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -30,21 +32,27 @@ public record CreateMealEntryRequest(
         @Schema(description = "Food catalog item UUID; null for ad-hoc entries")
         UUID foodId,
 
+        @PositiveOrZero
         @Schema(description = "Portion size in grams; required for food-backed entries", example = "150.00")
         BigDecimal quantityG,
 
+        @Size(max = 255)
         @Schema(description = "Free-text description; required for ad-hoc entries", example = "Homemade soup")
         String description,
 
+        @PositiveOrZero
         @Schema(description = "Kilocalories; required for ad-hoc entries", example = "250.00")
         BigDecimal kcal,
 
+        @PositiveOrZero
         @Schema(description = "Grams of protein; required for ad-hoc entries", example = "15.00")
         BigDecimal proteinG,
 
+        @PositiveOrZero
         @Schema(description = "Grams of carbohydrates; required for ad-hoc entries", example = "30.00")
         BigDecimal carbsG,
 
+        @PositiveOrZero
         @Schema(description = "Grams of fat; required for ad-hoc entries", example = "8.00")
         BigDecimal fatG
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
@@ -1,0 +1,51 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.MealType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Request body for creating a new meal log entry.
+ * Supply {@code foodId} for food-backed entries; omit it for ad-hoc entries.
+ * Food-backed entries require {@code quantityG}; macros are then snapshotted from the food catalog.
+ * Ad-hoc entries require {@code description} and all four macro fields.
+ *
+ * @param mealType    the meal category (required)
+ * @param foodId      UUID of the food catalog item (nullable — omit for ad-hoc entries)
+ * @param quantityG   portion size in grams (required for food-backed entries)
+ * @param description free-text label (required for ad-hoc entries)
+ * @param kcal        kilocalories (required for ad-hoc entries)
+ * @param proteinG    grams of protein (required for ad-hoc entries)
+ * @param carbsG      grams of carbohydrates (required for ad-hoc entries)
+ * @param fatG        grams of fat (required for ad-hoc entries)
+ */
+@Schema(description = "Request to log a meal entry for a given day")
+public record CreateMealEntryRequest(
+        @NotNull
+        @Schema(description = "Meal category", example = "LUNCH")
+        MealType mealType,
+
+        @Schema(description = "Food catalog item UUID; null for ad-hoc entries")
+        UUID foodId,
+
+        @Schema(description = "Portion size in grams; required for food-backed entries", example = "150.00")
+        BigDecimal quantityG,
+
+        @Schema(description = "Free-text description; required for ad-hoc entries", example = "Homemade soup")
+        String description,
+
+        @Schema(description = "Kilocalories; required for ad-hoc entries", example = "250.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Grams of protein; required for ad-hoc entries", example = "15.00")
+        BigDecimal proteinG,
+
+        @Schema(description = "Grams of carbohydrates; required for ad-hoc entries", example = "30.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Grams of fat; required for ad-hoc entries", example = "8.00")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/DaySummaryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/DaySummaryDTO.java
@@ -1,0 +1,33 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing the complete nutritional summary for a given day.
+ *
+ * @param date      the date of the summary
+ * @param entries   all meal entries logged for this day
+ * @param totals    aggregated macro-nutrient totals across all entries
+ * @param targets   computed daily nutrition targets (null if profile or weight data is missing)
+ * @param remaining remaining macro budget (targets minus totals; null if targets are unavailable)
+ */
+@Schema(description = "Nutritional summary for a given day")
+public record DaySummaryDTO(
+        @Schema(description = "Date of the summary", example = "2026-06-07")
+        LocalDate date,
+
+        @Schema(description = "All meal entries logged for this day")
+        List<MealEntryDTO> entries,
+
+        @Schema(description = "Aggregated macro-nutrient totals across all entries")
+        MacrosDTO totals,
+
+        @Schema(description = "Computed daily nutrition targets; null if profile or weight data is missing")
+        TargetsDTO targets,
+
+        @Schema(description = "Remaining macro budget (targets minus totals); null if targets are unavailable")
+        MacrosDTO remaining
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MacrosDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MacrosDTO.java
@@ -1,0 +1,28 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Data Transfer Object representing macro-nutrient totals or remaining values.
+ *
+ * @param kcal     kilocalories
+ * @param proteinG grams of protein
+ * @param carbsG   grams of carbohydrates
+ * @param fatG     grams of fat
+ */
+@Schema(description = "Macro-nutrient totals or remaining values for a day")
+public record MacrosDTO(
+        @Schema(description = "Kilocalories", example = "600.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Grams of protein", example = "40.00")
+        BigDecimal proteinG,
+
+        @Schema(description = "Grams of carbohydrates", example = "75.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Grams of fat", example = "15.00")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
@@ -1,0 +1,55 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.MealType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a logged meal entry.
+ *
+ * @param id          server-assigned unique identifier
+ * @param entryDate   the date this entry belongs to
+ * @param mealType    the meal category (BREAKFAST, LUNCH, DINNER, SNACK)
+ * @param foodId      UUID of the referenced food item (null for ad-hoc entries)
+ * @param description free-text label for ad-hoc entries (null for food-backed entries)
+ * @param quantityG   portion size in grams (null for ad-hoc entries)
+ * @param kcal        snapshotted kilocalories
+ * @param proteinG    snapshotted grams of protein
+ * @param carbsG      snapshotted grams of carbohydrates
+ * @param fatG        snapshotted grams of fat
+ */
+@Schema(description = "A logged meal entry for a given day")
+public record MealEntryDTO(
+        @Schema(description = "Meal entry identifier")
+        UUID id,
+
+        @Schema(description = "Date of the entry", example = "2026-06-07")
+        LocalDate entryDate,
+
+        @Schema(description = "Meal category", example = "LUNCH")
+        MealType mealType,
+
+        @Schema(description = "Referenced food item UUID (null for ad-hoc entries)")
+        UUID foodId,
+
+        @Schema(description = "Free-text description for ad-hoc entries", example = "Homemade soup")
+        String description,
+
+        @Schema(description = "Portion size in grams (null for ad-hoc entries)", example = "150.00")
+        BigDecimal quantityG,
+
+        @Schema(description = "Snapshotted kilocalories", example = "300.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Snapshotted grams of protein", example = "30.00")
+        BigDecimal proteinG,
+
+        @Schema(description = "Snapshotted grams of carbohydrates", example = "15.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Snapshotted grams of fat", example = "7.50")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
@@ -1,0 +1,44 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.MealType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Request body for updating an existing meal log entry.
+ * All fields are optional; only non-null values are applied.
+ * For food-backed entries a new {@code quantityG} triggers macro re-snapshotting.
+ * For ad-hoc entries the supplied macro values and description are applied directly.
+ *
+ * @param mealType    updated meal category (nullable)
+ * @param quantityG   updated portion size in grams; triggers re-snapshot for food-backed entries (nullable)
+ * @param description updated free-text label for ad-hoc entries (nullable)
+ * @param kcal        updated kilocalories for ad-hoc entries (nullable)
+ * @param proteinG    updated grams of protein for ad-hoc entries (nullable)
+ * @param carbsG      updated grams of carbohydrates for ad-hoc entries (nullable)
+ * @param fatG        updated grams of fat for ad-hoc entries (nullable)
+ */
+@Schema(description = "Request to update an existing meal log entry")
+public record UpdateMealEntryRequest(
+        @Schema(description = "Updated meal category (nullable)", example = "DINNER")
+        MealType mealType,
+
+        @Schema(description = "Updated portion size in grams; triggers macro re-snapshot for food-backed entries", example = "200.00")
+        BigDecimal quantityG,
+
+        @Schema(description = "Updated free-text description for ad-hoc entries", example = "Updated soup")
+        String description,
+
+        @Schema(description = "Updated kilocalories for ad-hoc entries", example = "350.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Updated grams of protein for ad-hoc entries", example = "20.00")
+        BigDecimal proteinG,
+
+        @Schema(description = "Updated grams of carbohydrates for ad-hoc entries", example = "40.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Updated grams of fat for ad-hoc entries", example = "10.00")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
@@ -2,6 +2,8 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.entity.MealType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 
 /**
@@ -23,21 +25,27 @@ public record UpdateMealEntryRequest(
         @Schema(description = "Updated meal category (nullable)", example = "DINNER")
         MealType mealType,
 
+        @PositiveOrZero
         @Schema(description = "Updated portion size in grams; triggers macro re-snapshot for food-backed entries", example = "200.00")
         BigDecimal quantityG,
 
+        @Size(max = 255)
         @Schema(description = "Updated free-text description for ad-hoc entries", example = "Updated soup")
         String description,
 
+        @PositiveOrZero
         @Schema(description = "Updated kilocalories for ad-hoc entries", example = "350.00")
         BigDecimal kcal,
 
+        @PositiveOrZero
         @Schema(description = "Updated grams of protein for ad-hoc entries", example = "20.00")
         BigDecimal proteinG,
 
+        @PositiveOrZero
         @Schema(description = "Updated grams of carbohydrates for ad-hoc entries", example = "40.00")
         BigDecimal carbsG,
 
+        @PositiveOrZero
         @Schema(description = "Updated grams of fat for ad-hoc entries", example = "10.00")
         BigDecimal fatG
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealEntryEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealEntryEntity.java
@@ -1,0 +1,72 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single meal log entry for a given day. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_entry", schema = "nutrition")
+public class MealEntryEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "entry_date", nullable = false)
+    private LocalDate entryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meal_type", nullable = false, length = 20)
+    private MealType mealType;
+
+    @Column(name = "food_id")
+    private UUID foodId;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "quantity_g", precision = 10, scale = 2)
+    private BigDecimal quantityG;
+
+    @Column(name = "kcal", nullable = false, precision = 10, scale = 2)
+    private BigDecimal kcal;
+
+    @Column(name = "protein_g", nullable = false, precision = 10, scale = 2)
+    private BigDecimal proteinG;
+
+    @Column(name = "carbs_g", nullable = false, precision = 10, scale = 2)
+    private BigDecimal carbsG;
+
+    @Column(name = "fat_g", nullable = false, precision = 10, scale = 2)
+    private BigDecimal fatG;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealEntryEntity that = (MealEntryEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealType.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealType.java
@@ -1,0 +1,13 @@
+package com.marvin.nutrition.entity;
+
+/** The meal category for a {@link MealEntryEntity}. */
+public enum MealType {
+    /** Morning meal. */
+    BREAKFAST,
+    /** Midday meal. */
+    LUNCH,
+    /** Evening meal. */
+    DINNER,
+    /** Small meal or snack between main meals. */
+    SNACK
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
@@ -1,0 +1,27 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.MealEntryDTO;
+import com.marvin.nutrition.entity.MealEntryEntity;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between {@link MealEntryEntity} and {@link MealEntryDTO}. */
+@Mapper(componentModel = "spring")
+public interface MealEntryMapper {
+
+    /**
+     * Maps a meal entry entity to its DTO representation.
+     *
+     * @param entity the meal entry entity to map
+     * @return the corresponding DTO
+     */
+    MealEntryDTO toDTO(MealEntryEntity entity);
+
+    /**
+     * Maps a list of meal entry entities to their DTO representations.
+     *
+     * @param entities the list of meal entry entities to map
+     * @return the list of corresponding DTOs
+     */
+    List<MealEntryDTO> toDTOList(List<MealEntryEntity> entities);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealEntryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealEntryRepository.java
@@ -1,0 +1,21 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealEntryEntity;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealEntryEntity}. */
+@Repository
+public interface MealEntryRepository extends JpaRepository<MealEntryEntity, UUID> {
+
+    /**
+     * Returns all meal entries for the given date, ordered by their creation timestamp ascending.
+     *
+     * @param entryDate the date to query
+     * @return list of meal entries for that date in creation order
+     */
+    List<MealEntryEntity> findByEntryDateOrderByCreationDateAsc(LocalDate entryDate);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -82,8 +82,9 @@ public class MealEntryService {
 
     /**
      * Updates an existing meal entry.
-     * For food-backed entries, a new {@code quantityG} triggers macro re-snapshotting.
-     * For ad-hoc entries, any non-null macro values and description from the request are applied.
+     * For food-backed entries, a new {@code quantityG} triggers macro re-snapshotting from the food catalog.
+     * For ad-hoc entries, any non-null macro values and description from the request are applied directly;
+     * {@code quantityG} is ignored for ad-hoc entries because there is no food catalog item to re-snapshot from.
      * Emits {@link NoSuchElementException} if no entry with the given id exists.
      *
      * @param id  the UUID of the entry to update
@@ -211,6 +212,8 @@ public class MealEntryService {
 
     /**
      * Applies update fields for an ad-hoc entry.
+     * Note: {@code req.quantityG()} is intentionally ignored here — it is only meaningful for
+     * food-backed entries where it drives macro re-snapshotting from the food catalog.
      *
      * @param entity the entity to update
      * @param req    the update request

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -1,0 +1,296 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
+import com.marvin.nutrition.dto.DaySummaryDTO;
+import com.marvin.nutrition.dto.MacrosDTO;
+import com.marvin.nutrition.dto.MealEntryDTO;
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealEntryEntity;
+import com.marvin.nutrition.mapper.MealEntryMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealEntryRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates meal logging operations including CRUD and day summary computation. */
+@Service
+public class MealEntryService {
+
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    private final MealEntryRepository mealEntryRepository;
+    private final FoodRepository foodRepository;
+    private final MealEntryMapper mealEntryMapper;
+    private final NutritionTargetService nutritionTargetService;
+
+    /**
+     * Creates a new MealEntryService with the required dependencies.
+     *
+     * @param mealEntryRepository    JPA repository for meal entries
+     * @param foodRepository         JPA repository for food catalog entries
+     * @param mealEntryMapper        MapStruct mapper for entity/DTO conversion
+     * @param nutritionTargetService service for computing daily nutrition targets
+     */
+    public MealEntryService(
+            MealEntryRepository mealEntryRepository,
+            FoodRepository foodRepository,
+            MealEntryMapper mealEntryMapper,
+            NutritionTargetService nutritionTargetService) {
+        this.mealEntryRepository = mealEntryRepository;
+        this.foodRepository = foodRepository;
+        this.mealEntryMapper = mealEntryMapper;
+        this.nutritionTargetService = nutritionTargetService;
+    }
+
+    /**
+     * Logs a new meal entry for the given date.
+     * If {@code req.foodId()} is non-null, macros are snapshotted from the food catalog using
+     * the supplied {@code quantityG}. Otherwise the entry is treated as ad-hoc and the supplied
+     * macro values are persisted directly.
+     * Emits {@link NoSuchElementException} if the referenced food is not found.
+     * Emits {@link IllegalArgumentException} if required fields are missing for the chosen entry mode.
+     *
+     * @param date the date to log the entry for
+     * @param req  the create request containing entry details
+     * @return a Mono emitting the created meal entry DTO
+     */
+    public Mono<MealEntryDTO> addEntry(LocalDate date, CreateMealEntryRequest req) {
+        return Mono.fromCallable(() -> {
+            final MealEntryEntity entity = new MealEntryEntity();
+            entity.setEntryDate(date);
+            entity.setMealType(req.mealType());
+
+            if (req.foodId() != null) {
+                buildFoodEntry(entity, req);
+            } else {
+                buildAdHocEntry(entity, req);
+            }
+
+            return mealEntryMapper.toDTO(mealEntryRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates an existing meal entry.
+     * For food-backed entries, a new {@code quantityG} triggers macro re-snapshotting.
+     * For ad-hoc entries, any non-null macro values and description from the request are applied.
+     * Emits {@link NoSuchElementException} if no entry with the given id exists.
+     *
+     * @param id  the UUID of the entry to update
+     * @param req the update request
+     * @return a Mono emitting the updated meal entry DTO
+     */
+    public Mono<MealEntryDTO> updateEntry(UUID id, UpdateMealEntryRequest req) {
+        return Mono.fromCallable(() -> {
+            final MealEntryEntity entity = mealEntryRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Meal entry not found: " + id));
+
+            if (req.mealType() != null) {
+                entity.setMealType(req.mealType());
+            }
+
+            if (entity.getFoodId() != null) {
+                applyFoodEntryUpdate(entity, req);
+            } else {
+                applyAdHocEntryUpdate(entity, req);
+            }
+
+            return mealEntryMapper.toDTO(mealEntryRepository.save(entity));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Deletes the meal entry with the given id.
+     * Emits {@link NoSuchElementException} if no entry with that id exists.
+     *
+     * @param id the UUID of the entry to delete
+     * @return an empty Mono on success
+     */
+    public Mono<Void> deleteEntry(UUID id) {
+        return Mono.fromCallable(() -> {
+            final MealEntryEntity entity = mealEntryRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Meal entry not found: " + id));
+            mealEntryRepository.delete(entity);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    /**
+     * Returns the day summary for the given date, including all entries, totals, targets and remaining macros.
+     * If the nutrition target service cannot compute targets (e.g. missing profile/weight),
+     * targets and remaining will be null.
+     *
+     * @param date the date to summarise
+     * @return a Mono emitting the day summary DTO
+     */
+    public Mono<DaySummaryDTO> getDay(LocalDate date) {
+        final Mono<List<MealEntryDTO>> entriesMono = Mono.fromCallable(() -> {
+            final List<MealEntryEntity> entities =
+                    mealEntryRepository.findByEntryDateOrderByCreationDateAsc(date);
+            return mealEntryMapper.toDTOList(entities);
+        }).subscribeOn(Schedulers.boundedElastic());
+
+        final Mono<Optional<TargetsDTO>> targetsMono = nutritionTargetService.getTargets()
+                .map(Optional::of)
+                .onErrorReturn(TargetCalculationException.class, Optional.empty());
+
+        return Mono.zip(entriesMono, targetsMono)
+                .map(tuple -> buildDaySummary(date, tuple.getT1(), tuple.getT2().orElse(null)));
+    }
+
+    /**
+     * Populates the entity fields for a food-backed entry by looking up the food and snapshotting macros.
+     *
+     * @param entity the entity to populate
+     * @param req    the create request
+     */
+    private void buildFoodEntry(MealEntryEntity entity, CreateMealEntryRequest req) {
+        final FoodEntity food = foodRepository.findById(req.foodId())
+                .orElseThrow(() -> new NoSuchElementException("Food not found: " + req.foodId()));
+
+        if (req.quantityG() == null) {
+            throw new IllegalArgumentException("quantityG is required for a food entry");
+        }
+
+        entity.setFoodId(req.foodId());
+        entity.setQuantityG(req.quantityG());
+        entity.setDescription(req.description());
+        entity.setKcal(snapshot(food.getKcalPer100(), req.quantityG()));
+        entity.setProteinG(snapshot(food.getProteinPer100(), req.quantityG()));
+        entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
+        entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
+    }
+
+    /**
+     * Populates the entity fields for an ad-hoc entry from the request.
+     *
+     * @param entity the entity to populate
+     * @param req    the create request
+     */
+    private void buildAdHocEntry(MealEntryEntity entity, CreateMealEntryRequest req) {
+        if (req.description() == null || req.description().isBlank()
+                || req.kcal() == null || req.proteinG() == null
+                || req.carbsG() == null || req.fatG() == null) {
+            throw new IllegalArgumentException(
+                    "ad-hoc entry requires description and kcal/proteinG/carbsG/fatG");
+        }
+        entity.setDescription(req.description());
+        entity.setKcal(req.kcal());
+        entity.setProteinG(req.proteinG());
+        entity.setCarbsG(req.carbsG());
+        entity.setFatG(req.fatG());
+    }
+
+    /**
+     * Applies update fields for a food-backed entry, re-snapshotting macros if quantity changed.
+     *
+     * @param entity the entity to update
+     * @param req    the update request
+     */
+    private void applyFoodEntryUpdate(MealEntryEntity entity, UpdateMealEntryRequest req) {
+        if (req.quantityG() != null) {
+            final FoodEntity food = foodRepository.findById(entity.getFoodId())
+                    .orElseThrow(() -> new NoSuchElementException("Food not found: " + entity.getFoodId()));
+            entity.setQuantityG(req.quantityG());
+            entity.setKcal(snapshot(food.getKcalPer100(), req.quantityG()));
+            entity.setProteinG(snapshot(food.getProteinPer100(), req.quantityG()));
+            entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
+            entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
+        }
+    }
+
+    /**
+     * Applies update fields for an ad-hoc entry.
+     *
+     * @param entity the entity to update
+     * @param req    the update request
+     */
+    private void applyAdHocEntryUpdate(MealEntryEntity entity, UpdateMealEntryRequest req) {
+        if (req.description() != null) {
+            entity.setDescription(req.description());
+        }
+        if (req.kcal() != null) {
+            entity.setKcal(req.kcal());
+        }
+        if (req.proteinG() != null) {
+            entity.setProteinG(req.proteinG());
+        }
+        if (req.carbsG() != null) {
+            entity.setCarbsG(req.carbsG());
+        }
+        if (req.fatG() != null) {
+            entity.setFatG(req.fatG());
+        }
+    }
+
+    /**
+     * Computes the snapshotted macro value: {@code per100 × quantityG / 100}, rounded half-up to 2 decimals.
+     *
+     * @param per100    the per-100-g value from the food catalog
+     * @param quantityG the portion size in grams
+     * @return the snapshotted value
+     */
+    private BigDecimal snapshot(BigDecimal per100, BigDecimal quantityG) {
+        return per100.multiply(quantityG).divide(HUNDRED, 2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Assembles a {@link DaySummaryDTO} from the loaded entries and nullable targets.
+     *
+     * @param date    the summary date
+     * @param entries the mapped entry DTOs
+     * @param targets the daily nutrition targets, or null if unavailable
+     * @return the assembled day summary
+     */
+    private DaySummaryDTO buildDaySummary(
+            LocalDate date, List<MealEntryDTO> entries, TargetsDTO targets) {
+        final MacrosDTO totals = computeTotals(entries);
+        final MacrosDTO remaining = targets != null ? computeRemaining(targets, totals) : null;
+        return new DaySummaryDTO(date, entries, totals, targets, remaining);
+    }
+
+    /**
+     * Sums macro-nutrient values across all entries.
+     *
+     * @param entries the entries to sum
+     * @return a MacrosDTO with aggregated totals
+     */
+    private MacrosDTO computeTotals(List<MealEntryDTO> entries) {
+        BigDecimal kcal = BigDecimal.ZERO;
+        BigDecimal proteinG = BigDecimal.ZERO;
+        BigDecimal carbsG = BigDecimal.ZERO;
+        BigDecimal fatG = BigDecimal.ZERO;
+        for (final MealEntryDTO entry : entries) {
+            kcal = kcal.add(entry.kcal());
+            proteinG = proteinG.add(entry.proteinG());
+            carbsG = carbsG.add(entry.carbsG());
+            fatG = fatG.add(entry.fatG());
+        }
+        return new MacrosDTO(kcal, proteinG, carbsG, fatG);
+    }
+
+    /**
+     * Computes the remaining macros as targets minus totals.
+     *
+     * @param targets the daily nutrition targets
+     * @param totals  the already-consumed totals
+     * @return a MacrosDTO with the remaining budget
+     */
+    private MacrosDTO computeRemaining(TargetsDTO targets, MacrosDTO totals) {
+        final BigDecimal kcal = BigDecimal.valueOf(targets.targetKcal()).subtract(totals.kcal());
+        final BigDecimal proteinG = BigDecimal.valueOf(targets.proteinG()).subtract(totals.proteinG());
+        final BigDecimal carbsG = BigDecimal.valueOf(targets.carbsG()).subtract(totals.carbsG());
+        final BigDecimal fatG = BigDecimal.valueOf(targets.fatG()).subtract(totals.fatG());
+        return new MacrosDTO(kcal, proteinG, carbsG, fatG);
+    }
+}

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_4__nutrition_meal_entry.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_4__nutrition_meal_entry.sql
@@ -1,0 +1,17 @@
+CREATE TABLE nutrition.meal_entry
+(
+    id            UUID           PRIMARY KEY,
+    entry_date    DATE           NOT NULL,
+    meal_type     VARCHAR(20)    NOT NULL,
+    food_id       UUID           REFERENCES nutrition.food(id) ON DELETE SET NULL,
+    description   VARCHAR(255),
+    quantity_g    NUMERIC(10, 2),
+    kcal          NUMERIC(10, 2) NOT NULL,
+    protein_g     NUMERIC(10, 2) NOT NULL,
+    carbs_g       NUMERIC(10, 2) NOT NULL,
+    fat_g         NUMERIC(10, 2) NOT NULL,
+    creation_date TIMESTAMP      NOT NULL,
+    last_modified TIMESTAMP      NOT NULL
+);
+
+CREATE INDEX idx_meal_entry_entry_date ON nutrition.meal_entry(entry_date);

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
@@ -1,0 +1,217 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
+import com.marvin.nutrition.dto.DaySummaryDTO;
+import com.marvin.nutrition.dto.MacrosDTO;
+import com.marvin.nutrition.dto.MealEntryDTO;
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.MealType;
+import com.marvin.nutrition.service.MealEntryService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealEntryController} covering all endpoints. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealEntryController Tests")
+class MealEntryControllerTest {
+
+    @Mock
+    private MealEntryService mealEntryService;
+
+    @InjectMocks
+    private MealEntryController mealEntryController;
+
+    private UUID entryId;
+    private LocalDate today;
+    private MealEntryDTO mealEntryDTO;
+    private CreateMealEntryRequest createRequest;
+    private UpdateMealEntryRequest updateRequest;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        entryId = UUID.randomUUID();
+        today = LocalDate.of(2026, 6, 7);
+
+        mealEntryDTO = new MealEntryDTO(
+                entryId, today, MealType.LUNCH, null, "Salad", null,
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+
+        createRequest = new CreateMealEntryRequest(
+                MealType.LUNCH, null, null, "Salad",
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+
+        updateRequest = new UpdateMealEntryRequest(
+                MealType.DINNER, null, "Updated salad", null, null, null, null
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/days/{date}/entries
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry returns 201 Created with Location header pointing to new entry")
+    void addEntry_Valid_Returns201WithLocation() {
+        when(mealEntryService.addEntry(eq(today), any(CreateMealEntryRequest.class)))
+                .thenReturn(Mono.just(mealEntryDTO));
+
+        final Mono<ResponseEntity<MealEntryDTO>> result =
+                mealEntryController.addEntry(today, createRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(MealType.LUNCH, response.getBody().mealType());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString()
+                            .contains(entryId.toString()));
+                })
+                .verifyComplete();
+
+        verify(mealEntryService).addEntry(eq(today), any(CreateMealEntryRequest.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /nutrition/days/{date}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getDay returns 200 with DaySummaryDTO")
+    void getDay_ReturnsDay_Returns200WithSummary() {
+        final MacrosDTO totals = new MacrosDTO(
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+        final TargetsDTO targets = new TargetsDTO(1700, 2200, 2000, 150, 67, 248, "MIFFLIN_ST_JEOR");
+        final MacrosDTO remaining = new MacrosDTO(
+                new BigDecimal("1700.00"), new BigDecimal("130.00"),
+                new BigDecimal("208.00"), new BigDecimal("57.00")
+        );
+        final DaySummaryDTO summaryDTO = new DaySummaryDTO(
+                today, List.of(mealEntryDTO), totals, targets, remaining
+        );
+
+        when(mealEntryService.getDay(today)).thenReturn(Mono.just(summaryDTO));
+
+        final Mono<DaySummaryDTO> result = mealEntryController.getDay(today);
+
+        StepVerifier.create(result)
+                .assertNext(summary -> {
+                    assertEquals(today, summary.date());
+                    assertEquals(1, summary.entries().size());
+                    assertNotNull(summary.totals());
+                    assertNotNull(summary.targets());
+                    assertNotNull(summary.remaining());
+                })
+                .verifyComplete();
+
+        verify(mealEntryService).getDay(today);
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/entries/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateEntry returns 200 with updated DTO when entry exists")
+    void updateEntry_Found_Returns200WithUpdatedDTO() {
+        final MealEntryDTO updatedDTO = new MealEntryDTO(
+                entryId, today, MealType.DINNER, null, "Updated salad", null,
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+
+        when(mealEntryService.updateEntry(eq(entryId), any(UpdateMealEntryRequest.class)))
+                .thenReturn(Mono.just(updatedDTO));
+
+        final Mono<ResponseEntity<MealEntryDTO>> result =
+                mealEntryController.updateEntry(entryId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(MealType.DINNER, response.getBody().mealType());
+                })
+                .verifyComplete();
+
+        verify(mealEntryService).updateEntry(eq(entryId), any(UpdateMealEntryRequest.class));
+    }
+
+    @Test
+    @DisplayName("updateEntry returns 404 when entry not found")
+    void updateEntry_NotFound_Returns404() {
+        when(mealEntryService.updateEntry(eq(entryId), any(UpdateMealEntryRequest.class)))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal entry not found: " + entryId)));
+
+        final Mono<ResponseEntity<MealEntryDTO>> result =
+                mealEntryController.updateEntry(entryId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealEntryService).updateEntry(eq(entryId), any(UpdateMealEntryRequest.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE /nutrition/entries/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteEntry returns 204 No Content when entry exists")
+    void deleteEntry_Exists_Returns204() {
+        when(mealEntryService.deleteEntry(entryId)).thenReturn(Mono.empty());
+
+        final Mono<ResponseEntity<Void>> result = mealEntryController.deleteEntry(entryId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(204, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealEntryService).deleteEntry(entryId);
+    }
+
+    @Test
+    @DisplayName("deleteEntry returns 404 when entry not found")
+    void deleteEntry_NotFound_Returns404() {
+        when(mealEntryService.deleteEntry(entryId))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal entry not found: " + entryId)));
+
+        final Mono<ResponseEntity<Void>> result = mealEntryController.deleteEntry(entryId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealEntryService).deleteEntry(entryId);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/MealEntryRequestValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/MealEntryRequestValidationTest.java
@@ -1,0 +1,152 @@
+package com.marvin.nutrition.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.marvin.nutrition.entity.MealType;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.math.BigDecimal;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests that validate Bean Validation constraints on meal entry request records directly. */
+public class MealEntryRequestValidationTest {
+
+    private final Validator validator = jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("valid CreateMealEntryRequest (food-backed) yields zero violations")
+    void createRequest_valid_foodBacked_noViolations() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH,
+                UUID.randomUUID(),
+                new BigDecimal("150.00"),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid food-backed request");
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest with negative quantityG yields a violation")
+    void createRequest_negativeQuantityG_yieldsViolation() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH,
+                UUID.randomUUID(),
+                new BigDecimal("-1.00"),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for negative quantityG");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("quantityG")),
+                "Expected the violation to be on the 'quantityG' property"
+        );
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest with negative kcal yields a violation")
+    void createRequest_negativeKcal_yieldsViolation() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.DINNER,
+                null,
+                null,
+                "Homemade soup",
+                new BigDecimal("-100.00"),
+                new BigDecimal("10.00"),
+                new BigDecimal("20.00"),
+                new BigDecimal("5.00")
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for negative kcal");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("kcal")),
+                "Expected the violation to be on the 'kcal' property"
+        );
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest with null mealType yields a violation")
+    void createRequest_nullMealType_yieldsViolation() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                null,
+                UUID.randomUUID(),
+                new BigDecimal("100.00"),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null mealType");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("mealType")),
+                "Expected the violation to be on the 'mealType' property"
+        );
+    }
+
+    @Test
+    @DisplayName("UpdateMealEntryRequest with negative quantityG yields a violation")
+    void updateRequest_negativeQuantityG_yieldsViolation() {
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null,
+                new BigDecimal("-50.00"),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<UpdateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for negative quantityG");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("quantityG")),
+                "Expected the violation to be on the 'quantityG' property"
+        );
+    }
+
+    @Test
+    @DisplayName("UpdateMealEntryRequest with over-long description yields a violation")
+    void updateRequest_overLongDescription_yieldsViolation() {
+        final String longDescription = "x".repeat(256);
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null,
+                null,
+                longDescription,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<UpdateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for description exceeding 255 chars");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -1,0 +1,460 @@
+package com.marvin.nutrition.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
+import com.marvin.nutrition.dto.MealEntryDTO;
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealEntryEntity;
+import com.marvin.nutrition.entity.MealType;
+import com.marvin.nutrition.mapper.MealEntryMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealEntryRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealEntryService} covering all business logic paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealEntryService Tests")
+class MealEntryServiceTest {
+
+    @Mock
+    private MealEntryRepository mealEntryRepository;
+
+    @Mock
+    private FoodRepository foodRepository;
+
+    @Mock
+    private MealEntryMapper mealEntryMapper;
+
+    @Mock
+    private NutritionTargetService nutritionTargetService;
+
+    @InjectMocks
+    private MealEntryService mealEntryService;
+
+    private UUID foodId;
+    private UUID entryId;
+    private FoodEntity foodEntity;
+    private MealEntryEntity mealEntryEntity;
+    private MealEntryDTO mealEntryDTO;
+    private LocalDate today;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        foodId = UUID.randomUUID();
+        entryId = UUID.randomUUID();
+        today = LocalDate.of(2026, 6, 7);
+
+        foodEntity = new FoodEntity();
+        foodEntity.setKcalPer100(new BigDecimal("200.00"));
+        foodEntity.setProteinPer100(new BigDecimal("20.00"));
+        foodEntity.setCarbsPer100(new BigDecimal("10.00"));
+        foodEntity.setFatPer100(new BigDecimal("5.00"));
+
+        mealEntryEntity = new MealEntryEntity();
+        mealEntryEntity.setEntryDate(today);
+        mealEntryEntity.setMealType(MealType.LUNCH);
+        mealEntryEntity.setKcal(new BigDecimal("300.00"));
+        mealEntryEntity.setProteinG(new BigDecimal("30.00"));
+        mealEntryEntity.setCarbsG(new BigDecimal("15.00"));
+        mealEntryEntity.setFatG(new BigDecimal("7.50"));
+
+        mealEntryDTO = new MealEntryDTO(
+                entryId, today, MealType.LUNCH, foodId, null,
+                new BigDecimal("150.00"),
+                new BigDecimal("300.00"), new BigDecimal("30.00"),
+                new BigDecimal("15.00"), new BigDecimal("7.50")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // addEntry — food-backed snapshot correctness
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry snapshots macros correctly from food × quantityG (kcalPer100=200, qty=150 → kcal=300.00)")
+    void addEntry_FoodEntry_SnapshotsMacrosCorrectly() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNext(mealEntryDTO)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e ->
+                new BigDecimal("300.00").compareTo(e.getKcal()) == 0
+                        && new BigDecimal("30.00").compareTo(e.getProteinG()) == 0
+                        && new BigDecimal("15.00").compareTo(e.getCarbsG()) == 0
+                        && new BigDecimal("7.50").compareTo(e.getFatG()) == 0
+                        && new BigDecimal("150").compareTo(e.getQuantityG()) == 0
+                        && foodId.equals(e.getFoodId())
+        ));
+    }
+
+    @Test
+    @DisplayName("addEntry food-backed entry propagates food id and quantity to saved entity")
+    void addEntry_FoodEntry_PropagatesFoodIdAndQuantity() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.BREAKFAST, foodId, new BigDecimal("100"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e ->
+                foodId.equals(e.getFoodId()) && new BigDecimal("100").compareTo(e.getQuantityG()) == 0
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // addEntry — ad-hoc entry
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry persists supplied macros for ad-hoc entry (no foodId)")
+    void addEntry_AdHocEntry_PersistsSuppliedMacros() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity saved = new MealEntryEntity();
+        saved.setDescription("Homemade soup");
+        saved.setKcal(new BigDecimal("250.00"));
+        saved.setProteinG(new BigDecimal("15.00"));
+        saved.setCarbsG(new BigDecimal("30.00"));
+        saved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
+        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNext(adHocDTO)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e ->
+                e.getFoodId() == null
+                        && e.getQuantityG() == null
+                        && "Homemade soup".equals(e.getDescription())
+                        && new BigDecimal("250.00").compareTo(e.getKcal()) == 0
+        ));
+        verify(foodRepository, never()).findById(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // addEntry — error paths
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry emits NoSuchElementException when food is not found")
+    void addEntry_FoodNotFound_EmitsNoSuchElementException() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("addEntry emits IllegalArgumentException when food entry has no quantityG")
+    void addEntry_FoodEntryMissingQuantityG_EmitsIllegalArgumentException() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, null, null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("addEntry emits IllegalArgumentException when ad-hoc entry has no description")
+    void addEntry_AdHocMissingDescription_EmitsIllegalArgumentException() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("addEntry emits IllegalArgumentException when ad-hoc entry has no macros")
+    void addEntry_AdHocMissingMacros_EmitsIllegalArgumentException() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Some food", null, null, null, null
+        );
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // updateEntry
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateEntry re-snapshots macros when food entry quantity changes")
+    void updateEntry_FoodEntryQuantityChanged_ReSnapshotsMacros() {
+        mealEntryEntity.setFoodId(foodId);
+        mealEntryEntity.setQuantityG(new BigDecimal("150"));
+        mealEntryEntity.setKcal(new BigDecimal("300.00"));
+
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null, new BigDecimal("200"), null, null, null, null, null
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        // kcalPer100=200, qty=200 → kcal = 200*200/100 = 400.00
+        verify(mealEntryRepository).save(argThat(e ->
+                new BigDecimal("400.00").compareTo(e.getKcal()) == 0
+                        && new BigDecimal("40.00").compareTo(e.getProteinG()) == 0
+                        && new BigDecimal("20.00").compareTo(e.getCarbsG()) == 0
+                        && new BigDecimal("10.00").compareTo(e.getFatG()) == 0
+                        && new BigDecimal("200").compareTo(e.getQuantityG()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("updateEntry applies non-null macro values for ad-hoc entry")
+    void updateEntry_AdHocEntry_AppliesNonNullMacros() {
+        mealEntryEntity.setFoodId(null);
+        mealEntryEntity.setDescription("Old soup");
+        mealEntryEntity.setKcal(new BigDecimal("100.00"));
+
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                MealType.DINNER, null, "New soup",
+                new BigDecimal("350.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+
+        final MealEntryEntity updatedEntity = new MealEntryEntity();
+        updatedEntity.setDescription("New soup");
+        updatedEntity.setMealType(MealType.DINNER);
+        updatedEntity.setKcal(new BigDecimal("350.00"));
+
+        final MealEntryDTO updatedDTO = new MealEntryDTO(
+                entryId, today, MealType.DINNER, null, "New soup", null,
+                new BigDecimal("350.00"), new BigDecimal("20.00"),
+                new BigDecimal("40.00"), new BigDecimal("10.00")
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(updatedEntity);
+        when(mealEntryMapper.toDTO(updatedEntity)).thenReturn(updatedDTO);
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .expectNext(updatedDTO)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e ->
+                MealType.DINNER.equals(e.getMealType())
+                        && "New soup".equals(e.getDescription())
+                        && new BigDecimal("350.00").compareTo(e.getKcal()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("updateEntry emits NoSuchElementException when entry not found")
+    void updateEntry_NotFound_EmitsNoSuchElementException() {
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                MealType.DINNER, null, null, null, null, null, null
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteEntry
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteEntry emits NoSuchElementException when entry not found")
+    void deleteEntry_NotFound_EmitsNoSuchElementException() {
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealEntryService.deleteEntry(entryId))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(mealEntryRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("deleteEntry deletes and completes when entry exists")
+    void deleteEntry_Exists_DeletesAndCompletes() {
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+
+        StepVerifier.create(mealEntryService.deleteEntry(entryId))
+                .verifyComplete();
+
+        verify(mealEntryRepository).delete(mealEntryEntity);
+    }
+
+    // -----------------------------------------------------------------------
+    // getDay
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getDay computes correct totals and remaining when targets are available")
+    void getDay_WithTargets_ComputesCorrectTotalsAndRemaining() {
+        final MealEntryEntity entry1 = new MealEntryEntity();
+        entry1.setKcal(new BigDecimal("400.00"));
+        entry1.setProteinG(new BigDecimal("30.00"));
+        entry1.setCarbsG(new BigDecimal("50.00"));
+        entry1.setFatG(new BigDecimal("10.00"));
+
+        final MealEntryEntity entry2 = new MealEntryEntity();
+        entry2.setKcal(new BigDecimal("200.00"));
+        entry2.setProteinG(new BigDecimal("10.00"));
+        entry2.setCarbsG(new BigDecimal("25.00"));
+        entry2.setFatG(new BigDecimal("5.00"));
+
+        final MealEntryDTO dto1 = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.BREAKFAST, null, "Oats", null,
+                new BigDecimal("400.00"), new BigDecimal("30.00"),
+                new BigDecimal("50.00"), new BigDecimal("10.00")
+        );
+        final MealEntryDTO dto2 = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.LUNCH, null, "Salad", null,
+                new BigDecimal("200.00"), new BigDecimal("10.00"),
+                new BigDecimal("25.00"), new BigDecimal("5.00")
+        );
+
+        final TargetsDTO targets = new TargetsDTO(1700, 2200, 2000, 150, 67, 248, "MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of(entry1, entry2));
+        when(mealEntryMapper.toDTOList(List.of(entry1, entry2)))
+                .thenReturn(List.of(dto1, dto2));
+        when(nutritionTargetService.getTargets()).thenReturn(Mono.just(targets));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assert today.equals(summary.date());
+                    assert 2 == summary.entries().size();
+                    // totals: kcal=600, protein=40, carbs=75, fat=15
+                    assert new BigDecimal("600.00").compareTo(summary.totals().kcal()) == 0;
+                    assert new BigDecimal("40.00").compareTo(summary.totals().proteinG()) == 0;
+                    assert new BigDecimal("75.00").compareTo(summary.totals().carbsG()) == 0;
+                    assert new BigDecimal("15.00").compareTo(summary.totals().fatG()) == 0;
+                    // targets present
+                    assert summary.targets() != null;
+                    assert 2000 == summary.targets().targetKcal();
+                    // remaining: kcal = 2000 - 600 = 1400
+                    assert summary.remaining() != null;
+                    assert new BigDecimal("1400").compareTo(summary.remaining().kcal()) == 0;
+                    assert new BigDecimal("110").compareTo(summary.remaining().proteinG()) == 0;
+                    assert new BigDecimal("173").compareTo(summary.remaining().carbsG()) == 0;
+                    assert new BigDecimal("52").compareTo(summary.remaining().fatG()) == 0;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getDay returns null targets and remaining when NutritionTargetService errors with TargetCalculationException")
+    void getDay_TargetCalculationException_ReturnsNullTargetsAndRemaining() {
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of());
+        when(mealEntryMapper.toDTOList(List.of())).thenReturn(List.of());
+        when(nutritionTargetService.getTargets())
+                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assert summary.targets() == null;
+                    assert summary.remaining() == null;
+                    assert new BigDecimal("0").compareTo(summary.totals().kcal()) == 0;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getDay returns zero totals for an empty day")
+    void getDay_EmptyDay_ReturnsZeroTotals() {
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of());
+        when(mealEntryMapper.toDTOList(List.of())).thenReturn(List.of());
+        when(nutritionTargetService.getTargets())
+                .thenReturn(Mono.error(new TargetCalculationException("No data")));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assert BigDecimal.ZERO.compareTo(summary.totals().kcal()) == 0;
+                    assert BigDecimal.ZERO.compareTo(summary.totals().proteinG()) == 0;
+                    assert BigDecimal.ZERO.compareTo(summary.totals().carbsG()) == 0;
+                    assert BigDecimal.ZERO.compareTo(summary.totals().fatG()) == 0;
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary

Implements **issue #107** — log what was eaten each day and get totals vs. the day's targets. Entries reference a food + portion, or are ad-hoc (free-text with directly supplied macros). Macros are **snapshotted at log time** so historical totals stay stable even if the food catalog changes later.

## Data model (schema `nutrition`)

New `meal_entry` table (`V1_4__nutrition_meal_entry.sql`): `id`, `entry_date`, `meal_type` (BREAKFAST/LUNCH/DINNER/SNACK), `food_id` (nullable, FK → `food` `ON DELETE SET NULL`), `description` (ad-hoc), `quantity_g`, snapshotted `kcal`/`protein_g`/`carbs_g`/`fat_g`, + audit timestamps. Indexed on `entry_date`.

## API

| Method | Path | Notes |
|---|---|---|
| POST | `/nutrition/days/{date}/entries` | `{mealType, foodId, quantityG}` (server snapshots macros) **or** ad-hoc `{mealType, description, kcal, proteinG, carbsG, fatG}` → 201 |
| PUT | `/nutrition/entries/{id}` | edit quantity (re-snapshots food entries) / ad-hoc values → 200 / 404 |
| DELETE | `/nutrition/entries/{id}` | remove → 204 / 404 |
| GET | `/nutrition/days/{date}` | `{date, entries[], totals{…}, targets{…}, remaining{…}}` |

`targets` reuses `NutritionTargetService`/`TargetService`; `remaining = targets − totals`. If no profile/weight exists yet, the day summary still returns entries+totals with `targets`/`remaining` as null (rather than failing the whole view).

## Acceptance criteria

- ✅ Adding a food entry snapshots macros = food per-100g × quantityG / 100 (BigDecimal, HALF_UP, 2 dp).
- ✅ Day summary returns correct totals, targets, and remaining.
- ✅ `./gradlew :nutrition:test` green.

## Testing

- `MealEntryServiceTest` (15 tests): food snapshot math, ad-hoc persistence, food-not-found (404), missing quantity/macros (400), update re-snapshot, not-found paths, day totals + remaining, and the missing-targets fallback.
- `MealEntryControllerTest` (6 tests): POST 201 + Location, GET day 200, PUT 200/404, DELETE 204/404.
- No existing tests modified. `./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` — green, zero checkstyle warnings.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)