### PR TITLE
feat(nutrition): validate ad-hoc meal description at the DTO (#139)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntryRequest.java
@@ -1,5 +1,6 @@
 package com.marvin.nutrition.dto;
 
+import com.marvin.nutrition.dto.validation.AdHocDescriptionRequired;
 import com.marvin.nutrition.entity.MealType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -24,6 +25,7 @@ import java.util.UUID;
  * @param fatG        grams of fat (required for ad-hoc entries)
  */
 @Schema(description = "Request to log a meal entry for a given day")
+@AdHocDescriptionRequired
 public record CreateMealEntryRequest(
         @NotNull
         @Schema(description = "Meal category", example = "LUNCH")

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealEntryRequest.java
@@ -1,5 +1,6 @@
 package com.marvin.nutrition.dto;
 
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import com.marvin.nutrition.entity.MealType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -30,6 +31,7 @@ public record UpdateMealEntryRequest(
         BigDecimal quantityG,
 
         @Size(max = 255)
+        @NullOrNotBlank
         @Schema(description = "Updated free-text description for ad-hoc entries", example = "Updated soup")
         String description,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/validation/AdHocDescriptionRequired.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/validation/AdHocDescriptionRequired.java
@@ -1,0 +1,39 @@
+package com.marvin.nutrition.dto.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level constraint requiring a non-blank {@code description} for ad-hoc meal entries
+ * (i.e. when {@code foodId} is {@code null}). Food-backed entries are not affected.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AdHocDescriptionRequiredValidator.class)
+public @interface AdHocDescriptionRequired {
+
+    /**
+     * The validation error message.
+     *
+     * @return the message template
+     */
+    String message() default "description must not be blank for ad-hoc entries";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for clients of the Bean Validation API.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/validation/AdHocDescriptionRequiredValidator.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/validation/AdHocDescriptionRequiredValidator.java
@@ -1,0 +1,50 @@
+package com.marvin.nutrition.dto.validation;
+
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validates that ad-hoc {@link CreateMealEntryRequest} instances (i.e. {@code foodId == null})
+ * carry a non-blank {@code description}. Food-backed entries are exempt since their description
+ * remains optional. The violation is reported on the {@code description} property so it surfaces
+ * as a field error.
+ */
+public class AdHocDescriptionRequiredValidator implements ConstraintValidator<AdHocDescriptionRequired, CreateMealEntryRequest> {
+
+    /**
+     * Initializes the validator. No setup is required.
+     *
+     * @param constraintAnnotation the annotation instance for this constraint
+     */
+    @Override
+    public void initialize(final AdHocDescriptionRequired constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    /**
+     * Checks that ad-hoc entries (where {@code foodId} is {@code null}) have a non-blank description.
+     * Food-backed entries and {@code null} requests are always considered valid by this constraint.
+     *
+     * @param value   the request to validate
+     * @param context the constraint validator context
+     * @return {@code true} if the request is valid with respect to this constraint
+     */
+    @Override
+    public boolean isValid(final CreateMealEntryRequest value, final ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        if (value.foodId() != null) {
+            return true;
+        }
+        if (value.description() != null && !value.description().isBlank()) {
+            return true;
+        }
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
+                .addPropertyNode("description")
+                .addConstraintViolation();
+        return false;
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/validation/NullOrNotBlank.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/validation/NullOrNotBlank.java
@@ -1,0 +1,40 @@
+package com.marvin.nutrition.dto.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Field-level constraint allowing a {@code null} value but rejecting blank or whitespace-only
+ * strings. Useful for partial-update request fields where {@code null} means "leave unchanged"
+ * but an explicitly supplied value must still be meaningful.
+ */
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NullOrNotBlankValidator.class)
+public @interface NullOrNotBlank {
+
+    /**
+     * The validation error message.
+     *
+     * @return the message template
+     */
+    String message() default "must not be blank";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for clients of the Bean Validation API.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/validation/NullOrNotBlankValidator.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/validation/NullOrNotBlankValidator.java
@@ -1,0 +1,34 @@
+package com.marvin.nutrition.dto.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validates that a {@link String} value is either {@code null} or non-blank.
+ * Blank or whitespace-only strings are rejected, while {@code null} is accepted so that
+ * partial-update requests may omit the field.
+ */
+public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, String> {
+
+    /**
+     * Initializes the validator. No setup is required.
+     *
+     * @param constraintAnnotation the annotation instance for this constraint
+     */
+    @Override
+    public void initialize(final NullOrNotBlank constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    /**
+     * Checks that the value is either {@code null} or a non-blank string.
+     *
+     * @param value   the value to validate
+     * @param context the constraint validator context
+     * @return {@code true} if the value is {@code null} or non-blank
+     */
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+        return value == null || !value.isBlank();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/MealEntryRequestValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/MealEntryRequestValidationTest.java
@@ -149,4 +149,146 @@ public class MealEntryRequestValidationTest {
                 "Expected the violation to be on the 'description' property"
         );
     }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest ad-hoc with null description yields a violation on 'description'")
+    void createRequest_adHoc_nullDescription_yieldsViolation() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.DINNER,
+                null,
+                null,
+                null,
+                new BigDecimal("100.00"),
+                new BigDecimal("10.00"),
+                new BigDecimal("20.00"),
+                new BigDecimal("5.00")
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for null description on an ad-hoc entry");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest ad-hoc with blank description yields a violation on 'description'")
+    void createRequest_adHoc_blankDescription_yieldsViolation() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.DINNER,
+                null,
+                null,
+                "   ",
+                new BigDecimal("100.00"),
+                new BigDecimal("10.00"),
+                new BigDecimal("20.00"),
+                new BigDecimal("5.00")
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for blank description on an ad-hoc entry");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest ad-hoc with valid description and macros yields zero violations")
+    void createRequest_adHoc_validDescription_noViolations() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.DINNER,
+                null,
+                null,
+                "Homemade soup",
+                new BigDecimal("100.00"),
+                new BigDecimal("10.00"),
+                new BigDecimal("20.00"),
+                new BigDecimal("5.00")
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid ad-hoc request");
+    }
+
+    @Test
+    @DisplayName("CreateMealEntryRequest food-backed with null description yields zero violations")
+    void createRequest_foodBacked_nullDescription_noViolations() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.LUNCH,
+                UUID.randomUUID(),
+                new BigDecimal("150.00"),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<CreateMealEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a food-backed request with null description");
+    }
+
+    @Test
+    @DisplayName("UpdateMealEntryRequest with blank description yields a violation on 'description'")
+    void updateRequest_blankDescription_yieldsViolation() {
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null,
+                null,
+                "  ",
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<UpdateMealEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for blank description");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")),
+                "Expected the violation to be on the 'description' property"
+        );
+    }
+
+    @Test
+    @DisplayName("UpdateMealEntryRequest with null description yields zero violations")
+    void updateRequest_nullDescription_noViolations() {
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<UpdateMealEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a null description on update");
+    }
+
+    @Test
+    @DisplayName("UpdateMealEntryRequest with valid description yields zero violations")
+    void updateRequest_validDescription_noViolations() {
+        final UpdateMealEntryRequest req = new UpdateMealEntryRequest(
+                null,
+                null,
+                "Updated soup",
+                null,
+                null,
+                null,
+                null
+        );
+
+        final Set<ConstraintViolation<UpdateMealEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid description on update");
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #139. Validates the ad-hoc meal `description` at the DTO boundary instead of relying on a late `IllegalArgumentException` in `MealEntryService.buildAdHocEntry`, yielding a consistent field-level validation-error shape.

## Changes
New `com.marvin.nutrition.dto.validation` package:
- **`@AdHocDescriptionRequired`** (class-level, on `CreateMealEntryRequest`): when `foodId == null` (ad-hoc), `description` must be non-blank; food-backed entries (`foodId != null`) keep `description` optional. The validator disables the default violation and re-roots it on the `description` property node, so it surfaces as a **field error** — required because `NutritionExceptionHandler.handleValidation` only reads `getFieldErrors()`.
- **`@NullOrNotBlank`** (field-level, on `UpdateMealEntryRequest.description`): symmetric handling — null stays allowed for partial updates, but a present description must not be blank.

The existing `buildAdHocEntry` guard is kept as defense-in-depth (it also covers the macro fields and non-HTTP callers).

## Tests
- 7 new cases in `MealEntryRequestValidationTest` covering ad-hoc null/blank/valid, food-backed-null-allowed, and update null/blank/valid — asserting the violation property path is `description`. No existing tests modified.
- `./gradlew :nutrition:test` + checkstyle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)