### PR TITLE
feat(nutrition): resolve foodName for meal entries (#125)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
@@ -19,6 +19,7 @@ import java.util.UUID;
  * @param proteinG    snapshotted grams of protein
  * @param carbsG      snapshotted grams of carbohydrates
  * @param fatG        snapshotted grams of fat
+ * @param foodName    resolved name of the referenced food item (null for ad-hoc entries)
  */
 @Schema(description = "A logged meal entry for a given day")
 public record MealEntryDTO(
@@ -50,6 +51,9 @@ public record MealEntryDTO(
         BigDecimal carbsG,
 
         @Schema(description = "Snapshotted grams of fat", example = "7.50")
-        BigDecimal fatG
+        BigDecimal fatG,
+
+        @Schema(description = "Resolved name of the referenced food item (null for ad-hoc entries)", example = "Chicken Breast")
+        String foodName
 ) {
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
@@ -2,7 +2,6 @@ package com.marvin.nutrition.mapper;
 
 import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.entity.MealEntryEntity;
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -30,14 +29,4 @@ public interface MealEntryMapper {
      */
     @Mapping(target = "foodName", source = "foodName")
     MealEntryDTO toDTO(MealEntryEntity entity, String foodName);
-
-    /**
-     * Maps a list of meal entry entities to their DTO representations with {@code foodName} null.
-     * Callers that need resolved food names should use {@link #toDTO(MealEntryEntity, String)} per entry.
-     *
-     * @param entities the list of meal entry entities to map
-     * @return the list of corresponding DTOs with {@code foodName} null for each entry
-     */
-    @Mapping(target = "foodName", ignore = true)
-    List<MealEntryDTO> toDTOList(List<MealEntryEntity> entities);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/MealEntryMapper.java
@@ -4,24 +4,40 @@ import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.entity.MealEntryEntity;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /** MapStruct mapper for converting between {@link MealEntryEntity} and {@link MealEntryDTO}. */
 @Mapper(componentModel = "spring")
 public interface MealEntryMapper {
 
     /**
-     * Maps a meal entry entity to its DTO representation.
+     * Maps a meal entry entity to its DTO representation with {@code foodName} set to {@code null}.
+     * Intended for ad-hoc entries where no food catalog item is referenced.
      *
      * @param entity the meal entry entity to map
-     * @return the corresponding DTO
+     * @return the corresponding DTO with {@code foodName} null
      */
+    @Mapping(target = "foodName", ignore = true)
     MealEntryDTO toDTO(MealEntryEntity entity);
 
     /**
-     * Maps a list of meal entry entities to their DTO representations.
+     * Maps a meal entry entity to its DTO representation, supplying the resolved food name.
+     * Intended for food-backed entries where the caller has already resolved the food name.
+     *
+     * @param entity   the meal entry entity to map
+     * @param foodName the resolved name of the referenced food item
+     * @return the corresponding DTO with {@code foodName} populated
+     */
+    @Mapping(target = "foodName", source = "foodName")
+    MealEntryDTO toDTO(MealEntryEntity entity, String foodName);
+
+    /**
+     * Maps a list of meal entry entities to their DTO representations with {@code foodName} null.
+     * Callers that need resolved food names should use {@link #toDTO(MealEntryEntity, String)} per entry.
      *
      * @param entities the list of meal entry entities to map
-     * @return the list of corresponding DTOs
+     * @return the list of corresponding DTOs with {@code foodName} null for each entry
      */
+    @Mapping(target = "foodName", ignore = true)
     List<MealEntryDTO> toDTOList(List<MealEntryEntity> entities);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -15,9 +15,11 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -71,11 +73,11 @@ public class MealEntryService {
             entity.setMealType(req.mealType());
 
             if (req.foodId() != null) {
-                buildFoodEntry(entity, req);
-            } else {
-                buildAdHocEntry(entity, req);
+                final String foodName = buildFoodEntry(entity, req);
+                return mealEntryMapper.toDTO(mealEntryRepository.save(entity), foodName);
             }
 
+            buildAdHocEntry(entity, req);
             return mealEntryMapper.toDTO(mealEntryRepository.save(entity));
         }).subscribeOn(Schedulers.boundedElastic());
     }
@@ -101,11 +103,11 @@ public class MealEntryService {
             }
 
             if (entity.getFoodId() != null) {
-                applyFoodEntryUpdate(entity, req);
-            } else {
-                applyAdHocEntryUpdate(entity, req);
+                final String foodName = applyFoodEntryUpdate(entity, req);
+                return mealEntryMapper.toDTO(mealEntryRepository.save(entity), foodName);
             }
 
+            applyAdHocEntryUpdate(entity, req);
             return mealEntryMapper.toDTO(mealEntryRepository.save(entity));
         }).subscribeOn(Schedulers.boundedElastic());
     }
