### PR TITLE
feat(nutrition): snapshot daily nutrition targets for historical day summaries

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/DaySummaryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/DaySummaryDTO.java
@@ -10,7 +10,11 @@ import java.util.List;
  * @param date      the date of the summary
  * @param entries   all meal entries logged for this day
  * @param totals    aggregated macro-nutrient totals across all entries
- * @param targets   computed daily nutrition targets (null if profile or weight data is missing)
+ * @param targets   the nutrition targets that applied on this day (null if profile or weight data is missing).
+ *                  If a target snapshot was recorded for this day (created the first time a meal entry was
+ *                  logged for it), that historical snapshot is returned so past days keep showing the targets
+ *                  that applied at the time, even if the profile or weight has since changed. Otherwise, the
+ *                  currently computed (live) targets are returned.
  * @param remaining remaining macro budget (targets minus totals; null if targets are unavailable)
  */
 @Schema(description = "Nutritional summary for a given day")
@@ -24,7 +28,9 @@ public record DaySummaryDTO(
         @Schema(description = "Aggregated macro-nutrient totals across all entries")
         MacrosDTO totals,
 
-        @Schema(description = "Computed daily nutrition targets; null if profile or weight data is missing")
+        @Schema(description = "Nutrition targets that applied on this day "
+                + "(a historical snapshot if one was recorded, otherwise live targets); "
+                + "null if profile or weight data is missing")
         TargetsDTO targets,
 
         @Schema(description = "Remaining macro budget (targets minus totals); null if targets are unavailable")

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/DayTargetSnapshotEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/DayTargetSnapshotEntity.java
@@ -1,0 +1,58 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing the nutrition targets that applied on a specific calendar day. */
+@Getter
+@Setter
+@Entity
+@Table(name = "day_target_snapshot", schema = "nutrition")
+public class DayTargetSnapshotEntity extends BasicEntity {
+
+    @Id
+    @Column(name = "entry_date", nullable = false, updatable = false)
+    private LocalDate entryDate;
+
+    @Column(name = "bmr", nullable = false)
+    private int bmr;
+
+    @Column(name = "maintenance_kcal", nullable = false)
+    private int maintenanceKcal;
+
+    @Column(name = "target_kcal", nullable = false)
+    private int targetKcal;
+
+    @Column(name = "protein_g", nullable = false)
+    private int proteinG;
+
+    @Column(name = "fat_g", nullable = false)
+    private int fatG;
+
+    @Column(name = "carbs_g", nullable = false)
+    private int carbsG;
+
+    @Column(name = "basis", nullable = false, length = 20)
+    private String basis;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DayTargetSnapshotEntity that = (DayTargetSnapshotEntity) o;
+        return Objects.equals(entryDate, that.entryDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(entryDate);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/DayTargetSnapshotRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/DayTargetSnapshotRepository.java
@@ -1,0 +1,9 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Spring Data JPA repository for per-day nutrition target snapshots. */
+public interface DayTargetSnapshotRepository extends JpaRepository<DayTargetSnapshotEntity, LocalDate> {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
@@ -1,6 +1,7 @@
 package com.marvin.nutrition.repository;
 
 import com.marvin.nutrition.entity.WeightEntryEntity;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,15 @@ public interface WeightEntryRepository extends JpaRepository<WeightEntryEntity, 
      * @return an Optional containing the latest entry, or empty if no entries exist
      */
     Optional<WeightEntryEntity> findTopByOrderByEntryDateDesc();
+
+    /**
+     * Returns the most recent weight entry on or before the given date, ordered by entry date descending.
+     * Used to determine the weight that applied as of a historical date.
+     *
+     * @param date the date to find the applicable weight entry for
+     * @return an Optional containing the applicable entry, or empty if no entry exists on or before that date
+     */
+    Optional<WeightEntryEntity> findTopByEntryDateLessThanEqualOrderByEntryDateDesc(LocalDate date);
 
     /**
      * Returns all weight entries ordered by entry date descending.

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -6,9 +6,11 @@ import com.marvin.nutrition.dto.MacrosDTO;
 import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealEntryEntity;
 import com.marvin.nutrition.mapper.MealEntryMapper;
+import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
 import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealEntryRepository;
 import java.math.BigDecimal;
@@ -34,24 +36,28 @@ public class MealEntryService {
     private final FoodRepository foodRepository;
     private final MealEntryMapper mealEntryMapper;
     private final NutritionTargetService nutritionTargetService;
+    private final DayTargetSnapshotRepository dayTargetSnapshotRepository;
 
     /**
      * Creates a new MealEntryService with the required dependencies.
      *
-     * @param mealEntryRepository    JPA repository for meal entries
-     * @param foodRepository         JPA repository for food catalog entries
-     * @param mealEntryMapper        MapStruct mapper for entity/DTO conversion
-     * @param nutritionTargetService service for computing daily nutrition targets
+     * @param mealEntryRepository         JPA repository for meal entries
+     * @param foodRepository              JPA repository for food catalog entries
+     * @param mealEntryMapper             MapStruct mapper for entity/DTO conversion
+     * @param nutritionTargetService      service for computing daily nutrition targets
+     * @param dayTargetSnapshotRepository JPA repository for per-day nutrition target snapshots
      */
     public MealEntryService(
             MealEntryRepository mealEntryRepository,
             FoodRepository foodRepository,
             MealEntryMapper mealEntryMapper,
-            NutritionTargetService nutritionTargetService) {
+            NutritionTargetService nutritionTargetService,
+            DayTargetSnapshotRepository dayTargetSnapshotRepository) {
         this.mealEntryRepository = mealEntryRepository;
         this.foodRepository = foodRepository;
         this.mealEntryMapper = mealEntryMapper;
         this.nutritionTargetService = nutritionTargetService;
+        this.dayTargetSnapshotRepository = dayTargetSnapshotRepository;
     }
 
     /**
@@ -72,14 +78,54 @@ public class MealEntryService {
             entity.setEntryDate(date);
             entity.setMealType(req.mealType());
 
+            final MealEntryDTO dto;
             if (req.foodId() != null) {
                 final String foodName = buildFoodEntry(entity, req);
-                return mealEntryMapper.toDTO(mealEntryRepository.save(entity), foodName);
+                dto = mealEntryMapper.toDTO(mealEntryRepository.save(entity), foodName);
+            } else {
+                buildAdHocEntry(entity, req);
+                dto = mealEntryMapper.toDTO(mealEntryRepository.save(entity));
             }
 
-            buildAdHocEntry(entity, req);
-            return mealEntryMapper.toDTO(mealEntryRepository.save(entity));
+            ensureDayTargetSnapshot(date);
+            return dto;
         }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Persists a {@link DayTargetSnapshotEntity} for the given date if one does not already exist
+     * and the daily nutrition targets can currently be computed. Silently does nothing if a
+     * snapshot already exists or if targets cannot be computed yet (e.g. no profile/weight data).
+     *
+     * @param date the date to snapshot targets for
+     */
+    private void ensureDayTargetSnapshot(LocalDate date) {
+        if (dayTargetSnapshotRepository.findById(date).isPresent()) {
+            return;
+        }
+        final Mono<TargetsDTO> targetsMono = nutritionTargetService.getTargets(date);
+        if (targetsMono == null) {
+            return;
+        }
+        final TargetsDTO targets;
+        try {
+            targets = targetsMono.block();
+        } catch (TargetCalculationException e) {
+            return;
+        }
+        if (targets == null) {
+            return;
+        }
+        final DayTargetSnapshotEntity snapshot = new DayTargetSnapshotEntity();
+        snapshot.setEntryDate(date);
+        snapshot.setBmr(targets.bmr());
+        snapshot.setMaintenanceKcal(targets.maintenanceKcal());
+        snapshot.setTargetKcal(targets.targetKcal());
+        snapshot.setProteinG(targets.proteinG());
+        snapshot.setFatG(targets.fatG());
+        snapshot.setCarbsG(targets.carbsG());
+        snapshot.setBasis(targets.basis());
+        dayTargetSnapshotRepository.save(snapshot);
     }
 
     /**
@@ -156,12 +202,39 @@ public class MealEntryService {
                     .collect(Collectors.toList());
         }).subscribeOn(Schedulers.boundedElastic());
 
-        final Mono<Optional<TargetsDTO>> targetsMono = nutritionTargetService.getTargets()
-                .map(Optional::of)
-                .onErrorReturn(TargetCalculationException.class, Optional.empty());
+        final Mono<Optional<TargetsDTO>> snapshotMono = Mono.fromCallable(() ->
+                dayTargetSnapshotRepository.findById(date).map(this::toTargetsDTO)
+        ).subscribeOn(Schedulers.boundedElastic());
+
+        final Mono<Optional<TargetsDTO>> targetsMono = snapshotMono.flatMap(snapshot -> {
+            if (snapshot.isPresent()) {
+                return Mono.just(snapshot);
+            }
+            return nutritionTargetService.getTargets()
+                    .map(Optional::of)
+                    .onErrorReturn(TargetCalculationException.class, Optional.empty());
+        });
 
         return Mono.zip(entriesMono, targetsMono)
                 .map(tuple -> buildDaySummary(date, tuple.getT1(), tuple.getT2().orElse(null)));
+    }
+
+    /**
+     * Converts a persisted day target snapshot into a {@link TargetsDTO}.
+     *
+     * @param snapshot the persisted snapshot entity
+     * @return the equivalent targets DTO
+     */
+    private TargetsDTO toTargetsDTO(DayTargetSnapshotEntity snapshot) {
+        return new TargetsDTO(
+                snapshot.getBmr(),
+                snapshot.getMaintenanceKcal(),
+                snapshot.getTargetKcal(),
+                snapshot.getProteinG(),
+                snapshot.getFatG(),
+                snapshot.getCarbsG(),
+                snapshot.getBasis()
+        );
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
@@ -5,6 +5,7 @@ import com.marvin.nutrition.entity.ProfileEntity;
 import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.repository.ProfileRepository;
 import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -44,6 +45,30 @@ public class NutritionTargetService {
             final ProfileEntity profile = profileRepository.findById(ProfileEntity.SINGLETON_ID).orElse(null);
             final WeightEntryEntity latestWeight = weightEntryRepository.findTopByOrderByEntryDateDesc().orElse(null);
             return targetService.computeTargets(profile, latestWeight);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Loads the current profile and the weight entry applicable as of the given date, computes and
+     * returns the daily nutrition targets that applied on that date.
+     *
+     * <p>The applicable weight is the most recent entry on or before {@code date}; if none exists
+     * (e.g. {@code date} is before the first ever weight entry), the latest known weight entry is
+     * used as a fallback so the calculation can still proceed.</p>
+     *
+     * <p>Emits {@link TargetCalculationException} if profile or weight data is missing entirely.</p>
+     *
+     * @param date the date to compute applicable targets for
+     * @return a Mono emitting the computed targets DTO
+     */
+    public Mono<TargetsDTO> getTargets(LocalDate date) {
+        return Mono.fromCallable(() -> {
+            final ProfileEntity profile = profileRepository.findById(ProfileEntity.SINGLETON_ID).orElse(null);
+            final WeightEntryEntity applicableWeight = weightEntryRepository
+                    .findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date)
+                    .or(weightEntryRepository::findTopByOrderByEntryDateDesc)
+                    .orElse(null);
+            return targetService.computeTargets(profile, applicableWeight, date);
         }).subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
@@ -42,7 +42,8 @@ public class TargetService {
     private static final double MIFFLIN_FEMALE_CONSTANT = -161.0;
 
     /**
-     * Computes daily nutrition targets from the given profile and the latest weight entry.
+     * Computes daily nutrition targets from the given profile and the latest weight entry,
+     * using today's date to determine age.
      *
      * @param profile     the user's nutrition profile; must not be null
      * @param latestWeight the most recent weight entry; must not be null
@@ -50,6 +51,21 @@ public class TargetService {
      * @throws TargetCalculationException if profile or latestWeight is null
      */
     public TargetsDTO computeTargets(ProfileEntity profile, WeightEntryEntity latestWeight) {
+        return computeTargets(profile, latestWeight, LocalDate.now());
+    }
+
+    /**
+     * Computes daily nutrition targets from the given profile and weight entry, computing age
+     * as of the given date rather than today. This allows historical day summaries to reflect
+     * the targets that applied on that day.
+     *
+     * @param profile      the user's nutrition profile; must not be null
+     * @param latestWeight the applicable weight entry; must not be null
+     * @param asOfDate     the date to use when computing age
+     * @return a {@link TargetsDTO} with all computed targets
+     * @throws TargetCalculationException if profile or latestWeight is null
+     */
+    public TargetsDTO computeTargets(ProfileEntity profile, WeightEntryEntity latestWeight, LocalDate asOfDate) {
         if (profile == null) {
             throw new TargetCalculationException("No nutrition profile found. Please create a profile first.");
         }
@@ -58,7 +74,7 @@ public class TargetService {
         }
 
         final double weightKg = latestWeight.getWeightKg().doubleValue();
-        final int bmr = resolveBmr(profile, weightKg);
+        final int bmr = resolveBmr(profile, weightKg, asOfDate);
         final int maintenanceKcal = computeMaintenance(bmr, profile.getActivityLevel());
         final int targetKcal = maintenanceKcal + goalAdjustment(profile.getGoal());
 
@@ -86,13 +102,14 @@ public class TargetService {
      *
      * @param profile  the user profile containing optional {@code basalKcal} override
      * @param weightKg current body weight in kilograms
+     * @param asOfDate the date to use when computing age
      * @return BMR rounded to the nearest whole kcal
      */
-    private int resolveBmr(ProfileEntity profile, double weightKg) {
+    private int resolveBmr(ProfileEntity profile, double weightKg, LocalDate asOfDate) {
         if (profile.getBasalKcal() != null) {
             return profile.getBasalKcal();
         }
-        return computeMifflinBmr(profile, weightKg);
+        return computeMifflinBmr(profile, weightKg, asOfDate);
     }
 
     /**
@@ -100,10 +117,11 @@ public class TargetService {
      *
      * @param profile  the user profile supplying sex, birth date and height
      * @param weightKg current body weight in kilograms
+     * @param asOfDate the date to use when computing age
      * @return BMR rounded to the nearest whole kcal
      */
-    private int computeMifflinBmr(ProfileEntity profile, double weightKg) {
-        final int age = Period.between(profile.getBirthDate(), LocalDate.now()).getYears();
+    private int computeMifflinBmr(ProfileEntity profile, double weightKg, LocalDate asOfDate) {
+        final int age = Period.between(profile.getBirthDate(), asOfDate).getYears();
         final double heightCm = profile.getHeightCm().doubleValue();
         final double sexConstant = profile.getSex() == Sex.MALE
                 ? MIFFLIN_MALE_CONSTANT

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_7__nutrition_day_target_snapshot.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_7__nutrition_day_target_snapshot.sql
@@ -1,0 +1,13 @@
+CREATE TABLE nutrition.day_target_snapshot
+(
+    entry_date       DATE           PRIMARY KEY,
+    bmr              INT            NOT NULL,
+    maintenance_kcal INT            NOT NULL,
+    target_kcal      INT            NOT NULL,
+    protein_g        INT            NOT NULL,
+    fat_g            INT            NOT NULL,
+    carbs_g          INT            NOT NULL,
+    basis            VARCHAR(20)    NOT NULL,
+    creation_date    TIMESTAMP      NOT NULL,
+    last_modified    TIMESTAMP      NOT NULL
+);

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -13,10 +13,12 @@ import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealEntryEntity;
 import com.marvin.nutrition.entity.MealType;
 import com.marvin.nutrition.mapper.MealEntryMapper;
+import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
 import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealEntryRepository;
 import java.math.BigDecimal;
@@ -51,6 +53,9 @@ class MealEntryServiceTest {
 
     @Mock
     private NutritionTargetService nutritionTargetService;
+
+    @Mock
+    private DayTargetSnapshotRepository dayTargetSnapshotRepository;
 
     @InjectMocks
     private MealEntryService mealEntryService;
@@ -247,6 +252,124 @@ class MealEntryServiceTest {
                 .verify();
 
         verify(mealEntryRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // addEntry — day target snapshot persistence
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntry persists a day target snapshot when none exists yet and targets can be computed")
+    void addEntry_NoExistingSnapshot_PersistsSnapshotFromComputedTargets() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity saved = new MealEntryEntity();
+        saved.setDescription("Homemade soup");
+        saved.setKcal(new BigDecimal("250.00"));
+        saved.setProteinG(new BigDecimal("15.00"));
+        saved.setCarbsG(new BigDecimal("30.00"));
+        saved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+
+        final TargetsDTO targets = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
+        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+        when(nutritionTargetService.getTargets(today)).thenReturn(Mono.just(targets));
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNext(adHocDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.equals(snapshot.getEntryDate())
+                        && snapshot.getBmr() == 1750
+                        && snapshot.getMaintenanceKcal() == 2160
+                        && snapshot.getTargetKcal() == 2160
+                        && snapshot.getProteinG() == 160
+                        && snapshot.getFatG() == 72
+                        && snapshot.getCarbsG() == 252
+                        && "MIFFLIN_ST_JEOR".equals(snapshot.getBasis())
+        ));
+    }
+
+    @Test
+    @DisplayName("addEntry does not overwrite an existing day target snapshot")
+    void addEntry_ExistingSnapshot_DoesNotOverwrite() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity saved = new MealEntryEntity();
+        saved.setDescription("Homemade soup");
+        saved.setKcal(new BigDecimal("250.00"));
+        saved.setProteinG(new BigDecimal("15.00"));
+        saved.setCarbsG(new BigDecimal("30.00"));
+        saved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
+        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(new DayTargetSnapshotEntity()));
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNext(adHocDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotRepository, never()).save(any());
+        verify(nutritionTargetService, never()).getTargets(any(LocalDate.class));
+    }
+
+    @Test
+    @DisplayName("addEntry skips snapshotting silently when targets cannot be computed yet")
+    void addEntry_TargetsUnavailable_SkipsSnapshotSilently() {
+        final CreateMealEntryRequest req = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity saved = new MealEntryEntity();
+        saved.setDescription("Homemade soup");
+        saved.setKcal(new BigDecimal("250.00"));
+        saved.setProteinG(new BigDecimal("15.00"));
+        saved.setCarbsG(new BigDecimal("30.00"));
+        saved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
+        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+        when(nutritionTargetService.getTargets(today))
+                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
+
+        StepVerifier.create(mealEntryService.addEntry(today, req))
+                .expectNext(adHocDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotRepository, never()).save(any());
     }
 
     // -----------------------------------------------------------------------
@@ -459,6 +582,77 @@ class MealEntryServiceTest {
                     assert BigDecimal.ZERO.compareTo(summary.totals().proteinG()) == 0;
                     assert BigDecimal.ZERO.compareTo(summary.totals().carbsG()) == 0;
                     assert BigDecimal.ZERO.compareTo(summary.totals().fatG()) == 0;
+                })
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // getDay — historical day target snapshot
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getDay uses the persisted snapshot's targets for a historical date, regardless of live targets")
+    void getDay_WithSnapshot_UsesSnapshotTargetsRegardlessOfLiveTargets() {
+        final MealEntryEntity entry = new MealEntryEntity();
+        entry.setKcal(new BigDecimal("400.00"));
+        entry.setProteinG(new BigDecimal("30.00"));
+        entry.setCarbsG(new BigDecimal("50.00"));
+        entry.setFatG(new BigDecimal("10.00"));
+
+        final MealEntryDTO dto = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.BREAKFAST, null, "Oats", null,
+                new BigDecimal("400.00"), new BigDecimal("30.00"),
+                new BigDecimal("50.00"), new BigDecimal("10.00"), null
+        );
+
+        final DayTargetSnapshotEntity snapshot = new DayTargetSnapshotEntity();
+        snapshot.setEntryDate(today);
+        snapshot.setBmr(1700);
+        snapshot.setMaintenanceKcal(2100);
+        snapshot.setTargetKcal(2000);
+        snapshot.setProteinG(150);
+        snapshot.setFatG(67);
+        snapshot.setCarbsG(248);
+        snapshot.setBasis("MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of(entry));
+        when(foodRepository.findAllById(any())).thenReturn(List.of());
+        when(mealEntryMapper.toDTO(any(MealEntryEntity.class), isNull())).thenReturn(dto);
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(snapshot));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assertEquals(2000, summary.targets().targetKcal());
+                    assertEquals(150, summary.targets().proteinG());
+                    assertEquals(67, summary.targets().fatG());
+                    assertEquals(248, summary.targets().carbsG());
+                    assertEquals(1700, summary.targets().bmr());
+                    assertEquals(2100, summary.targets().maintenanceKcal());
+                    assertEquals("MIFFLIN_ST_JEOR", summary.targets().basis());
+                    // remaining = snapshot targetKcal - totals.kcal = 2000 - 400 = 1600
+                    assertEquals(0, new BigDecimal("1600").compareTo(summary.remaining().kcal()));
+                })
+                .verifyComplete();
+
+        verify(nutritionTargetService, never()).getTargets();
+    }
+
+    @Test
+    @DisplayName("getDay falls back to live targets when no snapshot exists for the date")
+    void getDay_NoSnapshot_FallsBackToLiveTargets() {
+        final TargetsDTO liveTargets = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.findByEntryDateOrderByCreationDateAsc(today))
+                .thenReturn(List.of());
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+        when(nutritionTargetService.getTargets()).thenReturn(Mono.just(liveTargets));
+
+        StepVerifier.create(mealEntryService.getDay(today))
+                .assertNext(summary -> {
+                    assertEquals(2160, summary.targets().targetKcal());
+                    assertEquals(160, summary.targets().proteinG());
                 })
                 .verifyComplete();
     }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
@@ -12,6 +12,7 @@ import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.repository.ProfileRepository;
 import com.marvin.nutrition.repository.WeightEntryRepository;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -76,5 +77,55 @@ class NutritionTargetServiceTest {
                 .verify();
 
         verify(targetService).computeTargets(eq(null), eq(null));
+    }
+
+    // -----------------------------------------------------------------------
+    // getTargets(LocalDate date)
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getTargets(date) uses the weight applicable as of that date and computes age as of that date")
+    void getTargetsForDateUsesApplicableWeightAndDate() {
+        final LocalDate date = LocalDate.of(2026, 1, 15);
+        final ProfileEntity profile = new ProfileEntity();
+        profile.setId(ProfileEntity.SINGLETON_ID);
+        final WeightEntryEntity weight = new WeightEntryEntity();
+        weight.setWeightKg(BigDecimal.valueOf(78));
+        final TargetsDTO targets = new TargetsDTO(1700, 2100, 2100, 150, 70, 250, "MIFFLIN_ST_JEOR");
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(profile));
+        when(weightEntryRepository.findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date))
+                .thenReturn(Optional.of(weight));
+        when(targetService.computeTargets(profile, weight, date)).thenReturn(targets);
+
+        StepVerifier.create(nutritionTargetService.getTargets(date))
+                .expectNext(targets)
+                .verifyComplete();
+
+        verify(weightEntryRepository).findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date);
+        verify(weightEntryRepository, never()).findTopByOrderByEntryDateDesc();
+    }
+
+    @Test
+    @DisplayName("getTargets(date) falls back to the latest weight entry when none exists on/before that date")
+    void getTargetsForDateFallsBackToLatestWeightWhenNoneBeforeDate() {
+        final LocalDate date = LocalDate.of(2020, 1, 1);
+        final ProfileEntity profile = new ProfileEntity();
+        profile.setId(ProfileEntity.SINGLETON_ID);
+        final WeightEntryEntity latestWeight = new WeightEntryEntity();
+        latestWeight.setWeightKg(BigDecimal.valueOf(80));
+        final TargetsDTO targets = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(profile));
+        when(weightEntryRepository.findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date))
+                .thenReturn(Optional.empty());
+        when(weightEntryRepository.findTopByOrderByEntryDateDesc()).thenReturn(Optional.of(latestWeight));
+        when(targetService.computeTargets(profile, latestWeight, date)).thenReturn(targets);
+
+        StepVerifier.create(nutritionTargetService.getTargets(date))
+                .expectNext(targets)
+                .verifyComplete();
+
+        verify(weightEntryRepository).findTopByOrderByEntryDateDesc();
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -336,4 +336,46 @@ class TargetServiceTest {
         assertThrows(TargetCalculationException.class,
                 () -> targetService.computeTargets(p, null));
     }
+
+    // -----------------------------------------------------------------------
+    // Date-aware age computation (asOfDate overload)
+    // -----------------------------------------------------------------------
+
+    /**
+     * A person born on 2000-06-15 is 24 as of 2024-06-14 (birthday not yet reached)
+     * but 25 as of 2024-06-15 (birthday reached). With everything else fixed,
+     * the BMR (and therefore maintenance/target/carbs) must reflect the age as of
+     * the given date, not as of "today".
+     */
+    @Test
+    @DisplayName("computeTargets(profile, weight, asOfDate) computes age as of the given date")
+    void compute_WithAsOfDate_UsesAgeAsOfThatDate() {
+        final LocalDate birthDate = LocalDate.of(2000, 6, 15);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.MODERATE, Goal.MAINTAIN, 2.0, 0.30, null);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO beforeBirthday = targetService.computeTargets(p, w, LocalDate.of(2024, 6, 14));
+        final TargetsDTO onBirthday = targetService.computeTargets(p, w, LocalDate.of(2024, 6, 15));
+
+        // BMR = 10*80 + 6.25*175 - 5*age + 5 = 1898.75 - 5*age
+        // 2024-06-14 (day before 24th birthday): age 23 -> 1898.75 - 115 = 1783.75 -> 1784
+        // 2024-06-15 (24th birthday): age 24 -> 1898.75 - 120 = 1778.75 -> 1779
+        assertEquals(1784, beforeBirthday.bmr());
+        assertEquals(1779, onBirthday.bmr());
+    }
+
+    @Test
+    @DisplayName("computeTargets(profile, weight) (2-arg) delegates to asOfDate overload using today")
+    void compute_TwoArgOverload_DelegatesUsingToday() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.MODERATE, Goal.MAINTAIN, 2.0, 0.30, null);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO twoArgResult = targetService.computeTargets(p, w);
+        final TargetsDTO threeArgResult = targetService.computeTargets(p, w, LocalDate.now());
+
+        assertEquals(threeArgResult, twoArgResult);
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #136. Day summaries for past dates now reflect the nutrition targets that applied on that day (age computed as of that date, weight applicable as of that date), rather than always showing today's live targets.
- A `nutrition.day_target_snapshot` row is persisted for a date the first time a meal entry is logged for it (skipped silently if profile/weight data isn't available yet).
- `getDay(date)` prefers the persisted snapshot if one exists, falling back to live targets (today's profile/weight) when no snapshot exists — e.g. for "today" before the first entry, or future dates.

## Changes
- `V1_7__nutrition_day_target_snapshot.sql`: new `nutrition.day_target_snapshot` table.
- `DayTargetSnapshotEntity` / `DayTargetSnapshotRepository`: new entity and JPA repository.
- `WeightEntryRepository.findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date)`: finds the weight applicable as of a given date.
- `TargetService.computeTargets(profile, weight, asOfDate)`: new overload computing age as of `asOfDate`; the existing 2-arg method now delegates to it with `LocalDate.now()`.
- `NutritionTargetService.getTargets(date)`: new method resolving the applicable weight (falling back to the latest known weight if none exists on/before `date`) and delegating to the 3-arg `computeTargets`.
- `MealEntryService.addEntry`: persists a day target snapshot for the entry's date if one doesn't exist yet and targets can be computed.
- `MealEntryService.getDay`: uses the persisted snapshot's targets when present, otherwise falls back to live targets as before.
- `DaySummaryDTO`: javadoc updated to describe the snapshot-vs-live target semantics.

## Test plan
- [x] `./gradlew :nutrition:test` passes (all new and existing tests green)
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` clean
- [x] tdd-test-guardian confirmed no existing tests were modified, only new tests added