### PR TITLE
fix(nutrition): drop .block() in ensureDayTargetSnapshot

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -105,11 +105,8 @@ public class MealEntryService {
         }
         final TargetsDTO targets;
         try {
-            targets = nutritionTargetService.getTargets(date).block();
+            targets = nutritionTargetService.getTargetsSync(date);
         } catch (TargetCalculationException e) {
-            return;
-        }
-        if (targets == null) {
             return;
         }
         final DayTargetSnapshotEntity snapshot = new DayTargetSnapshotEntity();

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionTargetService.java
@@ -62,13 +62,31 @@ public class NutritionTargetService {
      * @return a Mono emitting the computed targets DTO
      */
     public Mono<TargetsDTO> getTargets(LocalDate date) {
-        return Mono.fromCallable(() -> {
-            final ProfileEntity profile = profileRepository.findById(ProfileEntity.SINGLETON_ID).orElse(null);
-            final WeightEntryEntity applicableWeight = weightEntryRepository
-                    .findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date)
-                    .or(weightEntryRepository::findTopByOrderByEntryDateDesc)
-                    .orElse(null);
-            return targetService.computeTargets(profile, applicableWeight, date);
-        }).subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> getTargetsSync(date)).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Loads the current profile and the weight entry applicable as of the given date, then computes
+     * and returns the daily nutrition targets that applied on that date, synchronously.
+     *
+     * <p>The applicable weight is the most recent entry on or before {@code date}; if none exists
+     * (e.g. {@code date} is before the first ever weight entry), the latest known weight entry is
+     * used as a fallback so the calculation can still proceed.</p>
+     *
+     * <p>Throws {@link TargetCalculationException} if profile or weight data is missing entirely.</p>
+     *
+     * <p>This method performs blocking repository access and must only be called from a thread
+     * already running on a blocking-friendly scheduler (e.g. {@link Schedulers#boundedElastic()}).</p>
+     *
+     * @param date the date to compute applicable targets for
+     * @return the computed targets DTO
+     */
+    public TargetsDTO getTargetsSync(LocalDate date) {
+        final ProfileEntity profile = profileRepository.findById(ProfileEntity.SINGLETON_ID).orElse(null);
+        final WeightEntryEntity applicableWeight = weightEntryRepository
+                .findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date)
+                .or(weightEntryRepository::findTopByOrderByEntryDateDesc)
+                .orElse(null);
+        return targetService.computeTargets(profile, applicableWeight, date);
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -97,7 +98,8 @@ class MealEntryServiceTest {
                 new BigDecimal("15.00"), new BigDecimal("7.50"), "Test Food"
         );
 
-        lenient().when(nutritionTargetService.getTargets(any(LocalDate.class))).thenReturn(Mono.empty());
+        lenient().when(nutritionTargetService.getTargetsSync(any(LocalDate.class)))
+                .thenThrow(new TargetCalculationException("No profile"));
     }
 
     // -----------------------------------------------------------------------
@@ -288,7 +290,7 @@ class MealEntryServiceTest {
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
         when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
         when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
-        when(nutritionTargetService.getTargets(today)).thenReturn(Mono.just(targets));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(today);
 
         StepVerifier.create(mealEntryService.addEntry(today, req))
                 .expectNext(adHocDTO)
@@ -337,7 +339,7 @@ class MealEntryServiceTest {
                 .verifyComplete();
 
         verify(dayTargetSnapshotRepository, never()).save(any());
-        verify(nutritionTargetService, never()).getTargets(any(LocalDate.class));
+        verify(nutritionTargetService, never()).getTargetsSync(any(LocalDate.class));
     }
 
     @Test
@@ -365,8 +367,6 @@ class MealEntryServiceTest {
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
         when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
         when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
-        when(nutritionTargetService.getTargets(today))
-                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
 
         StepVerifier.create(mealEntryService.addEntry(today, req))
                 .expectNext(adHocDTO)

--- a/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/NutritionTargetServiceTest.java
@@ -1,5 +1,7 @@
 package com.marvin.nutrition.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
@@ -127,5 +129,44 @@ class NutritionTargetServiceTest {
                 .verifyComplete();
 
         verify(weightEntryRepository).findTopByOrderByEntryDateDesc();
+    }
+
+    // -----------------------------------------------------------------------
+    // getTargetsSync(LocalDate date)
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getTargetsSync computes targets synchronously using the weight applicable as of that date")
+    void getTargetsSyncUsesApplicableWeightAndDate() {
+        final LocalDate date = LocalDate.of(2026, 1, 15);
+        final ProfileEntity profile = new ProfileEntity();
+        profile.setId(ProfileEntity.SINGLETON_ID);
+        final WeightEntryEntity weight = new WeightEntryEntity();
+        weight.setWeightKg(BigDecimal.valueOf(78));
+        final TargetsDTO targets = new TargetsDTO(1700, 2100, 2100, 150, 70, 250, "MIFFLIN_ST_JEOR");
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.of(profile));
+        when(weightEntryRepository.findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date))
+                .thenReturn(Optional.of(weight));
+        when(targetService.computeTargets(profile, weight, date)).thenReturn(targets);
+
+        assertEquals(targets, nutritionTargetService.getTargetsSync(date));
+
+        verify(weightEntryRepository, never()).findTopByOrderByEntryDateDesc();
+    }
+
+    @Test
+    @DisplayName("getTargetsSync throws TargetCalculationException when profile or weight data is missing")
+    void getTargetsSyncThrowsWhenDataMissing() {
+        final LocalDate date = LocalDate.of(2026, 1, 15);
+
+        when(profileRepository.findById(ProfileEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+        when(weightEntryRepository.findTopByEntryDateLessThanEqualOrderByEntryDateDesc(date))
+                .thenReturn(Optional.empty());
+        when(weightEntryRepository.findTopByOrderByEntryDateDesc()).thenReturn(Optional.empty());
+        when(targetService.computeTargets(isNull(), isNull(), eq(date)))
+                .thenThrow(new TargetCalculationException("No nutrition profile found. Please create a profile first."));
+
+        assertThrows(TargetCalculationException.class, () -> nutritionTargetService.getTargetsSync(date));
     }
 }


### PR DESCRIPTION
## Summary
- `ensureDayTargetSnapshot` no longer calls `nutritionTargetService.getTargets(date).block()` from within an already-`boundedElastic` `Mono.fromCallable`.
- Extracted the synchronous computation into a new `NutritionTargetService.getTargetsSync(LocalDate)` method (throws `TargetCalculationException` directly), called synchronously from `ensureDayTargetSnapshot`.
- `getTargets(LocalDate)` is now a thin reactive wrapper around `getTargetsSync(date)`, preserving its existing external contract.
- Removed the now-dead `targets == null` check, since `getTargetsSync` either returns a non-null DTO or throws.

Closes #151

## Test plan
- [x] `./gradlew :nutrition:test` (153 tests pass)
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest`
- [x] No `.block()` remains in `MealEntryService.java`