@@ -138,7 +140,16 @@ public class MealEntryService {
         final Mono<List<MealEntryDTO>> entriesMono = Mono.fromCallable(() -> {
             final List<MealEntryEntity> entities =
                     mealEntryRepository.findByEntryDateOrderByCreationDateAsc(date);
-            return mealEntryMapper.toDTOList(entities);
+            final List<UUID> foodIds = entities.stream()
+                    .map(MealEntryEntity::getFoodId)
+                    .filter(fid -> fid != null)
+                    .distinct()
+                    .collect(Collectors.toList());
+            final Map<UUID, String> foodNameById = foodRepository.findAllById(foodIds).stream()
+                    .collect(Collectors.toMap(FoodEntity::getId, FoodEntity::getName));
+            return entities.stream()
+                    .map(e -> mealEntryMapper.toDTO(e, foodNameById.get(e.getFoodId())))
+                    .collect(Collectors.toList());
         }).subscribeOn(Schedulers.boundedElastic());
 
         final Mono<Optional<TargetsDTO>> targetsMono = nutritionTargetService.getTargets()
@@ -154,8 +165,9 @@ public class MealEntryService {
      *
      * @param entity the entity to populate
      * @param req    the create request
+     * @return the name of the referenced food item
      */
-    private void buildFoodEntry(MealEntryEntity entity, CreateMealEntryRequest req) {
+    private String buildFoodEntry(MealEntryEntity entity, CreateMealEntryRequest req) {
         final FoodEntity food = foodRepository.findById(req.foodId())
                 .orElseThrow(() -> new NoSuchElementException("Food not found: " + req.foodId()));
 
@@ -170,6 +182,7 @@ public class MealEntryService {
         entity.setProteinG(snapshot(food.getProteinPer100(), req.quantityG()));
         entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
         entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
+        return food.getName();
     }
 
     /**
@@ -194,20 +207,23 @@ public class MealEntryService {
 
     /**
      * Applies update fields for a food-backed entry, re-snapshotting macros if quantity changed.
+     * Always resolves and returns the food name so the caller can populate {@code foodName} on the DTO.
      *
      * @param entity the entity to update
      * @param req    the update request
+     * @return the name of the referenced food item
      */
-    private void applyFoodEntryUpdate(MealEntryEntity entity, UpdateMealEntryRequest req) {
+    private String applyFoodEntryUpdate(MealEntryEntity entity, UpdateMealEntryRequest req) {
+        final FoodEntity food = foodRepository.findById(entity.getFoodId())
+                .orElseThrow(() -> new NoSuchElementException("Food not found: " + entity.getFoodId()));
         if (req.quantityG() != null) {
-            final FoodEntity food = foodRepository.findById(entity.getFoodId())
-                    .orElseThrow(() -> new NoSuchElementException("Food not found: " + entity.getFoodId()));
             entity.setQuantityG(req.quantityG());
             entity.setKcal(snapshot(food.getKcalPer100(), req.quantityG()));
             entity.setProteinG(snapshot(food.getProteinPer100(), req.quantityG()));
             entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
             entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
         }
+        return food.getName();
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
@@ -58,7 +58,7 @@ class MealEntryControllerTest {
         mealEntryDTO = new MealEntryDTO(
                 entryId, today, MealType.LUNCH, null, "Salad", null,
                 new BigDecimal("300.00"), new BigDecimal("20.00"),
-                new BigDecimal("40.00"), new BigDecimal("10.00")
+                new BigDecimal("40.00"), new BigDecimal("10.00"), null
         );
 
         createRequest = new CreateMealEntryRequest(
@@ -146,7 +146,7 @@ class MealEntryControllerTest {
         final MealEntryDTO updatedDTO = new MealEntryDTO(
                 entryId, today, MealType.DINNER, null, "Updated salad", null,
                 new BigDecimal("300.00"), new BigDecimal("20.00"),
-                new BigDecimal("40.00"), new BigDecimal("10.00")
+                new BigDecimal("40.00"), new BigDecimal("10.00"), null
         );
 
         when(mealEntryService.updateEntry(eq(entryId), any(UpdateMealEntryRequest.class)))

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -1,7 +1,10 @@
 package com.marvin.nutrition.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,6 +70,7 @@ class MealEntryServiceTest {
         today = LocalDate.of(2026, 6, 7);
 
         foodEntity = new FoodEntity();
+        foodEntity.setName("Test Food");
         foodEntity.setKcalPer100(new BigDecimal("200.00"));
         foodEntity.setProteinPer100(new BigDecimal("20.00"));
         foodEntity.setCarbsPer100(new BigDecimal("10.00"));
@@ -84,7 +88,7 @@ class MealEntryServiceTest {
                 entryId, today, MealType.LUNCH, foodId, null,
                 new BigDecimal("150.00"),
                 new BigDecimal("300.00"), new BigDecimal("30.00"),
-                new BigDecimal("15.00"), new BigDecimal("7.50")
+                new BigDecimal("15.00"), new BigDecimal("7.50"), "Test Food"
         );
     }
 
@@ -101,7 +105,7 @@ class MealEntryServiceTest {
 
         when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
-        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
 
         StepVerifier.create(mealEntryService.addEntry(today, req))
                 .expectNext(mealEntryDTO)
@@ -126,7 +130,7 @@ class MealEntryServiceTest {
 
         when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
-        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
 
         StepVerifier.create(mealEntryService.addEntry(today, req))
                 .expectNextCount(1)
@@ -160,7 +164,7 @@ class MealEntryServiceTest {
         final MealEntryDTO adHocDTO = new MealEntryDTO(
                 UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
                 new BigDecimal("250.00"), new BigDecimal("15.00"),
-                new BigDecimal("30.00"), new BigDecimal("8.00")
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
         );
 
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
@@ -263,7 +267,7 @@ class MealEntryServiceTest {
         when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
         when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
-        when(mealEntryMapper.toDTO(mealEntryEntity)).thenReturn(mealEntryDTO);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
 
         StepVerifier.create(mealEntryService.updateEntry(entryId, req))
                 .expectNextCount(1)
@@ -300,7 +304,7 @@ class MealEntryServiceTest {
         final MealEntryDTO updatedDTO = new MealEntryDTO(
                 entryId, today, MealType.DINNER, null, "New soup", null,
                 new BigDecimal("350.00"), new BigDecimal("20.00"),
-                new BigDecimal("40.00"), new BigDecimal("10.00")
+                new BigDecimal("40.00"), new BigDecimal("10.00"), null
         );
 
         when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
@@ -383,20 +387,21 @@ class MealEntryServiceTest {
         final MealEntryDTO dto1 = new MealEntryDTO(
                 UUID.randomUUID(), today, MealType.BREAKFAST, null, "Oats", null,
                 new BigDecimal("400.00"), new BigDecimal("30.00"),
-                new BigDecimal("50.00"), new BigDecimal("10.00")
+                new BigDecimal("50.00"), new BigDecimal("10.00"), null
         );
         final MealEntryDTO dto2 = new MealEntryDTO(
                 UUID.randomUUID(), today, MealType.LUNCH, null, "Salad", null,
                 new BigDecimal("200.00"), new BigDecimal("10.00"),
-                new BigDecimal("25.00"), new BigDecimal("5.00")
+                new BigDecimal("25.00"), new BigDecimal("5.00"), null
         );
 
         final TargetsDTO targets = new TargetsDTO(1700, 2200, 2000, 150, 67, 248, "MIFFLIN_ST_JEOR");
 
         when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
                 .thenReturn(List.of(entry1, entry2));
-        when(mealEntryMapper.toDTOList(List.of(entry1, entry2)))
-                .thenReturn(List.of(dto1, dto2));
+        when(foodRepository.findAllById(any())).thenReturn(List.of());
+        when(mealEntryMapper.toDTO(any(MealEntryEntity.class), isNull()))
+                .thenReturn(dto1, dto2);
         when(nutritionTargetService.getTargets()).thenReturn(Mono.just(targets));
 
         StepVerifier.create(mealEntryService.getDay(today))
@@ -426,7 +431,7 @@ class MealEntryServiceTest {
     void getDay_TargetCalculationException_ReturnsNullTargetsAndRemaining() {
         when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
                 .thenReturn(List.of());
-        when(mealEntryMapper.toDTOList(List.of())).thenReturn(List.of());
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
         when(nutritionTargetService.getTargets())
                 .thenReturn(Mono.error(new TargetCalculationException("No profile")));
 
@@ -444,7 +449,7 @@ class MealEntryServiceTest {
     void getDay_EmptyDay_ReturnsZeroTotals() {
         when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
                 .thenReturn(List.of());
-        when(mealEntryMapper.toDTOList(List.of())).thenReturn(List.of());
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
         when(nutritionTargetService.getTargets())
                 .thenReturn(Mono.error(new TargetCalculationException("No data")));
 
@@ -456,5 +461,161 @@ class MealEntryServiceTest {
                     assert BigDecimal.ZERO.compareTo(summary.totals().fatG()) == 0;
                 })
                 .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // foodName population
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry populates foodName from food catalog for food-backed entry")
+    void addEntry_FoodEntry_PopulatesFoodName() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .assertNext(dto -> assertEquals("Test Food", dto.foodName()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("addEntry leaves foodName null for ad-hoc entry")
+    void addEntry_AdHocEntry_FoodNameIsNull() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity saved = new MealEntryEntity();
+        saved.setDescription("Homemade soup");
+        saved.setKcal(new BigDecimal("250.00"));
+        saved.setProteinG(new BigDecimal("15.00"));
+        saved.setCarbsG(new BigDecimal("30.00"));
+        saved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
+        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .assertNext(dto -> assertNull(dto.foodName()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateEntry populates foodName for food-backed entry")
+    void updateEntry_FoodEntry_PopulatesFoodName() {
+        mealEntryEntity.setFoodId(foodId);
+        mealEntryEntity.setQuantityG(new BigDecimal("150"));
+
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null, new BigDecimal("150"), null, null, null, null, null
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .assertNext(dto -> assertEquals("Test Food", dto.foodName()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateEntry leaves foodName null for ad-hoc entry")
+    void updateEntry_AdHocEntry_FoodNameIsNull() {
+        mealEntryEntity.setFoodId(null);
+        mealEntryEntity.setDescription("Old soup");
+        mealEntryEntity.setKcal(new BigDecimal("100.00"));
+
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null, null, "Updated soup", null, null, null, null
+        );
+
+        final MealEntryEntity savedEntity = new MealEntryEntity();
+        savedEntity.setDescription("Updated soup");
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                entryId, today, MealType.LUNCH, null, "Updated soup", null,
+                new BigDecimal("100.00"), new BigDecimal("0.00"),
+                new BigDecimal("0.00"), new BigDecimal("0.00"), null
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(savedEntity);
+        when(mealEntryMapper.toDTO(savedEntity)).thenReturn(adHocDTO);
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .assertNext(dto -> assertNull(dto.foodName()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getDay resolves foodName via batch lookup for food-backed entries")
+    void getDay_FoodBackedEntries_ResolvesFoodNameViaBatchLookup() {
+        final UUID foodId2 = UUID.randomUUID();
+
+        final FoodEntity food2 = new FoodEntity();
+        food2.setId(foodId2);
+        food2.setName("Brown Rice");
+
+        foodEntity.setId(foodId);
+
+        final MealEntryEntity foodEntry1 = new MealEntryEntity();
+        foodEntry1.setFoodId(foodId);
+        foodEntry1.setKcal(new BigDecimal("300.00"));
+        foodEntry1.setProteinG(new BigDecimal("20.00"));
+        foodEntry1.setCarbsG(new BigDecimal("30.00"));
+        foodEntry1.setFatG(new BigDecimal("10.00"));
+
+        final MealEntryEntity foodEntry2 = new MealEntryEntity();
+        foodEntry2.setFoodId(foodId2);
+        foodEntry2.setKcal(new BigDecimal("200.00"));
+        foodEntry2.setProteinG(new BigDecimal("5.00"));
+        foodEntry2.setCarbsG(new BigDecimal("40.00"));
+        foodEntry2.setFatG(new BigDecimal("2.00"));
+
+        final MealEntryDTO dtoWithFoodName1 = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.LUNCH, foodId, null,
+                new BigDecimal("150.00"),
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("30.00"), new BigDecimal("10.00"), "Test Food"
+        );
+        final MealEntryDTO dtoWithFoodName2 = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.DINNER, foodId2, null,
+                new BigDecimal("100.00"),
+                new BigDecimal("200.00"), new BigDecimal("5.00"),
+                new BigDecimal("40.00"), new BigDecimal("2.00"), "Brown Rice"
+        );
+
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of(foodEntry1, foodEntry2));
+        when(foodRepository.findAllById(any())).thenReturn(List.of(foodEntity, food2));
+        when(mealEntryMapper.toDTO(foodEntry1, "Test Food")).thenReturn(dtoWithFoodName1);
+        when(mealEntryMapper.toDTO(foodEntry2, "Brown Rice")).thenReturn(dtoWithFoodName2);
+        when(nutritionTargetService.getTargets())
+                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assertEquals(2, summary.entries().size());
+                    assertEquals("Test Food", summary.entries().get(0).foodName());
+                    assertEquals("Brown Rice", summary.entries().get(1).foodName());
+                })
+                .verifyComplete();
+
+        verify(foodRepository).findAllById(any());
     }
 }


### PR DESCRIPTION
Closes #125

## Problem
`MealEntryDTO` had no `foodName` field, and `MealEntryMapper` did not populate one. The frontend day summary / edit dialog uses `entry.description ?? entry.foodName ?? "Eintrag"`. For food-backed entries `description` is null and `foodName` was always `undefined`, so **every food-based meal entry displayed as the generic "Eintrag"**.

## Fix
- Add a `foodName` field to `MealEntryDTO` (null for ad-hoc entries, which keep using `description`).
- Resolve the food name in `MealEntryService`:
  - `addEntry` / `updateEntry` (food-backed): populate from the already-loaded `FoodEntity`.
  - `getDay`: resolve names via a single batch `findAllById` over the distinct food ids → no N+1 queries.
- New `toDTO(entity, foodName)` MapStruct overload supplies the resolved name; the existing `toDTO(entity)` / `toDTOList(entities)` keep `foodName` null.

## Notes
- `applyFoodEntryUpdate` now always loads the referenced food (to resolve its name) rather than only when `quantityG` changes.

## Testing
- `./gradlew :nutrition:test` — 108 tests, 0 failures (added 5 tests covering foodName population for food-backed vs ad-hoc add/update and the getDay batch lookup).
- `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — 0 warnings.
- tdd-test-guardian verified existing test assertions are unchanged; modifications are mechanical record-arity / stub-signature adaptations forced by the new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)