### PR TITLE
feat(grocery): harden receipt OCR and item validation

### DIFF
--- a/grocery/build.gradle
+++ b/grocery/build.gradle
@@ -7,7 +7,12 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.3'
     implementation 'net.sourceforge.tess4j:tess4j:5.13.0'
+    implementation 'jakarta.validation:jakarta.validation-api'
+    implementation 'org.hibernate.validator:hibernate-validator'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // EL implementation required by Hibernate Validator at test time
+    testImplementation 'org.glassfish.expressly:expressly:5.0.0'
 
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -158,7 +159,7 @@ public class ReceiptController {
     )
     public Mono<ResponseEntity<ReceiptItemDTO>> addItem(
             @PathVariable @Parameter(description = "UUID of the receipt") UUID receiptId,
-            @RequestBody AddReceiptItemRequest request) {
+            @Valid @RequestBody AddReceiptItemRequest request) {
         return receiptService.addItem(receiptId, request)
                 .map(item -> ResponseEntity.status(HttpStatus.CREATED).body(item))
                 .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
@@ -188,7 +189,7 @@ public class ReceiptController {
     public Mono<ResponseEntity<ReceiptItemDTO>> updateItem(
             @PathVariable @Parameter(description = "UUID of the receipt") UUID receiptId,
             @PathVariable @Parameter(description = "Id of the item") Long itemId,
-            @RequestBody UpdateReceiptItemRequest request) {
+            @Valid @RequestBody UpdateReceiptItemRequest request) {
         return receiptService.updateItem(receiptId, itemId, request)
                 .map(ResponseEntity::ok)
                 .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());

--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -154,6 +154,7 @@ public class ReceiptController {
                         description = "Item created",
                         content = @Content(schema = @Schema(implementation = ReceiptItemDTO.class))
                 ),
+                @ApiResponse(responseCode = "400", description = "Invalid request body (validation failed)"),
                 @ApiResponse(responseCode = "404", description = "Receipt not found")
             }
     )
@@ -183,6 +184,7 @@ public class ReceiptController {
                         description = "Item updated",
                         content = @Content(schema = @Schema(implementation = ReceiptItemDTO.class))
                 ),
+                @ApiResponse(responseCode = "400", description = "Invalid request body (validation failed)"),
                 @ApiResponse(responseCode = "404", description = "Receipt or item not found")
             }
     )

