### PR TITLE
feat(nutrition): enforce single-row profile invariant

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/entity/ProfileEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/ProfileEntity.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
@@ -22,8 +20,10 @@ import lombok.Setter;
 @Table(name = "profile", schema = "nutrition")
 public class ProfileEntity extends BasicEntity {
 
+    /** Fixed identifier of the single nutrition profile row, enforced by a DB-level CHECK constraint. */
+    public static final long SINGLETON_ID = 1L;
+
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
 

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
@@ -4,7 +4,6 @@ import com.marvin.nutrition.dto.ProfileDTO;
 import com.marvin.nutrition.entity.ProfileEntity;
 import com.marvin.nutrition.mapper.ProfileMapper;
 import com.marvin.nutrition.repository.ProfileRepository;
-import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -34,13 +33,10 @@ public class NutritionProfileService {
      * @return a Mono emitting the profile DTO
      */
     public Mono<ProfileDTO> getProfile() {
-        return Mono.fromCallable(() -> {
-            final List<ProfileEntity> all = profileRepository.findAll();
-            if (all.isEmpty()) {
-                throw new NoSuchElementException("No nutrition profile has been created yet.");
-            }
-            return profileMapper.toDTO(all.get(0));
-        }).subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> profileRepository.findById(ProfileEntity.SINGLETON_ID)
+                .map(profileMapper::toDTO)
+                .orElseThrow(() -> new NoSuchElementException("No nutrition profile has been created yet.")))
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
@@ -51,13 +47,9 @@ public class NutritionProfileService {
      */
     public Mono<ProfileDTO> upsertProfile(ProfileDTO dto) {
         return Mono.fromCallable(() -> {
-            final List<ProfileEntity> all = profileRepository.findAll();
-            final ProfileEntity entity;
-            if (all.isEmpty()) {
-                entity = new ProfileEntity();
-            } else {
-                entity = all.get(0);
-            }
+            final ProfileEntity entity = profileRepository.findById(ProfileEntity.SINGLETON_ID)
+                    .orElseGet(ProfileEntity::new);
+            entity.setId(ProfileEntity.SINGLETON_ID);
             entity.setSex(dto.sex());
             entity.setBirthDate(dto.birthDate());
             entity.setHeightCm(dto.heightCm());

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
@@ -5,7 +5,6 @@ import com.marvin.nutrition.entity.ProfileEntity;
 import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.repository.ProfileRepository;
 import com.marvin.nutrition.repository.WeightEntryRepository;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -42,8 +41,7 @@ public class NutritionTargetService {
      */
     public Mono<TargetsDTO> getTargets() {
         return Mono.fromCallable(() -> {
-            final List<ProfileEntity> profiles = profileRepository.findAll();
-            final ProfileEntity profile = profiles.isEmpty() ? null : profiles.get(0);
+            final ProfileEntity profile = profileRepository.findById(ProfileEntity.SINGLETON_ID).orElse(null);
             final WeightEntryEntity latestWeight = weightEntryRepository.findTopByOrderByEntryDateDesc().orElse(null);
             return targetService.computeTargets(profile, latestWeight);
         }).subscribeOn(Schedulers.boundedElastic());

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_6__nutrition_profile_singleton.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_6__nutrition_profile_singleton.sql
@@ -1,0 +1,11 @@
+-- Enforce the single-row invariant on the nutrition profile.
+-- Collapse any accidental duplicates, pin the surviving row to the fixed id 1,
+-- and forbid any other id so concurrent inserts can no longer create a second row.
+DELETE FROM nutrition.profile
+WHERE id <> (SELECT MIN(id) FROM nutrition.profile);
+
+UPDATE nutrition.profile SET id = 1 WHERE id <> 1;
+
+ALTER TABLE nutrition.profile ALTER COLUMN id DROP DEFAULT;
+
+ALTER TABLE nutrition.profile ADD CONSTRAINT profile_single_row CHECK (id = 1);

--- a/nutrition/src/test/java/com/marvin/nutrition/service/NutritionProfileServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/NutritionProfileServiceTest.java
@@ -1,0 +1,158 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.ProfileDTO;
+import com.marvin.nutrition.entity.ActivityLevel;
+import com.marvin.nutrition.entity.Goal;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.entity.Sex;
+import com.marvin.nutrition.mapper.ProfileMapper;
+import com.marvin.nutrition.repository.ProfileRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link NutritionProfileService} covering the single-row profile invariant. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NutritionProfileService Tests")
+class NutritionProfileServiceTest {
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ProfileMapper profileMapper;
+
+    private NutritionProfileService nutritionProfileService;
+
+    @BeforeEach
+    void setUp() {
+        nutritionProfileService = new NutritionProfileService(profileRepository, profileMapper);
+    }
+
+    private ProfileDTO dto() {
+        return new ProfileDTO(
+                ProfileEntity.SINGLETON_ID,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                BigDecimal.valueOf(180),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                BigDecimal.valueOf(2.0),
+                BigDecimal.valueOf(0.30),
+                null);
+    }
+
+    @Test
+    @DisplayName("getProfile returns the row found by findById(SINGLETON_ID)")
+    void getProfileReturnsRowBySingletonId() {
+        final ProfileEntity entity = new ProfileEntity();
+        entity.setId(ProfileEntity.SINGLETON_ID);
+        final ProfileDTO expected = dto();
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(entity));
+        when(profileMapper.toDTO(entity)).thenReturn(expected);
+
+        StepVerifier.create(nutritionProfileService.getProfile())
+                .expectNext(expected)
+                .verifyComplete();
+
+        verify(profileRepository).findById(ProfileEntity.SINGLETON_ID);
+        verify(profileRepository, never()).findAll();
+    }
+
+    @Test
+    @DisplayName("getProfile emits NoSuchElementException when no profile exists")
+    void getProfileEmitsErrorWhenMissing() {
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(nutritionProfileService.getProfile())
+                .expectErrorMatches(error -> error instanceof NoSuchElementException
+                        && "No nutrition profile has been created yet.".equals(error.getMessage()))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("upsertProfile on empty repository creates a new entity pinned to SINGLETON_ID")
+    void upsertProfileCreatesNewEntityWithSingletonId() {
+        final ProfileDTO request = dto();
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+        when(profileRepository.save(any(ProfileEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(profileMapper.toDTO(any(ProfileEntity.class))).thenReturn(request);
+
+        StepVerifier.create(nutritionProfileService.upsertProfile(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        final ArgumentCaptor<ProfileEntity> captor = ArgumentCaptor.forClass(ProfileEntity.class);
+        verify(profileRepository).save(captor.capture());
+        assertEquals(ProfileEntity.SINGLETON_ID, captor.getValue().getId());
+    }
+
+    @Test
+    @DisplayName("upsertProfile on existing row updates that row, keeping id 1")
+    void upsertProfileUpdatesExistingRow() {
+        final ProfileEntity existing = new ProfileEntity();
+        existing.setId(ProfileEntity.SINGLETON_ID);
+        final ProfileDTO request = dto();
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(existing));
+        when(profileRepository.save(any(ProfileEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(profileMapper.toDTO(any(ProfileEntity.class))).thenReturn(request);
+
+        StepVerifier.create(nutritionProfileService.upsertProfile(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        final ArgumentCaptor<ProfileEntity> captor = ArgumentCaptor.forClass(ProfileEntity.class);
+        verify(profileRepository).save(captor.capture());
+        assertEquals(ProfileEntity.SINGLETON_ID, captor.getValue().getId());
+        verify(profileRepository, never()).findAll();
+    }
+
+    @Test
+    @DisplayName("upsertProfile defaults proteinPerKg and fatPct when not provided")
+    void upsertProfileAppliesDefaults() {
+        final ProfileDTO request = new ProfileDTO(
+                null,
+                Sex.FEMALE,
+                LocalDate.of(1995, 1, 1),
+                BigDecimal.valueOf(165),
+                ActivityLevel.LIGHT,
+                Goal.CUT,
+                null,
+                null,
+                null);
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+        when(profileRepository.save(any(ProfileEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(profileMapper.toDTO(any(ProfileEntity.class))).thenAnswer(invocation -> {
+            final ProfileEntity saved = invocation.getArgument(0);
+            return new ProfileDTO(saved.getId(), saved.getSex(), saved.getBirthDate(), saved.getHeightCm(),
+                    saved.getActivityLevel(), saved.getGoal(), saved.getProteinPerKg(), saved.getFatPct(),
+                    saved.getBasalKcal());
+        });
+
+        StepVerifier.create(nutritionProfileService.upsertProfile(request))
+                .assertNext(saved -> {
+                    assertEquals(BigDecimal.valueOf(2.0), saved.proteinPerKg());
+                    assertEquals(BigDecimal.valueOf(0.30), saved.fatPct());
+                })
+                .verifyComplete();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
@@ -1,0 +1,80 @@
+package com.marvin.nutrition.service;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.ProfileEntity;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import com.marvin.nutrition.repository.ProfileRepository;
+import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link NutritionTargetService} covering the single-row profile lookup. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NutritionTargetService Tests")
+class NutritionTargetServiceTest {
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private WeightEntryRepository weightEntryRepository;
+
+    @Mock
+    private TargetService targetService;
+
+    private NutritionTargetService nutritionTargetService;
+
+    @BeforeEach
+    void setUp() {
+        nutritionTargetService = new NutritionTargetService(profileRepository, weightEntryRepository, targetService);
+    }
+
+    @Test
+    @DisplayName("getTargets loads the profile via findById(SINGLETON_ID)")
+    void getTargetsLoadsProfileBySingletonId() {
+        final ProfileEntity profile = new ProfileEntity();
+        profile.setId(ProfileEntity.SINGLETON_ID);
+        final WeightEntryEntity weight = new WeightEntryEntity();
+        weight.setWeightKg(BigDecimal.valueOf(80));
+        final TargetsDTO targets = new TargetsDTO(1750, 2713, 2213, 160, 74, 248, "MIFFLIN_ST_JEOR");
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(profile));
+        when(weightEntryRepository.findTopByOrderByEntryDateDesc()).thenReturn(Optional.of(weight));
+        when(targetService.computeTargets(profile, weight)).thenReturn(targets);
+
+        StepVerifier.create(nutritionTargetService.getTargets())
+                .expectNext(targets)
+                .verifyComplete();
+
+        verify(profileRepository).findById(ProfileEntity.SINGLETON_ID);
+        verify(profileRepository, never()).findAll();
+    }
+
+    @Test
+    @DisplayName("getTargets passes a null profile to the calculation when none exists")
+    void getTargetsPassesNullProfileWhenAbsent() {
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+        when(weightEntryRepository.findTopByOrderByEntryDateDesc()).thenReturn(Optional.empty());
+        when(targetService.computeTargets(isNull(), isNull()))
+                .thenThrow(new TargetCalculationException("No nutrition profile found. Please create a profile first."));
+
+        StepVerifier.create(nutritionTargetService.getTargets())
+                .expectErrorMatches(error -> error instanceof TargetCalculationException)
+                .verify();
+
+        verify(targetService).computeTargets(eq(null), eq(null));
+    }
+}


### PR DESCRIPTION
## Summary
Resolves #129.

The nutrition profile is meant to be a single row but was read via `ProfileRepository.findAll().get(0)` with no ordering and no DB-level uniqueness. Concurrent upserts could create two rows and reads would pick an arbitrary one.

## Approach (user-approved)
Pin the profile to a single fixed-id row (`id = 1`) enforced by a DB CHECK constraint, and read it deterministically by id.

## Changes
- New migration `V1_6__nutrition_profile_singleton.sql`: collapses any accidental duplicates to one row, pins it to `id = 1`, drops the serial default, and adds `CHECK (id = 1)` so a second row can no longer be inserted.
- `ProfileEntity`: adds `SINGLETON_ID = 1L`; removes `@GeneratedValue` so the id is application-assigned and pinned.
- `NutritionProfileService`: `getProfile()` and `upsertProfile()` now read via `findById(SINGLETON_ID)` and explicitly pin the id on save.
- `NutritionTargetService`: `getTargets()` reads via `findById(SINGLETON_ID)`.

## Tests (new only, existing untouched)
- `NutritionProfileServiceTest`: deterministic read by fixed id, missing-profile error, upsert-create pins id to 1, upsert-update keeps id 1, default field values.
- `NutritionTargetServiceTest`: profile loaded via `findById(SINGLETON_ID)`; absent-profile path passes null to the calculation.

## Verification
- `./gradlew :nutrition:test` ✅
- `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` ✅

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)