### PR TITLE
fix(nutrition): constrain ProfileDTO.fatPct to (0,1] and require it

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
@@ -4,6 +4,7 @@ import com.marvin.nutrition.entity.ActivityLevel;
 import com.marvin.nutrition.entity.Goal;
 import com.marvin.nutrition.entity.Sex;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
@@ -52,7 +53,9 @@ public record ProfileDTO(
         @Schema(description = "Grams of protein per kg body weight", example = "2.0")
         BigDecimal proteinPerKg,
 
+        @NotNull
         @Positive
+        @DecimalMax("1.0")
         @Schema(description = "Fraction of target calories allocated to fat (0–1)", example = "0.30")
         BigDecimal fatPct,
 

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
@@ -1,0 +1,113 @@
+package com.marvin.nutrition.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.marvin.nutrition.entity.ActivityLevel;
+import com.marvin.nutrition.entity.Goal;
+import com.marvin.nutrition.entity.Sex;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests that validate Bean Validation constraints on {@link ProfileDTO} directly. */
+public class ProfileDTOValidationTest {
+
+    private final Validator validator = jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("valid ProfileDTO yields zero violations")
+    void profile_valid_noViolations() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("0.30"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid profile");
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with null fatPct yields a violation")
+    void profile_nullFatPct_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                null,
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null fatPct");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("fatPct")),
+                "Expected the violation to be on the 'fatPct' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with fatPct greater than 1 yields a violation")
+    void profile_fatPctAboveOne_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("1.5"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for fatPct greater than 1");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("fatPct")),
+                "Expected the violation to be on the 'fatPct' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with non-positive fatPct yields a violation")
+    void profile_nonPositiveFatPct_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("0"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for non-positive fatPct");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("fatPct")),
+                "Expected the violation to be on the 'fatPct' property"
+        );
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
@@ -40,6 +40,26 @@ public class ProfileDTOValidationTest {
     }
 
     @Test
+    @DisplayName("ProfileDTO with fatPct equal to the inclusive upper bound of 1.0 yields zero violations")
+    void profile_fatPctAtUpperBound_noViolations() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("1.0"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for fatPct exactly at the inclusive upper bound 1.0");
+    }
+
+    @Test
     @DisplayName("ProfileDTO with null fatPct yields a violation")
     void profile_nullFatPct_yieldsViolation() {
         final ProfileDTO profile = new ProfileDTO(


### PR DESCRIPTION
## Summary
Resolves #126.

`ProfileDTO.fatPct` was annotated `@Positive` only — no upper bound — and was not `@NotNull` even though the `fat_pct` column is `NOT NULL`. A `fatPct > 1` passed validation, and in `TargetService.computeTargets` the resulting `proteinKcal + fatKcal` could exceed `targetKcal`, silently flooring `carbsG` to 0 and producing nonsensical macro targets with no error.

## Changes
- `ProfileDTO.fatPct`: added `@NotNull` and `@DecimalMax("1.0")` alongside the existing `@Positive`, constraining it to `(0, 1]` and aligning nullability with the entity/column.
- New `ProfileDTOValidationTest` covering: valid value, null, `> 1`, and non-positive.

## Verification
- `./gradlew :nutrition:test` ✅
- `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` ✅

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)