--- a/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
@@ -1,6 +1,9 @@
 package com.marvin.grocery.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 
 /**
@@ -14,12 +17,15 @@ import java.math.BigDecimal;
 public record AddReceiptItemRequest(
 
         @Schema(description = "Name of the purchased item", example = "Vollmilch 3,5%")
+        @NotBlank
         String name,
 
         @Schema(description = "Number of units purchased", example = "2")
+        @Positive
         int quantity,
 
         @Schema(description = "Price per unit in euros", example = "1.29")
+        @NotNull
         BigDecimal singlePrice
 ) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/AddReceiptItemRequest.java
@@ -24,7 +24,9 @@ public record AddReceiptItemRequest(
         @Positive
         int quantity,
 
-        @Schema(description = "Price per unit in euros", example = "1.29")
+        // Intentionally @NotNull only — negative prices are allowed to represent discount /
+        // "Preisvorteil" lines that the parser accepts. Do not add @Positive here.
+        @Schema(description = "Price per unit in euros; may be negative for discount lines", example = "1.29")
         @NotNull
         BigDecimal singlePrice
 ) {

--- a/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
@@ -24,7 +24,9 @@ public record UpdateReceiptItemRequest(
         @Positive
         int quantity,
 
-        @Schema(description = "Price per unit in euros", example = "1.29")
+        // Intentionally @NotNull only — negative prices are allowed to represent discount /
+        // "Preisvorteil" lines that the parser accepts. Do not add @Positive here.
+        @Schema(description = "Price per unit in euros; may be negative for discount lines", example = "1.29")
         @NotNull
         BigDecimal singlePrice
 ) {

--- a/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/UpdateReceiptItemRequest.java
@@ -1,6 +1,9 @@
 package com.marvin.grocery.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 
 /**
@@ -14,12 +17,15 @@ import java.math.BigDecimal;
 public record UpdateReceiptItemRequest(
 
         @Schema(description = "Name of the purchased item", example = "Vollmilch 3,5%")
+        @NotBlank
         String name,
 
         @Schema(description = "Number of units purchased", example = "2")
+        @Positive
         int quantity,
 
         @Schema(description = "Price per unit in euros", example = "1.29")
+        @NotNull
         BigDecimal singlePrice
 ) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
@@ -21,7 +21,8 @@ public class ClaudeVisionOcrProvider implements OcrProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClaudeVisionOcrProvider.class);
     private static final String MODEL = "claude-sonnet-4-6";
-    private static final int MAX_TOKENS = 1024;
+    private static final int MAX_TOKENS = 4096;
+    private static final String STOP_REASON_MAX_TOKENS = "max_tokens";
     private static final String RECEIPT_PROMPT = """
             Extract all purchased items from this German grocery receipt.
             For each item output it on its own line as: item name  price  quantity  total price
@@ -63,12 +64,31 @@ public class ClaudeVisionOcrProvider implements OcrProvider {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(ClaudeResponse.class)
-                .map(response -> {
-                    final String text = response.content().get(0).text();
-                    LOGGER.info("Claude Vision extracted {} characters", text.length());
-                    return text;
-                })
+                .map(this::extractTextFromResponse)
                 .doOnError(e -> LOGGER.error("Claude Vision API call failed", e));
+    }
+
+    /**
+     * Extracts the text of the first content block from a Claude response, guarding against
+     * empty or text-less responses and warning when the response was truncated.
+     *
+     * @param response the deserialized Claude API response
+     * @return the extracted text
+     * @throws OcrExtractionException if the response contains no usable text block
+     */
+    String extractTextFromResponse(ClaudeResponse response) {
+        if (response == null || response.content() == null || response.content().isEmpty()) {
+            throw new OcrExtractionException("Claude Vision returned no content blocks");
+        }
+        final String text = response.content().get(0).text();
+        if (text == null) {
+            throw new OcrExtractionException("Claude Vision returned a content block without text");
+        }
+        if (STOP_REASON_MAX_TOKENS.equals(response.stopReason())) {
+            LOGGER.warn("Claude Vision response was truncated at max_tokens={}; receipt items may be incomplete", MAX_TOKENS);
+        }
+        LOGGER.info("Claude Vision extracted {} characters", text.length());
+        return text;
     }
 
     private Map<String, Object> buildRequest(String base64, String mediaType) {
@@ -93,7 +113,9 @@ public class ClaudeVisionOcrProvider implements OcrProvider {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record ClaudeResponse(@JsonProperty("content") List<ContentBlock> content) {
+    record ClaudeResponse(
+            @JsonProperty("stop_reason") String stopReason,
+            @JsonProperty("content") List<ContentBlock> content) {
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record ContentBlock(@JsonProperty("text") String text) { }

--- a/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/ClaudeVisionOcrProvider.java
@@ -80,10 +80,11 @@ public class ClaudeVisionOcrProvider implements OcrProvider {
         if (response == null || response.content() == null || response.content().isEmpty()) {
             throw new OcrExtractionException("Claude Vision returned no content blocks");
         }
-        final String text = response.content().get(0).text();
-        if (text == null) {
+        final ClaudeResponse.ContentBlock firstBlock = response.content().get(0);
+        if (firstBlock == null || firstBlock.text() == null) {
             throw new OcrExtractionException("Claude Vision returned a content block without text");
         }
+        final String text = firstBlock.text();
         if (STOP_REASON_MAX_TOKENS.equals(response.stopReason())) {
             LOGGER.warn("Claude Vision response was truncated at max_tokens={}; receipt items may be incomplete", MAX_TOKENS);
         }

--- a/grocery/src/main/java/com/marvin/grocery/ocr/OcrExtractionException.java
+++ b/grocery/src/main/java/com/marvin/grocery/ocr/OcrExtractionException.java
@@ -1,0 +1,14 @@
+package com.marvin.grocery.ocr;
+
+/** Thrown when an OCR provider cannot extract usable text from a response. */
+public class OcrExtractionException extends RuntimeException {
+
+    /**
+     * Creates a new OcrExtractionException with the given message.
+     *
+     * @param message the detail message describing the extraction failure
+     */
+    public OcrExtractionException(String message) {
+        super(message);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/parser/ReceiptParserService.java
+++ b/grocery/src/main/java/com/marvin/grocery/parser/ReceiptParserService.java
@@ -22,7 +22,7 @@ public class ReceiptParserService {
             Pattern.compile("^(.+?)\\s{2,}(-?\\d{1,4}[.,]\\d{2})\\s{2,}(\\d{1,4})\\s{2,}(-?\\d{1,4}[.,]\\d{2})\\s*$");
 
     private static final Pattern TOTAL_LINE_PATTERN =
-            Pattern.compile("(?i)(summe|gesamt|total|zwischensumme|zu zahlen|bar|ec.karte|mwst|ust)");
+            Pattern.compile("(?i)\\b(summe|gesamt|total|zwischensumme|zu zahlen|bar|ec[ .-]?karte|mwst|ust)\\b");
 
     private static final Pattern DATE_PATTERN =
             Pattern.compile("(\\d{2}\\.\\d{2}\\.\\d{4})");

--- a/grocery/src/test/java/com/marvin/grocery/dto/ReceiptItemRequestValidationTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/dto/ReceiptItemRequestValidationTest.java
@@ -1,0 +1,107 @@
+package com.marvin.grocery.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.math.BigDecimal;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests that validate Bean Validation constraints on receipt item request records directly. */
+class ReceiptItemRequestValidationTest {
+
+    private final Validator validator = jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("valid AddReceiptItemRequest yields zero violations")
+    void addRequest_valid_noViolations() {
+        final AddReceiptItemRequest req = new AddReceiptItemRequest("Vollmilch", 2, new BigDecimal("1.29"));
+
+        final Set<ConstraintViolation<AddReceiptItemRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("AddReceiptItemRequest with null singlePrice yields a violation")
+    void addRequest_nullSinglePrice_yieldsViolation() {
+        final AddReceiptItemRequest req = new AddReceiptItemRequest("Vollmilch", 2, null);
+
+        final Set<ConstraintViolation<AddReceiptItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null singlePrice");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("singlePrice")),
+                "Expected the violation to be on the 'singlePrice' property"
+        );
+    }
+
+    @Test
+    @DisplayName("AddReceiptItemRequest with zero quantity yields a violation")
+    void addRequest_zeroQuantity_yieldsViolation() {
+        final AddReceiptItemRequest req = new AddReceiptItemRequest("Vollmilch", 0, new BigDecimal("1.29"));
+
+        final Set<ConstraintViolation<AddReceiptItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for zero quantity");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("quantity")),
+                "Expected the violation to be on the 'quantity' property"
+        );
+    }
+
+    @Test
+    @DisplayName("AddReceiptItemRequest with blank name yields a violation")
+    void addRequest_blankName_yieldsViolation() {
+        final AddReceiptItemRequest req = new AddReceiptItemRequest("  ", 1, new BigDecimal("1.29"));
+
+        final Set<ConstraintViolation<AddReceiptItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for blank name");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("name")),
+                "Expected the violation to be on the 'name' property"
+        );
+    }
+
+    @Test
+    @DisplayName("valid UpdateReceiptItemRequest yields zero violations")
+    void updateRequest_valid_noViolations() {
+        final UpdateReceiptItemRequest req = new UpdateReceiptItemRequest("Vollmilch", 2, new BigDecimal("1.29"));
+
+        final Set<ConstraintViolation<UpdateReceiptItemRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateReceiptItemRequest with null singlePrice yields a violation")
+    void updateRequest_nullSinglePrice_yieldsViolation() {
+        final UpdateReceiptItemRequest req = new UpdateReceiptItemRequest("Vollmilch", 2, null);
+
+        final Set<ConstraintViolation<UpdateReceiptItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null singlePrice");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("singlePrice")),
+                "Expected the violation to be on the 'singlePrice' property"
+        );
+    }
+
+    @Test
+    @DisplayName("UpdateReceiptItemRequest with zero quantity yields a violation")
+    void updateRequest_zeroQuantity_yieldsViolation() {
+        final UpdateReceiptItemRequest req = new UpdateReceiptItemRequest("Vollmilch", 0, new BigDecimal("1.29"));
+
+        final Set<ConstraintViolation<UpdateReceiptItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for zero quantity");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("quantity")),
+                "Expected the violation to be on the 'quantity' property"
+        );
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/ocr/ClaudeVisionOcrProviderTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/ocr/ClaudeVisionOcrProviderTest.java
@@ -63,4 +63,14 @@ class ClaudeVisionOcrProviderTest {
 
         assertThrows(OcrExtractionException.class, () -> provider.extractTextFromResponse(response));
     }
+
+    @Test
+    @DisplayName("Should throw when the first element of the content list is null (e.g. JSON [null])")
+    void extractTextFromResponse_nullFirstElement_throws() {
+        final List<ContentBlock> contentWithNullElement = new java.util.ArrayList<>();
+        contentWithNullElement.add(null);
+        final ClaudeResponse response = new ClaudeResponse("end_turn", contentWithNullElement);
+
+        assertThrows(OcrExtractionException.class, () -> provider.extractTextFromResponse(response));
+    }
 }

--- a/grocery/src/test/java/com/marvin/grocery/ocr/ClaudeVisionOcrProviderTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/ocr/ClaudeVisionOcrProviderTest.java
@@ -1,0 +1,66 @@
+package com.marvin.grocery.ocr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.marvin.grocery.ocr.ClaudeVisionOcrProvider.ClaudeResponse;
+import com.marvin.grocery.ocr.ClaudeVisionOcrProvider.ClaudeResponse.ContentBlock;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@DisplayName("ClaudeVisionOcrProvider Tests")
+class ClaudeVisionOcrProviderTest {
+
+    private ClaudeVisionOcrProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new ClaudeVisionOcrProvider(WebClient.builder(), "test-key");
+    }
+
+    @Test
+    @DisplayName("Should return the text of the first content block")
+    void extractTextFromResponse_validResponse_returnsText() {
+        final ClaudeResponse response =
+                new ClaudeResponse("end_turn", List.of(new ContentBlock("Milch  0.99  1  0.99")));
+
+        assertEquals("Milch  0.99  1  0.99", provider.extractTextFromResponse(response));
+    }
+
+    @Test
+    @DisplayName("Should still return text when the response was truncated")
+    void extractTextFromResponse_truncatedResponse_returnsText() {
+        final ClaudeResponse response =
+                new ClaudeResponse("max_tokens", List.of(new ContentBlock("Milch  0.99  1  0.99")));
+
+        assertEquals("Milch  0.99  1  0.99", provider.extractTextFromResponse(response));
+    }
+
+    @Test
+    @DisplayName("Should throw when the content list is empty")
+    void extractTextFromResponse_emptyContent_throws() {
+        final ClaudeResponse response = new ClaudeResponse("end_turn", List.of());
+
+        assertThrows(OcrExtractionException.class, () -> provider.extractTextFromResponse(response));
+    }
+
+    @Test
+    @DisplayName("Should throw when the content list is null")
+    void extractTextFromResponse_nullContent_throws() {
+        final ClaudeResponse response = new ClaudeResponse("end_turn", null);
+
+        assertThrows(OcrExtractionException.class, () -> provider.extractTextFromResponse(response));
+    }
+
+    @Test
+    @DisplayName("Should throw when the first content block has no text")
+    void extractTextFromResponse_nullText_throws() {
+        final ClaudeResponse response =
+                new ClaudeResponse("end_turn", List.of(new ContentBlock(null)));
+
+        assertThrows(OcrExtractionException.class, () -> provider.extractTextFromResponse(response));
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
@@ -129,6 +129,32 @@ class ReceiptParserServiceTest {
     }
 
     @Test
+    @DisplayName("Should keep an item whose name merely contains a total keyword as a substring")
+    void parse_ItemNameContainingTotalKeyword_IsKept() {
+        final String text = "Rhabarber  2.99  1  2.99";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(1, result.items().size());
+        assertEquals("Rhabarber", result.items().get(0).name());
+    }
+
+    @Test
+    @DisplayName("Should keep substring-keyword items but still exclude genuine total lines")
+    void parse_MixedKeywordItemsAndTotals_KeepsItemsExcludesTotals() {
+        final String text = "Rhabarber  2.99  1  2.99\n"
+                + "Bratwurst  3.49  2  6.98\n"
+                + "Summe  9,97\n"
+                + "Bar  10,00";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(2, result.items().size());
+        assertEquals("Rhabarber", result.items().get(0).name());
+        assertEquals("Bratwurst", result.items().get(1).name());
+    }
+
+    @Test
     @DisplayName("Should parse Claude Vision OCR sample with negative prices, quantities, and date")
     void parse_ClaudeVisionSample_ReturnsAllItemsAndDate() {
         final String text = "Cherrystrauchtomaten  2.99  2  5.98\n"

--- a/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/parser/ReceiptParserServiceTest.java
@@ -155,6 +155,39 @@ class ReceiptParserServiceTest {
     }
 
     @Test
+    @DisplayName("Should exclude 'EC-Karte' (hyphen) payment line")
+    void parse_EcKarteHyphen_IsExcluded() {
+        final String text = "Butter  1.79  1  1.79\nEC-Karte  10,00";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(1, result.items().size());
+        assertEquals("Butter", result.items().get(0).name());
+    }
+
+    @Test
+    @DisplayName("Should exclude 'EC Karte' (space) payment line")
+    void parse_EcKarteSpace_IsExcluded() {
+        final String text = "Butter  1.79  1  1.79\nEC Karte  10,00";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(1, result.items().size());
+        assertEquals("Butter", result.items().get(0).name());
+    }
+
+    @Test
+    @DisplayName("Should exclude 'EC.Karte' (dot) payment line")
+    void parse_EcKarteDot_IsExcluded() {
+        final String text = "Butter  1.79  1  1.79\nEC.Karte  10,00";
+
+        final ParsedReceipt result = parserService.parse(text);
+
+        assertEquals(1, result.items().size());
+        assertEquals("Butter", result.items().get(0).name());
+    }
+
+    @Test
     @DisplayName("Should parse Claude Vision OCR sample with negative prices, quantities, and date")
     void parse_ClaudeVisionSample_ReturnsAllItemsAndDate() {
         final String text = "Cherrystrauchtomaten  2.99  2  5.98\n"


### PR DESCRIPTION
## Summary
Hardens the grocery receipt pipeline on three fronts:

- **Request validation** — add `@NotBlank`/`@Positive`/`@NotNull` to `AddReceiptItemRequest` and `UpdateReceiptItemRequest`, enforced via `@Valid` in `ReceiptController`. Adds `jakarta.validation` + Hibernate Validator (and Expressly EL for tests).
- **OCR robustness** — `ClaudeVisionOcrProvider` now guards against empty/text-less responses (`OcrExtractionException`) and warns when a response is truncated at `max_tokens`; `MAX_TOKENS` raised 1024 → 4096 to fit longer receipts.
- **Parser fix** — anchor the receipt total-line regex with word boundaries so item names that merely contain a total keyword as a substring (e.g. "Rhabarber") are no longer dropped, while genuine total lines are still excluded.

## Tests
- New `ReceiptItemRequestValidationTest` and `ClaudeVisionOcrProviderTest`.
- New parser cases for substring-keyword item names vs. real total lines.
- `./gradlew :grocery:test :grocery:checkstyleMain :grocery:checkstyleTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)