### PR TITLE
feat(nutrition): Claude canteen meal estimator (#108)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealEstimateController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealEstimateController.java
@@ -1,0 +1,66 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.MealEstimateDTO;
+import com.marvin.nutrition.dto.MealEstimateRequest;
+import com.marvin.nutrition.service.MealEstimator;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller that estimates macros for a described canteen meal via Claude.
+ * The result is transient — nothing is persisted by this endpoint.
+ */
+@RestController
+@RequestMapping("/nutrition/estimate")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class MealEstimateController {
+
+    private final MealEstimator mealEstimator;
+
+    /**
+     * Creates a new MealEstimateController.
+     *
+     * @param mealEstimator the service that estimates meal macros via Claude
+     */
+    public MealEstimateController(MealEstimator mealEstimator) {
+        this.mealEstimator = mealEstimator;
+    }
+
+    /**
+     * Accepts a meal description, calls Claude to estimate macros, and returns the estimate.
+     * Nothing is persisted — the returned estimate is only held in memory.
+     *
+     * @param request the meal description and optional portion hint
+     * @return a Mono with 200 OK and the parsed macro estimate DTO
+     */
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Estimate macros for a described meal",
+            description = "Sends the meal description to Claude and returns a transient macro estimate. "
+                    + "Provide an optional portion hint to improve accuracy. The estimate is never persisted.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Macro estimate successfully returned",
+                        content = @Content(schema = @Schema(implementation = MealEstimateDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed — description is blank or too long"),
+                @ApiResponse(responseCode = "422", description = "Estimation failed — Claude could not produce a usable result")
+            }
+    )
+    public Mono<ResponseEntity<MealEstimateDTO>> estimate(@Valid @RequestBody MealEstimateRequest request) {
+        return mealEstimator.estimate(request.description(), request.portionHint())
+                .map(ResponseEntity::ok);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.marvin.nutrition.controller;
 
 import com.marvin.nutrition.service.LabelReadException;
+import com.marvin.nutrition.service.MealEstimateException;
 import com.marvin.nutrition.service.TargetCalculationException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.NoSuchElementException;
@@ -69,6 +70,17 @@ public class NutritionExceptionHandler {
      */
     @ExceptionHandler(LabelReadException.class)
     public ResponseEntity<String> handleLabelRead(LabelReadException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link MealEstimateException} to HTTP 422 Unprocessable Entity.
+     *
+     * @param ex the exception indicating the meal macro estimation failed
+     * @return 422 response with the exception message
+     */
+    @ExceptionHandler(MealEstimateException.class)
+    public ResponseEntity<String> handleMealEstimate(MealEstimateException ex) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
     }
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealEstimateDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealEstimateDTO.java
@@ -1,0 +1,37 @@
+package com.marvin.nutrition.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+/**
+ * Transient macro estimate for a described canteen meal.
+ * This record is never persisted — it represents Claude's best-effort estimation
+ * of the nutritional values for the described meal and portion.
+ *
+ * @param kcal        estimated kilocalories for the described portion
+ * @param proteinG    estimated grams of protein
+ * @param carbsG      estimated grams of carbohydrates
+ * @param fatG        estimated grams of fat
+ * @param assumptions a human-readable summary of assumptions Claude made during estimation
+ */
+@Schema(description = "Transient macro estimate for a described meal — never persisted")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MealEstimateDTO(
+        @Schema(description = "Estimated kilocalories for the described portion", example = "650.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Estimated grams of protein", example = "45.00")
+        BigDecimal proteinG,
+
+        @Schema(description = "Estimated grams of carbohydrates", example = "70.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Estimated grams of fat", example = "18.00")
+        BigDecimal fatG,
+
+        @Schema(description = "Assumptions Claude made while estimating (e.g. portion size used)",
+                example = "Estimated for a standard canteen portion of 400 g")
+        String assumptions
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealEstimateRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealEstimateRequest.java
@@ -1,0 +1,26 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for estimating macros of a described canteen meal.
+ * Supply a free-text {@code description} of the meal; optionally include a {@code portionHint}
+ * to improve the accuracy of the calorie and macro estimate.
+ *
+ * @param description a free-text description of the meal (required, max 500 characters)
+ * @param portionHint optional hint about the portion size (e.g. "one plate", "400 g")
+ */
+@Schema(description = "Request to estimate macros for a described meal using Claude")
+public record MealEstimateRequest(
+        @NotBlank
+        @Size(max = 500)
+        @Schema(description = "Free-text description of the meal to estimate", example = "Schnitzel mit Pommes")
+        String description,
+
+        @Size(max = 255)
+        @Schema(description = "Optional portion hint to improve estimate accuracy", example = "one standard plate")
+        String portionHint
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimateException.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimateException.java
@@ -1,0 +1,24 @@
+package com.marvin.nutrition.service;
+
+/** Thrown when a canteen meal description cannot be estimated into a valid {@link com.marvin.nutrition.dto.MealEstimateDTO}. */
+public class MealEstimateException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the given explanatory message.
+     *
+     * @param message human-readable reason the meal could not be estimated
+     */
+    public MealEstimateException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the given message and root cause.
+     *
+     * @param message human-readable reason the meal could not be estimated
+     * @param cause   the underlying exception
+     */
+    public MealEstimateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimator.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimator.java
@@ -1,0 +1,114 @@
+package com.marvin.nutrition.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.MealEstimateDTO;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Estimates nutritional macros for a described canteen meal by calling the Anthropic Claude API
+ * with a text-only prompt. Returns a transient {@link MealEstimateDTO} — nothing is persisted.
+ */
+@Service
+public class MealEstimator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MealEstimator.class);
+    private static final String MODEL = "claude-sonnet-4-6";
+    private static final int MAX_TOKENS = 1024;
+    private static final String ESTIMATE_PROMPT = """
+            You are a nutritionist estimating macros for a canteen meal.
+            Return ONLY a strict JSON object with no markdown, no explanation, and no code block — just the raw JSON.
+            Use exactly these keys: kcal, proteinG, carbsG, fatG, assumptions.
+            Estimate the values for the described meal and portion.
+            The "assumptions" field must contain a concise English sentence describing your assumptions (e.g. portion size used).
+            Numbers must be plain decimals without units.""";
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a new MealEstimator.
+     *
+     * @param webClientBuilder the Spring WebClient builder
+     * @param apiKey           the Anthropic API key (from {@code nutrition.claude.api-key})
+     * @param objectMapper     Jackson mapper used to parse Claude's JSON response
+     */
+    public MealEstimator(
+            WebClient.Builder webClientBuilder,
+            @Value("${nutrition.claude.api-key}") String apiKey,
+            ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", apiKey)
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Sends the meal description (and optional portion hint) to Claude and returns a parsed
+     * {@link MealEstimateDTO}.
+     * Emits {@link MealEstimateException} if Claude's response cannot be parsed as JSON,
+     * if the response contains no content, or if the result lacks a usable {@code kcal} value.
+     *
+     * @param description free-text description of the meal
+     * @param portionHint optional hint about the portion size; may be {@code null}
+     * @return a Mono emitting the parsed macro estimate, or an error if estimation fails
+     */
+    public Mono<MealEstimateDTO> estimate(String description, String portionHint) {
+        LOGGER.info("Sending meal description to Claude estimator API: {}", description);
+        final Map<String, Object> request = buildRequest(description, portionHint);
+
+        return webClient.post()
+                .uri("/v1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .onErrorMap(WebClientResponseException.class,
+                        e -> new MealEstimateException("Claude API request failed: " + e.getStatusCode(), e))
+                .flatMap(this::parseClaudeResponse)
+                .doOnError(e -> LOGGER.error("Meal estimation failed", e));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<MealEstimateDTO> parseClaudeResponse(Map<?, ?> response) {
+        final List<?> content = (List<?>) response.get("content");
+        if (content == null || content.isEmpty()) {
+            return Mono.error(new MealEstimateException("Claude returned an empty content list"));
+        }
+        final Map<?, ?> firstBlock = (Map<?, ?>) content.get(0);
+        final Object textObj = firstBlock.get("text");
+        final String text = textObj != null ? textObj.toString().trim() : "";
+        try {
+            final MealEstimateDTO estimate = objectMapper.readValue(text, MealEstimateDTO.class);
+            if (estimate.kcal() == null) {
+                return Mono.error(new MealEstimateException("Claude returned no usable macro estimate"));
+            }
+            LOGGER.info("Parsed meal estimate: kcal={}", estimate.kcal());
+            return Mono.just(estimate);
+        } catch (Exception e) {
+            LOGGER.warn("Claude returned non-JSON text: {}", text);
+            return Mono.error(new MealEstimateException("Claude returned a non-JSON response: " + text, e));
+        }
+    }
+
+    private Map<String, Object> buildRequest(String description, String portionHint) {
+        final StringBuilder promptText = new StringBuilder(ESTIMATE_PROMPT);
+        promptText.append("\n\nMeal: ").append(description);
+        if (portionHint != null && !portionHint.isBlank()) {
+            promptText.append("\nPortion: ").append(portionHint);
+        }
+        final Map<String, Object> textBlock = Map.of("type", "text", "text", promptText.toString());
+        final Map<String, Object> message = Map.of("role", "user", "content", List.of(textBlock));
+        return Map.of("model", MODEL, "max_tokens", MAX_TOKENS, "messages", List.of(message));
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEstimateControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEstimateControllerTest.java
@@ -1,0 +1,111 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealEstimateDTO;
+import com.marvin.nutrition.dto.MealEstimateRequest;
+import com.marvin.nutrition.service.MealEstimateException;
+import com.marvin.nutrition.service.MealEstimator;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealEstimateController} covering success and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealEstimateController Tests")
+class MealEstimateControllerTest {
+
+    @Mock
+    private MealEstimator mealEstimator;
+
+    @InjectMocks
+    private MealEstimateController mealEstimateController;
+
+    private MealEstimateDTO estimateDTO;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        estimateDTO = new MealEstimateDTO(
+                new BigDecimal("650.00"),
+                new BigDecimal("45.00"),
+                new BigDecimal("70.00"),
+                new BigDecimal("18.00"),
+                "Estimated for a standard canteen portion of 400 g"
+        );
+    }
+
+    @Test
+    @DisplayName("estimate returns 200 with MealEstimateDTO when estimator succeeds without portionHint")
+    void estimate_Valid_NoPortionHint_Returns200WithDTO() {
+        final MealEstimateRequest request = new MealEstimateRequest("Schnitzel mit Pommes", null);
+        when(mealEstimator.estimate(eq("Schnitzel mit Pommes"), isNull()))
+                .thenReturn(Mono.just(estimateDTO));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result = mealEstimateController.estimate(request);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(0, new BigDecimal("650.00").compareTo(response.getBody().kcal()));
+                    assertEquals(0, new BigDecimal("45.00").compareTo(response.getBody().proteinG()));
+                    assertEquals(0, new BigDecimal("70.00").compareTo(response.getBody().carbsG()));
+                    assertEquals(0, new BigDecimal("18.00").compareTo(response.getBody().fatG()));
+                    assertEquals("Estimated for a standard canteen portion of 400 g",
+                            response.getBody().assumptions());
+                })
+                .verifyComplete();
+
+        verify(mealEstimator).estimate(eq("Schnitzel mit Pommes"), isNull());
+    }
+
+    @Test
+    @DisplayName("estimate returns 200 with MealEstimateDTO when estimator succeeds with portionHint")
+    void estimate_Valid_WithPortionHint_Returns200WithDTO() {
+        final MealEstimateRequest request = new MealEstimateRequest("Spaghetti Bolognese", "one plate");
+        when(mealEstimator.estimate(eq("Spaghetti Bolognese"), eq("one plate")))
+                .thenReturn(Mono.just(estimateDTO));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result = mealEstimateController.estimate(request);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                })
+                .verifyComplete();
+
+        verify(mealEstimator).estimate(eq("Spaghetti Bolognese"), eq("one plate"));
+    }
+
+    @Test
+    @DisplayName("estimate propagates MealEstimateException when estimator fails")
+    void estimate_EstimatorFails_PropagatesMealEstimateException() {
+        final MealEstimateRequest request = new MealEstimateRequest("mystery food", null);
+        when(mealEstimator.estimate(any(String.class), isNull()))
+                .thenReturn(Mono.error(new MealEstimateException("Claude returned a non-JSON response")));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result = mealEstimateController.estimate(request);
+
+        StepVerifier.create(result)
+                .expectError(MealEstimateException.class)
+                .verify();
+
+        verify(mealEstimator).estimate(any(String.class), isNull());
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/MealEstimateRequestValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/MealEstimateRequestValidationTest.java
@@ -1,0 +1,94 @@
+package com.marvin.nutrition.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests that validate Bean Validation constraints on {@link MealEstimateRequest} directly. */
+public class MealEstimateRequestValidationTest {
+
+    private final Validator validator = jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("valid MealEstimateRequest without portionHint yields zero violations")
+    void request_valid_noPortionHint_noViolations() {
+        final MealEstimateRequest req = new MealEstimateRequest("Schnitzel mit Pommes", null);
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request without portionHint");
+    }
+
+    @Test
+    @DisplayName("valid MealEstimateRequest with portionHint yields zero violations")
+    void request_valid_withPortionHint_noViolations() {
+        final MealEstimateRequest req = new MealEstimateRequest("Spaghetti Bolognese", "one plate");
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request with portionHint");
+    }
+
+    @Test
+    @DisplayName("blank description yields a violation")
+    void request_blankDescription_yieldsViolation() {
+        final MealEstimateRequest req = new MealEstimateRequest("   ", null);
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for blank description");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("null description yields a violation")
+    void request_nullDescription_yieldsViolation() {
+        final MealEstimateRequest req = new MealEstimateRequest(null, null);
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null description");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("description exceeding 500 characters yields a violation")
+    void request_overLongDescription_yieldsViolation() {
+        final String longDescription = "x".repeat(501);
+        final MealEstimateRequest req = new MealEstimateRequest(longDescription, null);
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for description exceeding 500 chars");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("portionHint exceeding 255 characters yields a violation")
+    void request_overLongPortionHint_yieldsViolation() {
+        final String longHint = "x".repeat(256);
+        final MealEstimateRequest req = new MealEstimateRequest("Valid description", longHint);
+
+        final Set<ConstraintViolation<MealEstimateRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for portionHint exceeding 255 chars");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("portionHint")),
+                "Expected the violation to be on the 'portionHint' property"
+        );
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEstimatorTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEstimatorTest.java
@@ -1,0 +1,172 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealEstimator} covering success and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealEstimatorTest")
+class MealEstimatorTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private MealEstimator mealEstimator;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Sets up the WebClient mock chain and creates the service under test. */
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClientBuilder.baseUrl(any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.defaultHeader(any(String.class), any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(webClient);
+
+        mealEstimator = new MealEstimator(webClientBuilder, "test-api-key", objectMapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubWebClientChain(Mono<?> responseMono) {
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(any(String.class))).thenReturn(requestBodySpec);
+        when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
+        doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any());
+        doReturn(responseSpec).when(requestHeadersSpec).retrieve();
+        doReturn(responseMono).when(responseSpec).bodyToMono(any(Class.class));
+    }
+
+    @Test
+    @DisplayName("estimate returns parsed MealEstimateDTO for valid JSON response without portionHint")
+    void estimate_ValidJson_NoPortion_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 650.0,
+                    "proteinG": 45.0,
+                    "carbsG": 70.0,
+                    "fatG": 18.0,
+                    "assumptions": "Estimated for a standard canteen portion of 400 g"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("Schnitzel mit Pommes", null))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("650.0").compareTo(dto.kcal()));
+                    assertEquals(0, new BigDecimal("45.0").compareTo(dto.proteinG()));
+                    assertEquals(0, new BigDecimal("70.0").compareTo(dto.carbsG()));
+                    assertEquals(0, new BigDecimal("18.0").compareTo(dto.fatG()));
+                    assertEquals("Estimated for a standard canteen portion of 400 g", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimate returns parsed MealEstimateDTO for valid JSON response with portionHint")
+    void estimate_ValidJson_WithPortionHint_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 450.0,
+                    "proteinG": 30.0,
+                    "carbsG": 50.0,
+                    "fatG": 12.0,
+                    "assumptions": "Used the provided portion hint of one small plate"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("Spaghetti Bolognese", "one small plate"))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("450.0").compareTo(dto.kcal()));
+                    assertEquals(0, new BigDecimal("30.0").compareTo(dto.proteinG()));
+                    assertEquals("Used the provided portion hint of one small plate", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimate emits MealEstimateException when Claude returns non-JSON garbage text")
+    void estimate_GarbageText_EmitsMealEstimateException() {
+        final String garbageText = "Sorry, I cannot estimate the meal from that description.";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", garbageText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("unknown meal", null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimate emits MealEstimateException when Claude response has empty content list")
+    void estimate_EmptyContent_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of("content", List.of());
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("Pasta", null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimate emits MealEstimateException when Claude API returns HTTP 401")
+    void estimate_ApiReturns401_EmitsMealEstimateException() {
+        final WebClientResponseException unauthorizedException = WebClientResponseException.create(
+                401, "Unauthorized", HttpHeaders.EMPTY, new byte[0], null);
+        stubWebClientChain(Mono.error(unauthorizedException));
+
+        StepVerifier.create(mealEstimator.estimate("Currywurst", null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimate emits MealEstimateException when Claude returns valid JSON with null kcal")
+    void estimate_EmptyJsonObject_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("text", "{}"))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("mystery dish", null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MealEstimator` service — mirrors `LabelReader` but text-only; calls Claude `claude-sonnet-4-6` with a single user text block asking for strict JSON with keys `kcal, proteinG, carbsG, fatG, assumptions`
- Add `POST /nutrition/estimate` via `MealEstimateController` accepting `MealEstimateRequest` (`description` required, `portionHint` optional) and returning `MealEstimateDTO`
- Add `MealEstimateException` (mirrors `LabelReadException`) and map it to HTTP 422 in `NutritionExceptionHandler`
- Reuses existing `nutrition.claude.api-key` config — no new config or migrations needed

## Test plan

- [x] `MealEstimatorTest` — WebClient mock chain covering: valid JSON (assert all macros + assumptions), valid JSON with portionHint, garbage text → exception, empty content list → exception, HTTP 401 → exception, empty `{}` (null kcal) → exception
- [x] `MealEstimateRequestValidationTest` — blank/null description rejected, oversized description (>500) rejected, oversized portionHint (>255) rejected, valid requests pass
- [x] `MealEstimateControllerTest` — success without portionHint (200), success with portionHint (200), estimator failure propagates `MealEstimateException`
- [x] `./gradlew :nutrition:build` passes with zero checkstyle warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)