### PR TITLE
fix(nutrition): remove dead null check in ensureDayTargetSnapshot

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -103,13 +103,9 @@ public class MealEntryService {
         if (dayTargetSnapshotRepository.findById(date).isPresent()) {
             return;
         }
-        final Mono<TargetsDTO> targetsMono = nutritionTargetService.getTargets(date);
-        if (targetsMono == null) {
-            return;
-        }
         final TargetsDTO targets;
         try {
-            targets = targetsMono.block();
+            targets = nutritionTargetService.getTargets(date).block();
         } catch (TargetCalculationException e) {
             return;
         }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,6 +96,8 @@ class MealEntryServiceTest {
                 new BigDecimal("300.00"), new BigDecimal("30.00"),
                 new BigDecimal("15.00"), new BigDecimal("7.50"), "Test Food"
         );
+
+        lenient().when(nutritionTargetService.getTargets(any(LocalDate.class))).thenReturn(Mono.empty());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes the dead `targetsMono == null` check in `MealEntryService.ensureDayTargetSnapshot`. `NutritionTargetService.getTargets(LocalDate)` never returns null, so this branch was unreachable.
- Adds a default lenient stub for `nutritionTargetService.getTargets(any(LocalDate.class))` in `MealEntryServiceTest` setup, since several tests previously relied on the dead null-check to avoid an NPE on the unstubbed mock.

Closes #150

## Test plan
- [x] `./gradlew :nutrition:test`
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest`