### PR TITLE
feat(nutrition): barcode lookup via OpenFoodFacts (#109)

### DIFF
--- a/.claude/agent-memory/java-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/java-code-reviewer/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [Nutrition Claude integration pattern](project_nutrition_claude_pattern.md) — how Claude-backed services (LabelReader, MealEstimator) are structured in the nutrition module
 - [No Bash tool in review sessions](feedback_no_bash_build.md) — cannot run ./gradlew; reviews are static-analysis only unless a Bash tool is present
+- [OpenFoodFacts v2 API](reference_openfoodfacts_api.md) — unknown barcodes return HTTP 200 + status:0 (not 404); affects BarcodeLookup not-found review

--- a/.claude/agent-memory/java-code-reviewer/reference_openfoodfacts_api.md
+++ b/.claude/agent-memory/java-code-reviewer/reference_openfoodfacts_api.md
@@ -1,0 +1,12 @@
+---
+name: openfoodfacts-api
+description: OpenFoodFacts v2 product API not-found semantics — returns HTTP 200 with status:0, not 404
+metadata:
+  type: reference
+---
+
+The `BarcodeLookup` service (nutrition module) queries OpenFoodFacts v2: `GET /api/v2/product/{ean}.json`.
+
+**Key non-obvious behavior (verified live 2026-06-07):** for an unknown/invalid barcode the API returns **HTTP 200** with body `{"code":..., "status":0, "status_verbose":"..."}` and **no `product` object** — it does NOT return HTTP 404.
+
+**How to apply:** When reviewing `BarcodeLookup` not-found handling, the real not-found signal is the absent `product` field in `parseResponse` (emits `NoSuchElementException`), not the `HttpStatus.NOT_FOUND` branch in `onErrorMap` — that 404 branch is defensive and rarely fires. Tests should (and do) cover the absent-product path, not just a mocked 404. Nutriment fields (`*_100g`) are user-contributed and may be missing or string-typed; code guards by requiring name + kcal else 422. See [[nutrition-claude-pattern]] for the shared transient-DTO conventions.

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.controller;
 
 import com.marvin.nutrition.dto.FoodDTO;
 import com.marvin.nutrition.dto.FoodDraftDTO;
+import com.marvin.nutrition.service.BarcodeLookup;
 import com.marvin.nutrition.service.FoodService;
 import com.marvin.nutrition.service.LabelReader;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,16 +51,19 @@ public class FoodController {
 
     private final FoodService foodService;
     private final LabelReader labelReader;
+    private final BarcodeLookup barcodeLookup;
 
     /**
      * Creates a new FoodController with the required services.
      *
-     * @param foodService the service handling food catalog operations
-     * @param labelReader the service that reads nutrition labels via Claude
+     * @param foodService   the service handling food catalog operations
+     * @param labelReader   the service that reads nutrition labels via Claude
+     * @param barcodeLookup the service that looks up food data by EAN barcode on OpenFoodFacts
      */
-    public FoodController(FoodService foodService, LabelReader labelReader) {
+    public FoodController(FoodService foodService, LabelReader labelReader, BarcodeLookup barcodeLookup) {
         this.foodService = foodService;
         this.labelReader = labelReader;
+        this.barcodeLookup = barcodeLookup;
     }
 
     /**
@@ -219,6 +223,38 @@ public class FoodController {
         LOGGER.info("Received scan-label request: filename={}", filePart.filename());
         return extractBytes(filePart)
                 .flatMap(labelReader::readLabel)
+                .map(draft -> ResponseEntity.ok()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(draft));
+    }
+
+    /**
+     * Looks up a food product by EAN barcode on OpenFoodFacts and returns a transient draft food.
+     * Nothing is persisted. Results are cached in-memory for repeated lookups.
+     *
+     * @param ean the EAN-8, EAN-13 or EAN-14 barcode (digits only, 8–14 characters)
+     * @return a Mono with 200 OK and the parsed draft food DTO
+     */
+    @GetMapping("/barcode/{ean}")
+    @Operation(
+            summary = "Look up food by barcode",
+            description = "Queries OpenFoodFacts for the given EAN barcode and returns a transient draft food with per-100g macros. "
+                    + "Results are cached. Nothing is persisted.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Barcode found; draft food returned",
+                        content = @Content(schema = @Schema(implementation = FoodDraftDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Invalid barcode format"),
+                @ApiResponse(responseCode = "404", description = "Barcode not found on OpenFoodFacts"),
+                @ApiResponse(responseCode = "422", description = "Barcode found but no usable nutrition data")
+            }
+    )
+    public Mono<ResponseEntity<FoodDraftDTO>> lookupBarcode(
+            @PathVariable @Parameter(description = "EAN-8, EAN-13 or EAN-14 barcode (digits only)") String ean) {
+        LOGGER.info("Received barcode lookup request: ean={}", ean);
+        return barcodeLookup.lookup(ean)
                 .map(draft -> ResponseEntity.ok()
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(draft));

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.marvin.nutrition.controller;
 
+import com.marvin.nutrition.service.BarcodeLookupException;
 import com.marvin.nutrition.service.LabelReadException;
 import com.marvin.nutrition.service.MealEstimateException;
 import com.marvin.nutrition.service.TargetCalculationException;
@@ -81,6 +82,17 @@ public class NutritionExceptionHandler {
      */
     @ExceptionHandler(MealEstimateException.class)
     public ResponseEntity<String> handleMealEstimate(MealEstimateException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link BarcodeLookupException} to HTTP 422 Unprocessable Entity.
+     *
+     * @param ex the exception indicating the barcode was found but returned no usable nutrition data
+     * @return 422 response with the exception message
+     */
+    @ExceptionHandler(BarcodeLookupException.class)
+    public ResponseEntity<String> handleBarcodeLookup(BarcodeLookupException ex) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
     }
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDraftDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/FoodDraftDTO.java
@@ -5,20 +5,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 
 /**
- * Transient draft food parsed from a nutrition label photo.
- * This record is never persisted — it represents raw values read by Claude
- * directly from a packaged food's nutrition label image.
+ * Transient draft food sourced from either a Claude nutrition-label scan or an OpenFoodFacts
+ * barcode lookup. This record is never persisted — it carries raw per-100 g values and an
+ * optional serving size until the caller decides whether to save a {@code FoodEntity}.
  *
  * @param name          food product name
- * @param brand         optional brand name; null if not visible on label
- * @param kcalPer100    kilocalories per 100 g, normalised from the label
- * @param proteinPer100 grams of protein per 100 g, normalised from the label
- * @param carbsPer100   grams of carbohydrates per 100 g, normalised from the label
- * @param fatPer100     grams of fat per 100 g, normalised from the label
- * @param fiberPer100   grams of dietary fibre per 100 g; null if not present on label
- * @param servingG      suggested serving size in grams; null if not present on label
+ * @param brand         optional brand name; null if not available from the source
+ * @param kcalPer100    kilocalories per 100 g
+ * @param proteinPer100 grams of protein per 100 g
+ * @param carbsPer100   grams of carbohydrates per 100 g
+ * @param fatPer100     grams of fat per 100 g
+ * @param fiberPer100   grams of dietary fibre per 100 g; null if not provided by the source
+ * @param servingG      suggested serving size in grams; null if not provided by the source
  */
-@Schema(description = "Transient food draft parsed from a nutrition label photo — never persisted")
+@Schema(description = "Transient food draft from a label scan or barcode lookup — never persisted")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FoodDraftDTO(
         @Schema(description = "Food product name", example = "Müsli")

--- a/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookup.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookup.java
@@ -1,11 +1,11 @@
 package com.marvin.nutrition.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marvin.nutrition.dto.FoodDraftDTO;
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,20 +27,36 @@ public class BarcodeLookup {
     private static final String USER_AGENT = "backend-nutrition/1.0 (geitnermarvin@googlemail.com)";
     private static final String EAN_PATTERN = "\\d{8,14}";
 
+    /**
+     * Maximum number of barcodes retained in the LRU cache.
+     * Once this limit is reached the least-recently-accessed entry is evicted,
+     * keeping memory consumption bounded regardless of how many distinct barcodes are scanned.
+     */
+    private static final int MAX_CACHE_ENTRIES = 500;
+
     private final WebClient webClient;
-    private final Map<String, FoodDraftDTO> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Bounded LRU cache: access-order {@link LinkedHashMap} capped at {@link #MAX_CACHE_ENTRIES},
+     * wrapped in {@link Collections#synchronizedMap} for thread safety.
+     */
+    private final Map<String, FoodDraftDTO> cache = Collections.synchronizedMap(
+            new LinkedHashMap<>(MAX_CACHE_ENTRIES, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, FoodDraftDTO> eldest) {
+                    return size() > MAX_CACHE_ENTRIES;
+                }
+            });
 
     /**
      * Creates a new BarcodeLookup service.
      *
      * @param webClientBuilder the Spring WebClient builder
      * @param baseUrl          the OpenFoodFacts base URL (from {@code nutrition.openfoodfacts.base-url})
-     * @param objectMapper     Jackson mapper (reserved for future use; kept for consistency with LabelReader)
      */
     public BarcodeLookup(
             WebClient.Builder webClientBuilder,
-            @Value("${nutrition.openfoodfacts.base-url:https://world.openfoodfacts.org}") String baseUrl,
-            ObjectMapper objectMapper) {
+            @Value("${nutrition.openfoodfacts.base-url:https://world.openfoodfacts.org}") String baseUrl) {
         this.webClient = webClientBuilder
                 .baseUrl(baseUrl)
                 .defaultHeader("User-Agent", USER_AGENT)

--- a/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookup.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookup.java
@@ -1,0 +1,148 @@
+package com.marvin.nutrition.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.FoodDraftDTO;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Looks up food nutrition data from the OpenFoodFacts API by EAN barcode.
+ * Returns a transient {@link FoodDraftDTO} — nothing is persisted.
+ * Successful lookups are cached in-memory to avoid redundant HTTP calls.
+ */
+@Service
+public class BarcodeLookup {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BarcodeLookup.class);
+    private static final String USER_AGENT = "backend-nutrition/1.0 (geitnermarvin@googlemail.com)";
+    private static final String EAN_PATTERN = "\\d{8,14}";
+
+    private final WebClient webClient;
+    private final Map<String, FoodDraftDTO> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new BarcodeLookup service.
+     *
+     * @param webClientBuilder the Spring WebClient builder
+     * @param baseUrl          the OpenFoodFacts base URL (from {@code nutrition.openfoodfacts.base-url})
+     * @param objectMapper     Jackson mapper (reserved for future use; kept for consistency with LabelReader)
+     */
+    public BarcodeLookup(
+            WebClient.Builder webClientBuilder,
+            @Value("${nutrition.openfoodfacts.base-url:https://world.openfoodfacts.org}") String baseUrl,
+            ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder
+                .baseUrl(baseUrl)
+                .defaultHeader("User-Agent", USER_AGENT)
+                .build();
+    }
+
+    /**
+     * Looks up the food product identified by the given EAN barcode on OpenFoodFacts.
+     * The EAN must be 8–14 digits. Results are cached; a cache hit skips the HTTP call.
+     *
+     * @param ean the EAN-8, EAN-13, or EAN-14 barcode string (digits only)
+     * @return a Mono emitting the parsed draft food, or an error if the lookup fails
+     */
+    public Mono<FoodDraftDTO> lookup(String ean) {
+        if (ean == null || ean.isBlank() || !ean.matches(EAN_PATTERN)) {
+            return Mono.error(new IllegalArgumentException("Invalid barcode: " + ean));
+        }
+
+        return Mono.defer(() -> {
+            final FoodDraftDTO cached = cache.get(ean);
+            if (cached != null) {
+                LOGGER.info("Cache hit for barcode {}", ean);
+                return Mono.just(cached);
+            }
+
+            LOGGER.info("Looking up barcode {} on OpenFoodFacts", ean);
+
+            return webClient.get()
+                    .uri("/api/v2/product/" + ean + ".json?fields=product_name,brands,nutriments,serving_quantity")
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .onErrorMap(WebClientResponseException.class, e -> {
+                        if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                            return new NoSuchElementException("Barcode not found: " + ean);
+                        }
+                        return new BarcodeLookupException("OpenFoodFacts request failed: " + e.getStatusCode(), e);
+                    })
+                    .flatMap(response -> parseResponse(response, ean))
+                    .doOnSuccess(draft -> {
+                        cache.put(ean, draft);
+                        LOGGER.info("Barcode lookup succeeded: name={}", draft.name());
+                    })
+                    .doOnError(e -> LOGGER.error("Barcode lookup failed for EAN {}", ean, e));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<FoodDraftDTO> parseResponse(Map<?, ?> response, String ean) {
+        final Object productObj = response.get("product");
+        if (!(productObj instanceof Map)) {
+            return Mono.error(new NoSuchElementException("Barcode not found: " + ean));
+        }
+        final Map<?, ?> product = (Map<?, ?>) productObj;
+        final Object nutrimentsObj = product.get("nutriments");
+        final Map<?, ?> nutriments = nutrimentsObj instanceof Map ? (Map<?, ?>) nutrimentsObj : Map.of();
+
+        final String name = product.get("product_name") instanceof String s ? s : null;
+        final String brandsRaw = product.get("brands") instanceof String s ? s : null;
+        final String brand = parseBrand(brandsRaw);
+
+        final BigDecimal kcalPer100 = toBigDecimal(nutriments.get("energy-kcal_100g"));
+        final BigDecimal proteinPer100 = toBigDecimal(nutriments.get("proteins_100g"));
+        final BigDecimal carbsPer100 = toBigDecimal(nutriments.get("carbohydrates_100g"));
+        final BigDecimal fatPer100 = toBigDecimal(nutriments.get("fat_100g"));
+        final BigDecimal fiberPer100 = toBigDecimal(nutriments.get("fiber_100g"));
+        final BigDecimal servingG = toBigDecimal(product.get("serving_quantity"));
+
+        if (name == null || name.isBlank() || kcalPer100 == null) {
+            return Mono.error(new BarcodeLookupException(
+                    "OpenFoodFacts returned no usable nutrition data for barcode: " + ean));
+        }
+
+        final FoodDraftDTO draft = new FoodDraftDTO(name, brand, kcalPer100, proteinPer100, carbsPer100,
+                fatPer100, fiberPer100, servingG);
+        return Mono.just(draft);
+    }
+
+    private String parseBrand(String brandsRaw) {
+        if (brandsRaw == null || brandsRaw.isBlank()) {
+            return null;
+        }
+        final String first = brandsRaw.split(",")[0].trim();
+        return first.isBlank() ? null : first;
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return new BigDecimal(number.toString());
+        }
+        if (value instanceof String s) {
+            if (s.isBlank()) {
+                return null;
+            }
+            try {
+                return new BigDecimal(s);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookupException.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/BarcodeLookupException.java
@@ -1,0 +1,24 @@
+package com.marvin.nutrition.service;
+
+/** Thrown when an OpenFoodFacts barcode lookup fails or returns no usable nutrition data. */
+public class BarcodeLookupException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the given explanatory message.
+     *
+     * @param message human-readable reason the barcode lookup failed
+     */
+    public BarcodeLookupException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the given message and root cause.
+     *
+     * @param message human-readable reason the barcode lookup failed
+     * @param cause   the underlying exception
+     */
+    public BarcodeLookupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 import com.marvin.nutrition.dto.FoodDTO;
 import com.marvin.nutrition.dto.FoodDraftDTO;
 import com.marvin.nutrition.entity.FoodSource;
+import com.marvin.nutrition.service.BarcodeLookup;
+import com.marvin.nutrition.service.BarcodeLookupException;
 import com.marvin.nutrition.service.FoodService;
 import com.marvin.nutrition.service.LabelReadException;
 import com.marvin.nutrition.service.LabelReader;
@@ -43,6 +45,9 @@ class FoodControllerTest {
 
     @Mock
     private LabelReader labelReader;
+
+    @Mock
+    private BarcodeLookup barcodeLookup;
 
     @Mock
     private FilePart filePart;
@@ -289,5 +294,61 @@ class FoodControllerTest {
         StepVerifier.create(result)
                 .expectError(LabelReadException.class)
                 .verify();
+    }
+
+    @Test
+    @DisplayName("lookupBarcode returns 200 with draft DTO when barcode lookup succeeds")
+    void lookupBarcode_Success_Returns200WithDraft() {
+        final FoodDraftDTO draft = new FoodDraftDTO(
+                "Nutella", "Ferrero",
+                new BigDecimal("539"), new BigDecimal("6.3"),
+                new BigDecimal("57.5"), new BigDecimal("30.9"),
+                new BigDecimal("0"), new BigDecimal("15")
+        );
+        when(barcodeLookup.lookup("3017620422003")).thenReturn(Mono.just(draft));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.lookupBarcode("3017620422003");
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Nutella", response.getBody().name());
+                    assertEquals("Ferrero", response.getBody().brand());
+                    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+                })
+                .verifyComplete();
+
+        verify(barcodeLookup).lookup("3017620422003");
+    }
+
+    @Test
+    @DisplayName("lookupBarcode propagates NoSuchElementException when barcode is not found")
+    void lookupBarcode_NotFound_PropagatesNoSuchElementException() {
+        when(barcodeLookup.lookup("9999999999999"))
+                .thenReturn(Mono.error(new NoSuchElementException("Barcode not found: 9999999999999")));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.lookupBarcode("9999999999999");
+
+        StepVerifier.create(result)
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(barcodeLookup).lookup("9999999999999");
+    }
+
+    @Test
+    @DisplayName("lookupBarcode propagates BarcodeLookupException when no usable nutrition data")
+    void lookupBarcode_NoUsableData_PropagatesBarcodeLookupException() {
+        when(barcodeLookup.lookup("3017620422003"))
+                .thenReturn(Mono.error(new BarcodeLookupException("OpenFoodFacts returned no usable nutrition data")));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.lookupBarcode("3017620422003");
+
+        StepVerifier.create(result)
+                .expectError(BarcodeLookupException.class)
+                .verify();
+
+        verify(barcodeLookup).lookup("3017620422003");
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/BarcodeLookupTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/BarcodeLookupTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marvin.nutrition.dto.FoodDraftDTO;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -58,7 +57,7 @@ class BarcodeLookupTest {
         when(webClientBuilder.defaultHeader(any(String.class), any(String.class))).thenReturn(webClientBuilder);
         when(webClientBuilder.build()).thenReturn(webClient);
 
-        barcodeLookup = new BarcodeLookup(webClientBuilder, "https://world.openfoodfacts.org", new ObjectMapper());
+        barcodeLookup = new BarcodeLookup(webClientBuilder, "https://world.openfoodfacts.org");
     }
 
     @SuppressWarnings("unchecked")

--- a/nutrition/src/test/java/com/marvin/nutrition/service/BarcodeLookupTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/BarcodeLookupTest.java
@@ -1,0 +1,224 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.FoodDraftDTO;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link BarcodeLookup} covering success, caching, and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BarcodeLookupTest")
+class BarcodeLookupTest {
+
+    private static final String VALID_EAN = "3017620422003";
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec<?> requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private BarcodeLookup barcodeLookup;
+
+    /** Sets up the WebClient mock chain and creates the service under test. */
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClientBuilder.baseUrl(any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.defaultHeader(any(String.class), any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(webClient);
+
+        barcodeLookup = new BarcodeLookup(webClientBuilder, "https://world.openfoodfacts.org", new ObjectMapper());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubWebClientChain(Mono<?> responseMono) {
+        doReturn(requestHeadersUriSpec).when(webClient).get();
+        doReturn(requestHeadersSpec).when(requestHeadersUriSpec).uri(any(String.class));
+        doReturn(responseSpec).when(requestHeadersSpec).retrieve();
+        doReturn(responseMono).when(responseSpec).bodyToMono(any(Class.class));
+    }
+
+    private Map<String, Object> buildOffResponse() {
+        final Map<String, Object> nutriments = Map.of(
+                "energy-kcal_100g", 539,
+                "proteins_100g", 6.3,
+                "carbohydrates_100g", 57.5,
+                "fat_100g", 30.9,
+                "fiber_100g", 0
+        );
+        final Map<String, Object> product = Map.of(
+                "product_name", "Nutella",
+                "brands", "Ferrero, Nutella",
+                "serving_quantity", 15,
+                "nutriments", nutriments
+        );
+        return Map.of("code", VALID_EAN, "status", 1, "product", product);
+    }
+
+    @Test
+    @DisplayName("lookup returns parsed FoodDraftDTO with correct per-100g values and first brand")
+    void lookup_ValidResponse_ReturnsParsedDTO() {
+        stubWebClientChain(Mono.just(buildOffResponse()));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .assertNext(dto -> {
+                    assertEquals("Nutella", dto.name());
+                    assertEquals("Ferrero", dto.brand());
+                    assertEquals(0, new BigDecimal("539").compareTo(dto.kcalPer100()));
+                    assertEquals(0, new BigDecimal("6.3").compareTo(dto.proteinPer100()));
+                    assertEquals(0, new BigDecimal("57.5").compareTo(dto.carbsPer100()));
+                    assertEquals(0, new BigDecimal("30.9").compareTo(dto.fatPer100()));
+                    assertEquals(0, new BigDecimal("0").compareTo(dto.fiberPer100()));
+                    assertEquals(0, new BigDecimal("15").compareTo(dto.servingG()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("lookup returns FoodDraftDTO with null optional nutriments when fiber and serving absent")
+    void lookup_MissingOptionalNutriments_ReturnsNullOptionals() {
+        final Map<String, Object> nutriments = Map.of(
+                "energy-kcal_100g", 200,
+                "proteins_100g", 10.0,
+                "carbohydrates_100g", 25.0,
+                "fat_100g", 5.0
+        );
+        final Map<String, Object> product = Map.of(
+                "product_name", "Plain Cracker",
+                "nutriments", nutriments
+        );
+        final Map<String, Object> response = Map.of("product", product);
+        stubWebClientChain(Mono.just(response));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .assertNext(dto -> {
+                    assertEquals("Plain Cracker", dto.name());
+                    assertNull(dto.brand());
+                    assertNull(dto.fiberPer100());
+                    assertNull(dto.servingG());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("lookup returns cached result on second call without hitting WebClient again")
+    void lookup_CacheHit_DoesNotCallWebClientAgain() {
+        stubWebClientChain(Mono.just(buildOffResponse()));
+
+        final Mono<FoodDraftDTO> first = barcodeLookup.lookup(VALID_EAN);
+        final Mono<FoodDraftDTO> second = barcodeLookup.lookup(VALID_EAN);
+
+        StepVerifier.create(first).assertNext(dto -> assertEquals("Nutella", dto.name())).verifyComplete();
+        StepVerifier.create(second).assertNext(dto -> assertEquals("Nutella", dto.name())).verifyComplete();
+
+        verify(webClient, times(1)).get();
+    }
+
+    @Test
+    @DisplayName("lookup emits NoSuchElementException when product is absent in response")
+    void lookup_ProductAbsent_EmitsNoSuchElementException() {
+        final Map<String, Object> response = Map.of("status", 0);
+        stubWebClientChain(Mono.just(response));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("lookup emits NoSuchElementException when API returns HTTP 404")
+    void lookup_Http404_EmitsNoSuchElementException() {
+        final WebClientResponseException notFound = WebClientResponseException.create(
+                HttpStatus.NOT_FOUND.value(), "Not Found", HttpHeaders.EMPTY, new byte[0], null);
+        stubWebClientChain(Mono.error(notFound));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("lookup emits BarcodeLookupException when API returns HTTP 500")
+    void lookup_Http500_EmitsBarcodeLookupException() {
+        final WebClientResponseException serverError = WebClientResponseException.create(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(), "Internal Server Error", HttpHeaders.EMPTY, new byte[0], null);
+        stubWebClientChain(Mono.error(serverError));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .expectError(BarcodeLookupException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("lookup emits BarcodeLookupException when product has no name or kcal")
+    void lookup_NoUsableNutritionData_EmitsBarcodeLookupException() {
+        final Map<String, Object> product = Map.of("nutriments", Map.of());
+        final Map<String, Object> response = Map.of("product", product);
+        stubWebClientChain(Mono.just(response));
+
+        StepVerifier.create(barcodeLookup.lookup(VALID_EAN))
+                .expectError(BarcodeLookupException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("lookup emits IllegalArgumentException for blank EAN without calling WebClient")
+    void lookup_BlankEan_EmitsIllegalArgumentExceptionWithoutWebClientCall() {
+        StepVerifier.create(barcodeLookup.lookup(""))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(webClient, times(0)).get();
+    }
+
+    @Test
+    @DisplayName("lookup emits IllegalArgumentException for non-digit EAN without calling WebClient")
+    void lookup_NonDigitEan_EmitsIllegalArgumentExceptionWithoutWebClientCall() {
+        StepVerifier.create(barcodeLookup.lookup("abc"))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(webClient, times(0)).get();
+    }
+
+    @Test
+    @DisplayName("lookup emits IllegalArgumentException for too-short EAN without calling WebClient")
+    void lookup_TooShortEan_EmitsIllegalArgumentExceptionWithoutWebClientCall() {
+        StepVerifier.create(barcodeLookup.lookup("12"))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        verify(webClient, times(0)).get();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **backend** part of #109: packaged-food barcode lookup via OpenFoodFacts.

- New endpoint `GET /nutrition/foods/barcode/{ean}` queries the OpenFoodFacts v2 product API and returns a transient `FoodDraftDTO` with per-100g macros. Nothing is persisted (mirrors the existing `/scan-label` flow). The frontend then prefills/saves a `Food` with `source=BARCODE`.
- `BarcodeLookup` service:
  - Validates the EAN (8–14 digits) → `400` on invalid input.
  - Reactive `WebClient` call following the existing `LabelReader` pattern; configurable base URL via `nutrition.openfoodfacts.base-url` (defaults to the public instance), descriptive `User-Agent`.
  - In-memory `ConcurrentHashMap` cache of successful lookups — a cache hit skips the HTTP call.
  - Maps brand from the comma-separated `brands` field; extracts `energy-kcal_100g`, `proteins_100g`, `carbohydrates_100g`, `fat_100g`, `fiber_100g`, `serving_quantity`.
  - Error mapping: OFF `404` → `NoSuchElementException` (`404`); product missing → `404`; upstream/parse/no-usable-data → `BarcodeLookupException` (`422`).
- `BarcodeLookupException` mapped to `422` in `NutritionExceptionHandler`.

The `FoodSource.BARCODE` enum value already existed.

## Tests (TDD)

- New `BarcodeLookupTest`: success, missing optional nutriments, **cache hit (WebClient invoked once)**, product absent, HTTP 404 → not found, HTTP 500 → 422, no usable data, invalid EAN variants (never calls WebClient).
- New barcode-endpoint cases added to `FoodControllerTest` (additions only — existing tests untouched, verified by tdd-test-guardian).
- Full nutrition suite green; zero checkstyle warnings.

## Out of scope

Frontend camera scanner (separate frontend repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)