### PR TITLE
feat(nutrition): paginate GET /nutrition/foods (#138)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.net.URI;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -23,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,11 +46,15 @@ import reactor.core.publisher.Mono;
  */
 @RestController
 @RequestMapping("/nutrition/foods")
+@Validated
 @Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
 public class FoodController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FoodController.class);
     private static final String FOODS_LOCATION_PREFIX = "/nutrition/foods/";
+    private static final String DEFAULT_PAGE = "0";
+    private static final String DEFAULT_SIZE = "50";
+    private static final long MAX_SIZE = 200;
 
     private final FoodService foodService;
     private final LabelReader labelReader;
@@ -67,27 +74,37 @@ public class FoodController {
     }
 
     /**
-     * Lists all food entries, optionally filtered by a name search query.
+     * Lists food entries, optionally filtered by a name search query, one page at a time.
      *
-     * @param q optional case-insensitive name contains filter
-     * @return a Flux emitting matching food DTOs ordered by name
+     * @param q    optional case-insensitive name contains filter
+     * @param page zero-based page number (default {@value #DEFAULT_PAGE})
+     * @param size page size, between 1 and {@value #MAX_SIZE} (default {@value #DEFAULT_SIZE})
+     * @return a Flux emitting matching food DTOs ordered by name for the requested page
      */
     @GetMapping
     @Operation(
             summary = "List food entries",
-            description = "Returns all food catalog entries, or those whose name contains the given query string (case-insensitive).",
+            description = "Returns a page of food catalog entries, or those whose name contains the given query string "
+                    + "(case-insensitive), ordered by name.",
             responses = {
                 @ApiResponse(
                         responseCode = "200",
                         description = "Food list returned",
                         content = @Content(array = @ArraySchema(schema = @Schema(implementation = FoodDTO.class)))
-                )
+                ),
+                @ApiResponse(responseCode = "400", description = "Invalid pagination parameters")
             }
     )
     public Flux<FoodDTO> listFoods(
             @RequestParam(required = false)
-            @Parameter(description = "Optional name search query (case-insensitive contains)") String q) {
-        return foodService.findAll(q);
+            @Parameter(description = "Optional name search query (case-insensitive contains)") String q,
+            @RequestParam(defaultValue = DEFAULT_PAGE)
+            @Min(0)
+            @Parameter(description = "Zero-based page number") int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE)
+            @Min(1) @Max(MAX_SIZE)
+            @Parameter(description = "Page size (1-200)") int size) {
+        return foodService.findAll(q, page, size);
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -5,6 +5,7 @@ import com.marvin.nutrition.service.LabelReadException;
 import com.marvin.nutrition.service.MealEstimateException;
 import com.marvin.nutrition.service.TargetCalculationException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -117,6 +118,20 @@ public class NutritionExceptionHandler {
     public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
         final String errors = ex.getBindingResult().getFieldErrors().stream()
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    /**
+     * Maps method-parameter constraint violations ({@link ConstraintViolationException}) to HTTP 400.
+     *
+     * @param ex the exception carrying constraint violation details
+     * @return 400 response with comma-separated constraint violation messages
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<String> handleConstraintViolation(ConstraintViolationException ex) {
+        final String errors = ex.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
                 .collect(Collectors.joining(", "));
         return ResponseEntity.badRequest().body(errors);
     }

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/FoodRepository.java
@@ -3,6 +3,7 @@ package com.marvin.nutrition.repository;
 import com.marvin.nutrition.entity.FoodEntity;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -13,12 +14,14 @@ public interface FoodRepository extends JpaRepository<FoodEntity, UUID> {
 
     /**
      * Searches for food entries whose name contains the given query string, case-insensitively,
-     * ordered alphabetically by name. The caller must pre-escape LIKE special characters
-     * ({@code \}, {@code %}, {@code _}) using {@code ESCAPE '\\'}.
+     * ordered alphabetically by name, returning at most one page of results. The caller must
+     * pre-escape LIKE special characters ({@code \}, {@code %}, {@code _}) using {@code ESCAPE '\\'}.
      *
-     * @param q the pre-escaped substring to search for within food names
-     * @return list of matching food entities ordered by name
+     * @param q        the pre-escaped substring to search for within food names
+     * @param pageable the pagination information (page number and size); its sort, if any, is ignored
+     *                 since the query already orders by name
+     * @return list of matching food entities ordered by name, limited to the requested page
      */
     @Query("SELECT f FROM FoodEntity f WHERE LOWER(f.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\' ORDER BY f.name")
-    List<FoodEntity> searchByName(String q);
+    List<FoodEntity> searchByName(String q, Pageable pageable);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/FoodService.java
@@ -8,6 +8,8 @@ import com.marvin.nutrition.repository.FoodRepository;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -33,22 +35,25 @@ public class FoodService {
     }
 
     /**
-     * Returns all food entries, or those matching the given name query.
-     * If {@code q} is null or blank, all foods ordered by name are returned.
-     * Otherwise, a case-insensitive name-contains search is performed.
+     * Returns a page of food entries, or those matching the given name query.
+     * If {@code q} is null or blank, all foods ordered by name are returned, paginated.
+     * Otherwise, a case-insensitive name-contains search is performed, paginated.
      * LIKE special characters ({@code \}, {@code %}, {@code _}) in the query are
      * escaped before being passed to the repository.
      *
-     * @param q optional search string to filter by name
-     * @return a Flux emitting matching food DTOs
+     * @param q    optional search string to filter by name
+     * @param page zero-based page number
+     * @param size page size
+     * @return a Flux emitting matching food DTOs for the requested page
      */
-    public Flux<FoodDTO> findAll(String q) {
+    public Flux<FoodDTO> findAll(String q, int page, int size) {
         return Mono.fromCallable(() -> {
             final List<FoodEntity> entities;
             if (q == null || q.isBlank()) {
-                entities = foodRepository.findAll(Sort.by("name"));
+                final Pageable pageable = PageRequest.of(page, size, Sort.by("name"));
+                entities = foodRepository.findAll(pageable).getContent();
             } else {
-                entities = foodRepository.searchByName(escapeLike(q));
+                entities = foodRepository.searchByName(escapeLike(q), PageRequest.of(page, size));
             }
             return foodMapper.toDTOList(entities);
         }).subscribeOn(Schedulers.boundedElastic())

--- a/nutrition/src/test/java/com/marvin/nutrition/NutritionTestApplication.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/NutritionTestApplication.java
@@ -1,0 +1,10 @@
+package com.marvin.nutrition;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application used as context anchor for slice tests.
+ */
+@SpringBootApplication
+class NutritionTestApplication {
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
@@ -86,43 +86,43 @@ class FoodControllerTest {
                 new BigDecimal("10.00"), new BigDecimal("40.00"),
                 FoodSource.MANUAL
         );
-        when(foodService.findAll(null)).thenReturn(Flux.just(testFoodDTO, second));
+        when(foodService.findAll(null, 0, 50)).thenReturn(Flux.just(testFoodDTO, second));
 
-        final Flux<FoodDTO> result = foodController.listFoods(null);
+        final Flux<FoodDTO> result = foodController.listFoods(null, 0, 50);
 
         StepVerifier.create(result)
                 .expectNext(testFoodDTO)
                 .expectNext(second)
                 .verifyComplete();
 
-        verify(foodService).findAll(null);
+        verify(foodService).findAll(null, 0, 50);
     }
 
     @Test
     @DisplayName("Should return matching foods as Flux when query parameter is provided")
     void listFoods_WithQuery_ReturnsMatchingFoods() {
-        when(foodService.findAll("chicken")).thenReturn(Flux.just(testFoodDTO));
+        when(foodService.findAll("chicken", 0, 50)).thenReturn(Flux.just(testFoodDTO));
 
-        final Flux<FoodDTO> result = foodController.listFoods("chicken");
+        final Flux<FoodDTO> result = foodController.listFoods("chicken", 0, 50);
 
         StepVerifier.create(result)
                 .expectNext(testFoodDTO)
                 .verifyComplete();
 
-        verify(foodService).findAll("chicken");
+        verify(foodService).findAll("chicken", 0, 50);
     }
 
     @Test
     @DisplayName("Should return empty Flux when no foods match the query")
     void listFoods_NoMatch_ReturnsEmptyFlux() {
-        when(foodService.findAll("xyz")).thenReturn(Flux.empty());
+        when(foodService.findAll("xyz", 0, 50)).thenReturn(Flux.empty());
 
-        final Flux<FoodDTO> result = foodController.listFoods("xyz");
+        final Flux<FoodDTO> result = foodController.listFoods("xyz", 0, 50);
 
         StepVerifier.create(result)
                 .verifyComplete();
 
-        verify(foodService).findAll("xyz");
+        verify(foodService).findAll("xyz", 0, 50);
     }
 
     @Test

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerValidationTest.java
@@ -1,0 +1,80 @@
+package com.marvin.nutrition.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.service.BarcodeLookup;
+import com.marvin.nutrition.service.FoodService;
+import com.marvin.nutrition.service.LabelReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+
+/**
+ * End-to-end validation tests for the pagination parameters on {@code GET /nutrition/foods}.
+ * Exercises the real {@code @Validated} method-validation proxy and the
+ * {@link NutritionExceptionHandler} constraint-violation mapping via {@link WebTestClient}.
+ */
+@WebFluxTest(
+        controllers = FoodController.class,
+        excludeAutoConfiguration = ReactiveSecurityAutoConfiguration.class
+)
+@DisplayName("FoodController pagination validation Tests")
+class FoodControllerValidationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private FoodService foodService;
+
+    @MockitoBean
+    private LabelReader labelReader;
+
+    @MockitoBean
+    private BarcodeLookup barcodeLookup;
+
+    @Test
+    @DisplayName("GET /nutrition/foods with default pagination returns 200")
+    void listFoods_DefaultPagination_ReturnsOk() {
+        when(foodService.findAll(any(), anyInt(), anyInt())).thenReturn(Flux.empty());
+
+        webTestClient.get()
+                .uri("/nutrition/foods")
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    @DisplayName("GET /nutrition/foods with size above the maximum returns 400")
+    void listFoods_SizeAboveMax_ReturnsBadRequest() {
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/nutrition/foods").queryParam("size", 201).build())
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("GET /nutrition/foods with size below the minimum returns 400")
+    void listFoods_SizeBelowMin_ReturnsBadRequest() {
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/nutrition/foods").queryParam("size", 0).build())
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("GET /nutrition/foods with negative page returns 400")
+    void listFoods_NegativePage_ReturnsBadRequest() {
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/nutrition/foods").queryParam("page", -1).build())
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
@@ -1,0 +1,30 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.validation.ConstraintViolationException;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/** Unit tests for {@link NutritionExceptionHandler}. */
+@DisplayName("NutritionExceptionHandler Tests")
+class NutritionExceptionHandlerTest {
+
+    private final NutritionExceptionHandler handler = new NutritionExceptionHandler();
+
+    @Test
+    @DisplayName("handleConstraintViolation returns 400")
+    void handleConstraintViolation_ReturnsBadRequest() {
+        final ConstraintViolationException ex =
+                new ConstraintViolationException("size: must be less than or equal to 200", Set.of());
+
+        final ResponseEntity<String> response = handler.handleConstraintViolation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/FoodServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/FoodServiceTest.java
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import reactor.test.StepVerifier;
 
 /** Unit tests for {@link FoodService} covering CRUD, source defaulting, wildcard escaping, and error paths. */
@@ -327,80 +329,119 @@ class FoodServiceTest {
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("findAll with null q calls findAll(Sort), not searchByName")
+    @DisplayName("findAll with null q calls findAll(Pageable), not searchByName")
     void findAll_NullQuery_CallsFindAllSort() {
-        when(foodRepository.findAll(any(Sort.class))).thenReturn(List.of(testEntity));
+        when(foodRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(testEntity)));
         when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
 
-        StepVerifier.create(foodService.findAll(null))
+        StepVerifier.create(foodService.findAll(null, 0, 50))
                 .expectNext(testDTO)
                 .verifyComplete();
 
-        verify(foodRepository).findAll(any(Sort.class));
-        verify(foodRepository, never()).searchByName(any());
+        verify(foodRepository).findAll(any(Pageable.class));
+        verify(foodRepository, never()).searchByName(any(), any());
     }
 
     @Test
-    @DisplayName("findAll with blank q calls findAll(Sort), not searchByName")
+    @DisplayName("findAll with blank q calls findAll(Pageable), not searchByName")
     void findAll_BlankQuery_CallsFindAllSort() {
-        when(foodRepository.findAll(any(Sort.class))).thenReturn(List.of(testEntity));
+        when(foodRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(testEntity)));
         when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
 
-        StepVerifier.create(foodService.findAll("   "))
+        StepVerifier.create(foodService.findAll("   ", 0, 50))
                 .expectNext(testDTO)
                 .verifyComplete();
 
-        verify(foodRepository).findAll(any(Sort.class));
-        verify(foodRepository, never()).searchByName(any());
+        verify(foodRepository).findAll(any(Pageable.class));
+        verify(foodRepository, never()).searchByName(any(), any());
     }
 
     @Test
     @DisplayName("findAll with non-blank q calls searchByName with LIKE-escaped string")
     void findAll_NonBlankQuery_CallsSearchByName() {
-        when(foodRepository.searchByName("chicken")).thenReturn(List.of(testEntity));
+        when(foodRepository.searchByName(eq("chicken"), any(Pageable.class))).thenReturn(List.of(testEntity));
         when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
 
-        StepVerifier.create(foodService.findAll("chicken"))
+        StepVerifier.create(foodService.findAll("chicken", 0, 50))
                 .expectNext(testDTO)
                 .verifyComplete();
 
-        verify(foodRepository).searchByName("chicken");
-        verify(foodRepository, never()).findAll(any(Sort.class));
+        verify(foodRepository).searchByName(eq("chicken"), any(Pageable.class));
+        verify(foodRepository, never()).findAll(any(Pageable.class));
     }
 
     @Test
     @DisplayName("findAll escapes percent wildcard in query before passing to searchByName")
     void findAll_QueryWithPercent_EscapesPercent() {
-        when(foodRepository.searchByName(eq("50\\%"))).thenReturn(List.of());
+        when(foodRepository.searchByName(eq("50\\%"), any(Pageable.class))).thenReturn(List.of());
         when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
 
-        StepVerifier.create(foodService.findAll("50%"))
+        StepVerifier.create(foodService.findAll("50%", 0, 50))
                 .verifyComplete();
 
-        verify(foodRepository).searchByName("50\\%");
+        verify(foodRepository).searchByName(eq("50\\%"), any(Pageable.class));
     }
 
     @Test
     @DisplayName("findAll escapes underscore wildcard in query before passing to searchByName")
     void findAll_QueryWithUnderscore_EscapesUnderscore() {
-        when(foodRepository.searchByName(eq("fat\\_free"))).thenReturn(List.of());
+        when(foodRepository.searchByName(eq("fat\\_free"), any(Pageable.class))).thenReturn(List.of());
         when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
 
-        StepVerifier.create(foodService.findAll("fat_free"))
+        StepVerifier.create(foodService.findAll("fat_free", 0, 50))
                 .verifyComplete();
 
-        verify(foodRepository).searchByName("fat\\_free");
+        verify(foodRepository).searchByName(eq("fat\\_free"), any(Pageable.class));
     }
 
     @Test
     @DisplayName("findAll escapes backslash in query before passing to searchByName")
     void findAll_QueryWithBackslash_EscapesBackslash() {
-        when(foodRepository.searchByName(eq("a\\\\b"))).thenReturn(List.of());
+        when(foodRepository.searchByName(eq("a\\\\b"), any(Pageable.class))).thenReturn(List.of());
         when(foodMapper.toDTOList(List.of())).thenReturn(List.of());
 
-        StepVerifier.create(foodService.findAll("a\\b"))
+        StepVerifier.create(foodService.findAll("a\\b", 0, 50))
                 .verifyComplete();
 
-        verify(foodRepository).searchByName("a\\\\b");
+        verify(foodRepository).searchByName(eq("a\\\\b"), any(Pageable.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // findAll — pagination forwarding
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findAll with no query forwards page, size and name sort to repository")
+    void findAll_NoQuery_ForwardsPageable() {
+        when(foodRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(testEntity)));
+        when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
+
+        StepVerifier.create(foodService.findAll(null, 2, 25))
+                .expectNext(testDTO)
+                .verifyComplete();
+
+        final ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(foodRepository).findAll(captor.capture());
+        final Pageable pageable = captor.getValue();
+        assert pageable.getPageNumber() == 2;
+        assert pageable.getPageSize() == 25;
+        assert pageable.getSort().getOrderFor("name") != null;
+    }
+
+    @Test
+    @DisplayName("findAll with query forwards page and size to searchByName")
+    void findAll_WithQuery_ForwardsPageable() {
+        when(foodRepository.searchByName(eq("chicken"), any(Pageable.class))).thenReturn(List.of(testEntity));
+        when(foodMapper.toDTOList(List.of(testEntity))).thenReturn(List.of(testDTO));
+
+        StepVerifier.create(foodService.findAll("chicken", 1, 10))
+                .expectNext(testDTO)
+                .verifyComplete();
+
+        final ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(foodRepository).searchByName(eq("chicken"), captor.capture());
+        final Pageable pageable = captor.getValue();
+        assert pageable.getPageNumber() == 1;
+        assert pageable.getPageSize() == 10;
     }
 }


### PR DESCRIPTION
## Summary
Fixes #138. `GET /nutrition/foods` previously returned the entire catalog via an unbounded `Flux`. It is now paginated.

## Changes
- Adds `page` (default `0`) and `size` (default `50`, **max 200**, min 1) query params, validated with `@Min`/`@Max` and `@Validated` on the controller.
- **Response shape is unchanged** — still a JSON array; it's just bounded by the page window. Pagination applies to both the list-all and the name-search branches.
- `FoodService.findAll(q, page, size)` uses `PageRequest.of(page, size, Sort.by("name"))` for list-all and a **sort-less** `PageRequest` for `searchByName` (whose `@Query` already has `ORDER BY f.name`), avoiding a double-ORDER-BY clash.
- `NutritionExceptionHandler` maps `ConstraintViolationException` → HTTP 400.

## Tests
- Updated the existing `FoodService`/`FoodController` unit tests to the new signatures (user-approved) and added `ArgumentCaptor<Pageable>` tests asserting page/size/sort are forwarded on both branches.
- Added `NutritionExceptionHandlerTest` for the 400 mapping and a `@WebFluxTest` slice (`FoodControllerValidationTest`) asserting `size=201`, `size=0`, `page=-1` return 400 end-to-end through the validation proxy.
- `./gradlew :nutrition:test` + checkstyle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)