### PR TITLE
fix(nutrition): round fat and carb targets HALF_UP (#137)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
@@ -65,12 +65,14 @@ public class TargetService {
         final int proteinG = (int) Math.round(profile.getProteinPerKg().doubleValue() * weightKg);
         final int fatG = profile.getFatPct()
                 .multiply(BigDecimal.valueOf(targetKcal))
-                .divide(BigDecimal.valueOf(KCAL_PER_GRAM_FAT), 4, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(KCAL_PER_GRAM_FAT), 0, RoundingMode.HALF_UP)
                 .intValue();
         final int proteinKcal = proteinG * KCAL_PER_GRAM_PROTEIN;
         final int fatKcal = fatG * KCAL_PER_GRAM_FAT;
         final int remaining = Math.max(0, targetKcal - proteinKcal - fatKcal);
-        final int carbsG = remaining / KCAL_PER_GRAM_CARBS;
+        final int carbsG = BigDecimal.valueOf(remaining)
+                .divide(BigDecimal.valueOf(KCAL_PER_GRAM_CARBS), 0, RoundingMode.HALF_UP)
+                .intValue();
 
         final String basis = profile.getBasalKcal() != null
                 ? TargetBasis.BASAL_KCAL.name()

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -92,8 +92,8 @@ class TargetServiceTest {
      * Female, 25 years, 165 cm, 60 kg → BMR = 10*60 + 6.25*165 - 5*25 - 161 = 600+1031.25-125-161 = 1345.25 → 1345.
      * LIGHT activity: 1345 * 1.375 = 1849.375 → 1849.
      * CUT goal: 1849 - 500 = 1349.
-     * protein = 2.0 * 60 = 120 g, fat = 0.30 * 1349 / 9 = 404.7 / 9 = 44.97 → 44 g,
-     * carbs = (1349 - 120*4 - 44*9) / 4 = (1349 - 480 - 396) / 4 = 473 / 4 = 118.25 → 118 g.
+     * protein = 2.0 * 60 = 120 g, fat = round(0.30 * 1349 / 9) = round(44.97) = 45 g,
+     * carbs = round((1349 - 120*4 - 45*9) / 4) = round((1349 - 480 - 405) / 4) = round(464 / 4) = round(116) = 116 g.
      */
     @Test
     @DisplayName("FEMALE LIGHT CUT uses Mifflin–St Jeor and returns correct macros")
@@ -109,8 +109,8 @@ class TargetServiceTest {
         assertEquals(1849, result.maintenanceKcal());
         assertEquals(1349, result.targetKcal());
         assertEquals(120, result.proteinG());
-        assertEquals(44, result.fatG());
-        assertEquals(118, result.carbsG());
+        assertEquals(45, result.fatG());
+        assertEquals(116, result.carbsG());
         assertEquals(TargetBasis.MIFFLIN_ST_JEOR.name(), result.basis());
     }
 
@@ -255,13 +255,38 @@ class TargetServiceTest {
 
         // targetKcal = round(2000 * 1.2) = 2400
         // protein = round(1.8 * 75) = 135 g → 135 * 4 = 540 kcal
-        // fat = floor(0.28 * 2400 / 9) = floor(74.666...) = 74 g → 74 * 9 = 666 kcal
-        // remaining = 2400 - 540 - 666 = 1194 kcal
-        // carbs = floor(1194 / 4) = 298 g
+        // fat = round(0.28 * 2400 / 9) = round(74.666...) = 75 g → 75 * 9 = 675 kcal
+        // remaining = 2400 - 540 - 675 = 1185 kcal
+        // carbs = round(1185 / 4) = round(296.25) = 296 g
         assertEquals(2400, result.targetKcal());
         assertEquals(135, result.proteinG());
-        assertEquals(74, result.fatG());
-        assertEquals(298, result.carbsG());
+        assertEquals(75, result.fatG());
+        assertEquals(296, result.carbsG());
+    }
+
+    /**
+     * Boundary case where the old truncating logic and the new HALF_UP logic disagree.
+     *
+     * <p>basalKcal = 2000, SEDENTARY → maintenance = round(2000 * 1.2) = 2400, MAINTAIN → targetKcal = 2400.
+     * protein = round(2.0 * 70) = 140 g → 140 * 4 = 560 kcal.
+     * fat = round(0.246 * 2400 / 9) = round(65.6) = 66 g (old truncating logic gave 65) → 66 * 9 = 594 kcal.
+     * remaining = 2400 - 560 - 594 = 1246 kcal.
+     * carbs = round(1246 / 4) = round(311.5) = 312 g (old integer division gave 311).</p>
+     */
+    @Test
+    @DisplayName("Fat and carbs are rounded HALF_UP at the .5 boundary instead of truncated")
+    void compute_FatAndCarbsAtHalfUpBoundary_RoundUp() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.MAINTAIN, 2.0, 0.246, 2000);
+        final WeightEntryEntity w = weight(70.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(2400, result.targetKcal());
+        assertEquals(140, result.proteinG());
+        assertEquals(66, result.fatG());
+        assertEquals(312, result.carbsG());
     }
 
     // -----------------------------------------------------------------------

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -297,7 +297,7 @@ class TargetServiceTest {
      * Very low weight + aggressive CUT + high protein/fat can push proteinKcal + fatKcal above targetKcal.
      * basalKcal = 1400, weight = 45 kg, SEDENTARY → maintenance = round(1400 * 1.2) = 1680, CUT target = 1180.
      * protein = round(3.5 * 45) = 158 g → 158 * 4 = 632 kcal.
-     * fat = floor(0.55 * 1180 / 9) = floor(72.11) = 72 g → 72 * 9 = 648 kcal.
+     * fat = round(0.55 * 1180 / 9) = round(72.11) = 72 g → 72 * 9 = 648 kcal.
      * remaining = 1180 - 632 - 648 = -100 kcal → clamped to 0, carbsG must be 0.
      */
     @Test


### PR DESCRIPTION
## Summary
Fixes #137. `TargetService.computeTargets` rounded the three macros inconsistently: protein rounded to nearest, while **fat** (truncated after `divide(...,4,HALF_UP)`) and **carbs** (integer division) were systematically rounded **down**, slightly under-reporting targets.

## Changes
- **fat**: round at scale `0` with `HALF_UP` (was scale 4 + `intValue()` truncation).
- **carbs**: use `BigDecimal.divide(..., 0, HALF_UP)` instead of integer division. The existing `Math.max(0, ...)` clamp is preserved so carbs cannot go negative.
- protein already used `Math.round` (HALF_UP-equivalent for positive values) — unchanged.

## Tests
- Updated two existing `TargetServiceTest` cases that encoded the old truncation (user-approved): `compute_FemaleLightCut_MifflinFormula` (fat 44→45, carbs 118→116) and `compute_MacroCarbsRemainder` (fat 74→75, carbs 298→296).
- Added `compute_FatAndCarbsAtHalfUpBoundary_RoundUp` exercising the `.5`+ rounding boundary.
- `./gradlew :nutrition:test` and checkstyle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)