### PR TITLE
fix(nutrition): select first text content block from Claude response

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/LabelReader.java
@@ -5,6 +5,7 @@ import com.marvin.nutrition.dto.FoodDraftDTO;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -86,9 +87,20 @@ public class LabelReader {
         if (content == null || content.isEmpty()) {
             return Mono.error(new LabelReadException("Claude returned an empty content list"));
         }
-        final Map<?, ?> firstBlock = (Map<?, ?>) content.get(0);
-        final Object textObj = firstBlock.get("text");
-        final String text = textObj != null ? textObj.toString().trim() : "";
+        final Optional<String> text = findFirstTextBlock(content);
+        if (text.isEmpty()) {
+            return Mono.error(new LabelReadException("Claude returned no text content block"));
+        }
+        return parseDraft(text.get());
+    }
+
+    /**
+     * Parses the given text as a {@link FoodDraftDTO} and validates that usable nutrition data is present.
+     *
+     * @param text the trimmed text content extracted from Claude's response
+     * @return a Mono emitting the parsed draft, or an error if parsing or validation fails
+     */
+    private Mono<FoodDraftDTO> parseDraft(String text) {
         try {
             final FoodDraftDTO draft = objectMapper.readValue(text, FoodDraftDTO.class);
             if (draft.name() == null || draft.name().isBlank() || draft.kcalPer100() == null) {
@@ -100,6 +112,27 @@ public class LabelReader {
             LOGGER.warn("Claude returned non-JSON text: {}", text);
             return Mono.error(new LabelReadException("Claude returned a non-JSON response: " + text, e));
         }
+    }
+
+    /**
+     * Finds the first content block whose {@code type} is {@code "text"} and returns its trimmed {@code text}.
+     * Blocks that are not maps, or whose type is not {@code "text"}, are skipped.
+     *
+     * @param content the list of content blocks returned by Claude
+     * @return the trimmed text of the first text block, or empty if none was found
+     */
+    private Optional<String> findFirstTextBlock(List<?> content) {
+        for (final Object blockObj : content) {
+            if (!(blockObj instanceof Map<?, ?> block)) {
+                continue;
+            }
+            if ("text".equals(String.valueOf(block.get("type")))) {
+                final Object textObj = block.get("text");
+                final String text = textObj != null ? textObj.toString().trim() : "";
+                return Optional.of(text);
+            }
+        }
+        return Optional.empty();
     }
 
     private Map<String, Object> buildRequest(String base64, String mediaType) {

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimator.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEstimator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marvin.nutrition.dto.MealEstimateDTO;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,9 +86,20 @@ public class MealEstimator {
         if (content == null || content.isEmpty()) {
             return Mono.error(new MealEstimateException("Claude returned an empty content list"));
         }
-        final Map<?, ?> firstBlock = (Map<?, ?>) content.get(0);
-        final Object textObj = firstBlock.get("text");
-        final String text = textObj != null ? textObj.toString().trim() : "";
+        final Optional<String> text = findFirstTextBlock(content);
+        if (text.isEmpty()) {
+            return Mono.error(new MealEstimateException("Claude returned no text content block"));
+        }
+        return parseEstimate(text.get());
+    }
+
+    /**
+     * Parses the given text as a {@link MealEstimateDTO} and validates that a usable kcal value is present.
+     *
+     * @param text the trimmed text content extracted from Claude's response
+     * @return a Mono emitting the parsed estimate, or an error if parsing or validation fails
+     */
+    private Mono<MealEstimateDTO> parseEstimate(String text) {
         try {
             final MealEstimateDTO estimate = objectMapper.readValue(text, MealEstimateDTO.class);
             if (estimate.kcal() == null) {
@@ -110,5 +122,26 @@ public class MealEstimator {
         final Map<String, Object> textBlock = Map.of("type", "text", "text", promptText.toString());
         final Map<String, Object> message = Map.of("role", "user", "content", List.of(textBlock));
         return Map.of("model", MODEL, "max_tokens", MAX_TOKENS, "messages", List.of(message));
+    }
+
+    /**
+     * Finds the first content block whose {@code type} is {@code "text"} and returns its trimmed {@code text}.
+     * Blocks that are not maps, or whose type is not {@code "text"}, are skipped.
+     *
+     * @param content the list of content blocks returned by Claude
+     * @return the trimmed text of the first text block, or empty if none was found
+     */
+    private Optional<String> findFirstTextBlock(List<?> content) {
+        for (final Object blockObj : content) {
+            if (!(blockObj instanceof Map<?, ?> block)) {
+                continue;
+            }
+            if ("text".equals(String.valueOf(block.get("type")))) {
+                final Object textObj = block.get("text");
+                final String text = textObj != null ? textObj.toString().trim() : "";
+                return Optional.of(text);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/LabelReaderTest.java
@@ -84,7 +84,7 @@ class LabelReaderTest {
                     "servingG": 45.0
                 }""";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", jsonText))
+                "content", List.of(Map.of("type", "text", "text", jsonText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -118,7 +118,7 @@ class LabelReaderTest {
                     "servingG": null
                 }""";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", jsonText))
+                "content", List.of(Map.of("type", "text", "text", jsonText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -138,7 +138,7 @@ class LabelReaderTest {
     void readLabel_GarbageText_EmitsLabelReadException() {
         final String garbageText = "Sorry, I cannot read the label in this image.";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", garbageText))
+                "content", List.of(Map.of("type", "text", "text", garbageText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -177,7 +177,51 @@ class LabelReaderTest {
     @DisplayName("readLabel emits LabelReadException when Claude returns valid JSON with no usable fields")
     void readLabel_EmptyJsonObject_EmitsLabelReadException() {
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", "{}"))
+                "content", List.of(Map.of("type", "text", "text", "{}"))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(labelReader.readLabel(imageBytes))
+                .expectError(LabelReadException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("readLabel returns parsed FoodDraftDTO when a non-text block precedes the text block")
+    void readLabel_LeadingNonTextBlock_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "name": "Haferflocken",
+                    "brand": "Bio",
+                    "kcalPer100": 350.0,
+                    "proteinPer100": 12.0,
+                    "carbsPer100": 60.0,
+                    "fatPer100": 7.0,
+                    "fiberPer100": 10.0,
+                    "servingG": 50.0
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(
+                        Map.of("type", "thinking", "thinking", "Let me look at this label..."),
+                        Map.of("type", "text", "text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(labelReader.readLabel(pngBytes))
+                .assertNext(dto -> {
+                    assertEquals("Haferflocken", dto.name());
+                    assertEquals(0, new BigDecimal("350.0").compareTo(dto.kcalPer100()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("readLabel emits LabelReadException when no content block has type text")
+    void readLabel_NoTextBlock_EmitsLabelReadException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "thinking", "thinking", "Hmm..."))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEstimatorTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEstimatorTest.java
@@ -80,7 +80,7 @@ class MealEstimatorTest {
                     "assumptions": "Estimated for a standard canteen portion of 400 g"
                 }""";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", jsonText))
+                "content", List.of(Map.of("type", "text", "text", jsonText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -107,7 +107,7 @@ class MealEstimatorTest {
                     "assumptions": "Used the provided portion hint of one small plate"
                 }""";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", jsonText))
+                "content", List.of(Map.of("type", "text", "text", jsonText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -125,7 +125,7 @@ class MealEstimatorTest {
     void estimate_GarbageText_EmitsMealEstimateException() {
         final String garbageText = "Sorry, I cannot estimate the meal from that description.";
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", garbageText))
+                "content", List.of(Map.of("type", "text", "text", garbageText))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 
@@ -161,7 +161,46 @@ class MealEstimatorTest {
     @DisplayName("estimate emits MealEstimateException when Claude returns valid JSON with null kcal")
     void estimate_EmptyJsonObject_EmitsMealEstimateException() {
         final Map<String, Object> claudeResponse = Map.of(
-                "content", List.of(Map.of("text", "{}"))
+                "content", List.of(Map.of("type", "text", "text", "{}"))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("mystery dish", null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimate returns parsed MealEstimateDTO when a non-text block precedes the text block")
+    void estimate_LeadingNonTextBlock_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 500.0,
+                    "proteinG": 35.0,
+                    "carbsG": 55.0,
+                    "fatG": 15.0,
+                    "assumptions": "Estimated for a standard portion"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(
+                        Map.of("type", "thinking", "thinking", "Let me think about this..."),
+                        Map.of("type", "text", "text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        StepVerifier.create(mealEstimator.estimate("Burger mit Pommes", null))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("500.0").compareTo(dto.kcal()));
+                    assertEquals("Estimated for a standard portion", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimate emits MealEstimateException when no content block has type text")
+    void estimate_NoTextBlock_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "thinking", "thinking", "Hmm..."))
         );
         stubWebClientChain(Mono.just(claudeResponse));
 


### PR DESCRIPTION
## Summary
Resolves #127.

`MealEstimator.parseClaudeResponse` and `LabelReader.parseClaudeResponse` both read `content.get(0).get("text")`, assuming the leading content block is always text. With `claude-sonnet-4-6` and no thinking enabled this holds today, but any non-text leading block (e.g. a `thinking` block if extended thinking is ever enabled) would break parsing.

## Changes
- Both services now iterate the `content` list and select the first block whose `type == "text"` (via a `findFirstTextBlock` helper), skipping non-map/non-text blocks.
- When no text block is present, the existing domain exception is emitted (`MealEstimateException` / `LabelReadException`).
- Added tests for: a leading non-text (thinking) block followed by a text block (parsed correctly), and a response with no text block (emits the domain exception).
- Existing test fixtures were updated to include the realistic `"type":"text"` field that real Claude responses always carry — assertions unchanged. (User-approved change to existing test data.)

## Verification
- `./gradlew :nutrition:test` ✅
- `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` ✅

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)