### PR TITLE
fix(nutrition): snapshot food name onto meal entries

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealEntryDTO.java
@@ -19,7 +19,8 @@ import java.util.UUID;
  * @param proteinG    snapshotted grams of protein
  * @param carbsG      snapshotted grams of carbohydrates
  * @param fatG        snapshotted grams of fat
- * @param foodName    resolved name of the referenced food item (null for ad-hoc entries)
+ * @param foodName    resolved name of the referenced food item; uses the live catalog name if the food
+ *                     still exists, otherwise falls back to the snapshotted name (null for ad-hoc entries)
  */
 @Schema(description = "A logged meal entry for a given day")
 public record MealEntryDTO(

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealEntryEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealEntryEntity.java
@@ -41,6 +41,9 @@ public class MealEntryEntity extends BasicEntity {
     @Column(name = "description", length = 255)
     private String description;
 
+    @Column(name = "food_name", length = 255)
+    private String foodName;
+
     @Column(name = "quantity_g", precision = 10, scale = 2)
     private BigDecimal quantityG;
 

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -148,7 +148,11 @@ public class MealEntryService {
             final Map<UUID, String> foodNameById = foodRepository.findAllById(foodIds).stream()
                     .collect(Collectors.toMap(FoodEntity::getId, FoodEntity::getName));
             return entities.stream()
-                    .map(e -> mealEntryMapper.toDTO(e, foodNameById.get(e.getFoodId())))
+                    .map(e -> {
+                        final String live = foodNameById.get(e.getFoodId());
+                        final String display = live != null ? live : e.getFoodName();
+                        return mealEntryMapper.toDTO(e, display);
+                    })
                     .collect(Collectors.toList());
         }).subscribeOn(Schedulers.boundedElastic());
 
@@ -182,6 +186,7 @@ public class MealEntryService {
         entity.setProteinG(snapshot(food.getProteinPer100(), req.quantityG()));
         entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
         entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
+        entity.setFoodName(food.getName());
         return food.getName();
     }
 
@@ -223,6 +228,7 @@ public class MealEntryService {
             entity.setCarbsG(snapshot(food.getCarbsPer100(), req.quantityG()));
             entity.setFatG(snapshot(food.getFatPer100(), req.quantityG()));
         }
+        entity.setFoodName(food.getName());
         return food.getName();
     }
 

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_5__nutrition_meal_entry_food_name.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_5__nutrition_meal_entry_food_name.sql
@@ -1,0 +1,6 @@
+ALTER TABLE nutrition.meal_entry ADD COLUMN food_name VARCHAR(255);
+
+UPDATE nutrition.meal_entry me
+SET food_name = f.name
+FROM nutrition.food f
+WHERE me.food_id = f.id;

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -563,6 +563,81 @@ class MealEntryServiceTest {
     }
 
     @Test
+    @DisplayName("addEntry snapshots foodName onto the saved entity for a food-backed entry")
+    void addEntry_FoodEntry_SnapshotsFoodNameOntoSavedEntity() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e -> "Test Food".equals(e.getFoodName())));
+    }
+
+    @Test
+    @DisplayName("updateEntry re-snapshots foodName onto the saved entity for a food-backed entry")
+    void updateEntry_FoodEntry_ReSnapshotsFoodNameOntoSavedEntity() {
+        mealEntryEntity.setFoodId(foodId);
+        mealEntryEntity.setQuantityG(new BigDecimal("150"));
+
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null, new BigDecimal("200"), null, null, null, null, null
+        );
+
+        when(mealEntryRepository.findById(entryId)).thenReturn(Optional.of(mealEntryEntity));
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        StepVerifier.create(mealEntryService.updateEntry(entryId, req))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(mealEntryRepository).save(argThat(e -> "Test Food".equals(e.getFoodName())));
+    }
+
+    @Test
+    @DisplayName("getDay falls back to snapshotted foodName for an orphaned entry whose food was deleted")
+    void getDay_OrphanedEntry_FallsBackToSnapshottedFoodName() {
+        final MealEntryEntity orphanedEntry = new MealEntryEntity();
+        orphanedEntry.setFoodId(null);
+        orphanedEntry.setFoodName("Deleted Food");
+        orphanedEntry.setKcal(new BigDecimal("300.00"));
+        orphanedEntry.setProteinG(new BigDecimal("20.00"));
+        orphanedEntry.setCarbsG(new BigDecimal("30.00"));
+        orphanedEntry.setFatG(new BigDecimal("10.00"));
+
+        final MealEntryDTO orphanedDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.LUNCH, null, null,
+                new BigDecimal("150.00"),
+                new BigDecimal("300.00"), new BigDecimal("20.00"),
+                new BigDecimal("30.00"), new BigDecimal("10.00"), "Deleted Food"
+        );
+
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of(orphanedEntry));
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
+        when(mealEntryMapper.toDTO(orphanedEntry, "Deleted Food")).thenReturn(orphanedDTO);
+        when(nutritionTargetService.getTargets())
+                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assertEquals(1, summary.entries().size());
+                    assertEquals("Deleted Food", summary.entries().get(0).foodName());
+                })
+                .verifyComplete();
+
+        verify(foodRepository).findAllById(List.of());
+    }
+
+    @Test
     @DisplayName("getDay resolves foodName via batch lookup for food-backed entries")
     void getDay_FoodBackedEntries_ResolvesFoodNameViaBatchLookup() {
         final UUID foodId2 = UUID.randomUUID();


### PR DESCRIPTION
## Summary
Resolves #128.

`meal_entry.food_id` uses `ON DELETE SET NULL`. Snapshotted macros are preserved when a food is deleted, but the entry was left with `food_id = NULL` and no name, so it was treated as ad-hoc and rendered as the generic "Eintrag".

## Approach (user-approved)
Snapshot the food name onto the entry at log time so it stays meaningful after the food is gone.

## Changes
- New migration `V1_5__nutrition_meal_entry_food_name.sql`: adds nullable `food_name VARCHAR(255)`, backfilled from the food catalog for existing rows.
- `MealEntryEntity`: new `foodName` field mapped to `food_name`.
- `MealEntryService`: `buildFoodEntry` and `applyFoodEntryUpdate` snapshot `food.getName()`. `getDay` prefers the live catalog name and falls back to the snapshotted `foodName` when the food has been deleted; ad-hoc entries remain `null`.
- `MealEntryDTO`: Javadoc clarified for the live-vs-snapshot fallback.

## Tests (new only, existing untouched)
- Logging a food-backed entry snapshots the food name onto the saved entity.
- Updating a food-backed entry keeps `foodName` populated.
- `getDay` for an orphaned entry (food_id null, food_name set) renders the snapshotted name instead of null.

## Verification
- `./gradlew :nutrition:test` ✅
- `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` ✅

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)