### PR TITLE
fix(nutrition): refresh day-target snapshot when same-day weight is logged

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/DayTargetSnapshotService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/DayTargetSnapshotService.java
@@ -1,0 +1,94 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
+import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
+import java.time.LocalDate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Owns read/write logic for per-day nutrition target snapshots.
+ *
+ * <p>All methods in this service perform blocking repository access and must only be called from
+ * a thread already running on a blocking-friendly scheduler (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}).</p>
+ */
+@Service
+public class DayTargetSnapshotService {
+
+    private final DayTargetSnapshotRepository dayTargetSnapshotRepository;
+    private final NutritionTargetService nutritionTargetService;
+
+    /**
+     * Creates a new DayTargetSnapshotService.
+     *
+     * @param dayTargetSnapshotRepository JPA repository for per-day nutrition target snapshots
+     * @param nutritionTargetService      service for computing daily nutrition targets
+     */
+    public DayTargetSnapshotService(
+            DayTargetSnapshotRepository dayTargetSnapshotRepository,
+            NutritionTargetService nutritionTargetService) {
+        this.dayTargetSnapshotRepository = dayTargetSnapshotRepository;
+        this.nutritionTargetService = nutritionTargetService;
+    }
+
+    /**
+     * Persists a {@link DayTargetSnapshotEntity} for the given date if one does not already exist
+     * and the daily nutrition targets can currently be computed. Silently does nothing if a
+     * snapshot already exists or if targets cannot be computed yet (e.g. no profile/weight data).
+     *
+     * @param date the date to snapshot targets for
+     */
+    public void ensureSnapshot(LocalDate date) {
+        if (dayTargetSnapshotRepository.findById(date).isPresent()) {
+            return;
+        }
+        final TargetsDTO targets;
+        try {
+            targets = nutritionTargetService.getTargetsSync(date);
+        } catch (TargetCalculationException e) {
+            return;
+        }
+        dayTargetSnapshotRepository.save(toSnapshot(new DayTargetSnapshotEntity(), date, targets));
+    }
+
+    /**
+     * Recomputes and overwrites the {@link DayTargetSnapshotEntity} for the given date if one
+     * already exists. Silently leaves the existing snapshot untouched if targets cannot currently
+     * be computed (e.g. no profile/weight data). Does nothing if no snapshot exists for the date.
+     *
+     * @param date the date whose snapshot should be refreshed
+     */
+    public void refreshSnapshotIfExists(LocalDate date) {
+        final DayTargetSnapshotEntity existing = dayTargetSnapshotRepository.findById(date).orElse(null);
+        if (existing == null) {
+            return;
+        }
+        final TargetsDTO targets;
+        try {
+            targets = nutritionTargetService.getTargetsSync(date);
+        } catch (TargetCalculationException e) {
+            return;
+        }
+        dayTargetSnapshotRepository.save(toSnapshot(existing, date, targets));
+    }
+
+    /**
+     * Populates the given snapshot entity's fields from the computed targets.
+     *
+     * @param snapshot the snapshot entity to populate (new or existing)
+     * @param date     the date the snapshot applies to
+     * @param targets  the computed nutrition targets
+     * @return the populated snapshot entity
+     */
+    private DayTargetSnapshotEntity toSnapshot(DayTargetSnapshotEntity snapshot, LocalDate date, TargetsDTO targets) {
+        snapshot.setEntryDate(date);
+        snapshot.setBmr(targets.bmr());
+        snapshot.setMaintenanceKcal(targets.maintenanceKcal());
+        snapshot.setTargetKcal(targets.targetKcal());
+        snapshot.setProteinG(targets.proteinG());
+        snapshot.setFatG(targets.fatG());
+        snapshot.setCarbsG(targets.carbsG());
+        snapshot.setBasis(targets.basis());
+        return snapshot;
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -37,6 +37,7 @@ public class MealEntryService {
     private final MealEntryMapper mealEntryMapper;
     private final NutritionTargetService nutritionTargetService;
     private final DayTargetSnapshotRepository dayTargetSnapshotRepository;
+    private final DayTargetSnapshotService dayTargetSnapshotService;
 
     /**
      * Creates a new MealEntryService with the required dependencies.
@@ -46,18 +47,21 @@ public class MealEntryService {
      * @param mealEntryMapper             MapStruct mapper for entity/DTO conversion
      * @param nutritionTargetService      service for computing daily nutrition targets
      * @param dayTargetSnapshotRepository JPA repository for per-day nutrition target snapshots
+     * @param dayTargetSnapshotService    service for creating/refreshing per-day nutrition target snapshots
      */
     public MealEntryService(
             MealEntryRepository mealEntryRepository,
             FoodRepository foodRepository,
             MealEntryMapper mealEntryMapper,
             NutritionTargetService nutritionTargetService,
-            DayTargetSnapshotRepository dayTargetSnapshotRepository) {
+            DayTargetSnapshotRepository dayTargetSnapshotRepository,
+            DayTargetSnapshotService dayTargetSnapshotService) {
         this.mealEntryRepository = mealEntryRepository;
         this.foodRepository = foodRepository;
         this.mealEntryMapper = mealEntryMapper;
         this.nutritionTargetService = nutritionTargetService;
         this.dayTargetSnapshotRepository = dayTargetSnapshotRepository;
+        this.dayTargetSnapshotService = dayTargetSnapshotService;
     }
 
     /**
@@ -87,38 +91,9 @@ public class MealEntryService {
                 dto = mealEntryMapper.toDTO(mealEntryRepository.save(entity));
             }
 
-            ensureDayTargetSnapshot(date);
+            dayTargetSnapshotService.ensureSnapshot(date);
             return dto;
         }).subscribeOn(Schedulers.boundedElastic());
-    }
-
-    /**
-     * Persists a {@link DayTargetSnapshotEntity} for the given date if one does not already exist
-     * and the daily nutrition targets can currently be computed. Silently does nothing if a
-     * snapshot already exists or if targets cannot be computed yet (e.g. no profile/weight data).
-     *
-     * @param date the date to snapshot targets for
-     */
-    private void ensureDayTargetSnapshot(LocalDate date) {
-        if (dayTargetSnapshotRepository.findById(date).isPresent()) {
-            return;
-        }
-        final TargetsDTO targets;
-        try {
-            targets = nutritionTargetService.getTargetsSync(date);
-        } catch (TargetCalculationException e) {
-            return;
-        }
-        final DayTargetSnapshotEntity snapshot = new DayTargetSnapshotEntity();
-        snapshot.setEntryDate(date);
-        snapshot.setBmr(targets.bmr());
-        snapshot.setMaintenanceKcal(targets.maintenanceKcal());
-        snapshot.setTargetKcal(targets.targetKcal());
-        snapshot.setProteinG(targets.proteinG());
-        snapshot.setFatG(targets.fatG());
-        snapshot.setCarbsG(targets.carbsG());
-        snapshot.setBasis(targets.basis());
-        dayTargetSnapshotRepository.save(snapshot);
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
@@ -5,6 +5,7 @@ import com.marvin.nutrition.dto.WeightEntryDTO;
 import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.mapper.WeightEntryMapper;
 import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
@@ -18,16 +19,22 @@ public class WeightService {
 
     private final WeightEntryRepository weightEntryRepository;
     private final WeightEntryMapper weightEntryMapper;
+    private final DayTargetSnapshotService dayTargetSnapshotService;
 
     /**
      * Creates a new WeightService.
      *
-     * @param weightEntryRepository JPA repository for weight entries
-     * @param weightEntryMapper     MapStruct mapper for entity/DTO conversion
+     * @param weightEntryRepository    JPA repository for weight entries
+     * @param weightEntryMapper        MapStruct mapper for entity/DTO conversion
+     * @param dayTargetSnapshotService service for creating/refreshing per-day nutrition target snapshots
      */
-    public WeightService(WeightEntryRepository weightEntryRepository, WeightEntryMapper weightEntryMapper) {
+    public WeightService(
+            WeightEntryRepository weightEntryRepository,
+            WeightEntryMapper weightEntryMapper,
+            DayTargetSnapshotService dayTargetSnapshotService) {
         this.weightEntryRepository = weightEntryRepository;
         this.weightEntryMapper = weightEntryMapper;
+        this.dayTargetSnapshotService = dayTargetSnapshotService;
     }
 
     /**
@@ -45,6 +52,8 @@ public class WeightService {
 
     /**
      * Creates a new weight entry.
+     * Refreshes the day-target snapshot for the entry date if one already exists, so that the
+     * newly recorded weight is reflected in that day's targets.
      *
      * @param request the entry date and weight in kg
      * @return a Mono emitting the created weight entry DTO
@@ -54,12 +63,17 @@ public class WeightService {
             final WeightEntryEntity entity = new WeightEntryEntity();
             entity.setEntryDate(request.entryDate());
             entity.setWeightKg(request.weightKg());
-            return weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+            final WeightEntryDTO dto = weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+            dayTargetSnapshotService.refreshSnapshotIfExists(request.entryDate());
+            return dto;
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
      * Updates an existing weight entry.
+     * Refreshes the day-target snapshot for the new entry date if one already exists. If the entry
+     * date changed, also refreshes the snapshot for the previous date, since the applicable weight
+     * for that day may now differ.
      * Emits {@link NoSuchElementException} if no entry with the given id exists.
      *
      * @param id      the id of the entry to update
@@ -70,9 +84,15 @@ public class WeightService {
         return Mono.fromCallable(() -> {
             final WeightEntryEntity entity = weightEntryRepository.findById(id)
                     .orElseThrow(() -> new NoSuchElementException("Weight entry not found: " + id));
+            final LocalDate oldEntryDate = entity.getEntryDate();
             entity.setEntryDate(request.entryDate());
             entity.setWeightKg(request.weightKg());
-            return weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+            final WeightEntryDTO dto = weightEntryMapper.toDTO(weightEntryRepository.save(entity));
+            dayTargetSnapshotService.refreshSnapshotIfExists(request.entryDate());
+            if (!oldEntryDate.equals(request.entryDate())) {
+                dayTargetSnapshotService.refreshSnapshotIfExists(oldEntryDate);
+            }
+            return dto;
         }).subscribeOn(Schedulers.boundedElastic());
     }
 

--- a/nutrition/src/test/java/com/marvin/nutrition/service/DayTargetSnapshotServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/DayTargetSnapshotServiceTest.java
@@ -1,0 +1,157 @@
+package com.marvin.nutrition.service;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.TargetsDTO;
+import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
+import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link DayTargetSnapshotService}. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DayTargetSnapshotService Tests")
+class DayTargetSnapshotServiceTest {
+
+    @Mock
+    private DayTargetSnapshotRepository dayTargetSnapshotRepository;
+
+    @Mock
+    private NutritionTargetService nutritionTargetService;
+
+    @InjectMocks
+    private DayTargetSnapshotService dayTargetSnapshotService;
+
+    private LocalDate today;
+    private TargetsDTO targets;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        today = LocalDate.of(2026, 6, 7);
+        targets = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+    }
+
+    // -----------------------------------------------------------------------
+    // ensureSnapshot
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("ensureSnapshot persists a snapshot when none exists and targets can be computed")
+    void ensureSnapshot_NoExistingSnapshot_PersistsSnapshotFromComputedTargets() {
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(today);
+
+        dayTargetSnapshotService.ensureSnapshot(today);
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.equals(snapshot.getEntryDate())
+                        && snapshot.getBmr() == 1750
+                        && snapshot.getMaintenanceKcal() == 2160
+                        && snapshot.getTargetKcal() == 2160
+                        && snapshot.getProteinG() == 160
+                        && snapshot.getFatG() == 72
+                        && snapshot.getCarbsG() == 252
+                        && "MIFFLIN_ST_JEOR".equals(snapshot.getBasis())
+        ));
+    }
+
+    @Test
+    @DisplayName("ensureSnapshot does nothing when a snapshot already exists")
+    void ensureSnapshot_ExistingSnapshot_DoesNothing() {
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(new DayTargetSnapshotEntity()));
+
+        dayTargetSnapshotService.ensureSnapshot(today);
+
+        verify(dayTargetSnapshotRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(nutritionTargetService, never()).getTargetsSync(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("ensureSnapshot does nothing when targets cannot be computed")
+    void ensureSnapshot_TargetsUnavailable_DoesNothing() {
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+        when(nutritionTargetService.getTargetsSync(today)).thenThrow(new TargetCalculationException("No profile"));
+
+        dayTargetSnapshotService.ensureSnapshot(today);
+
+        verify(dayTargetSnapshotRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    // -----------------------------------------------------------------------
+    // refreshSnapshotIfExists
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("refreshSnapshotIfExists overwrites an existing snapshot with freshly computed targets")
+    void refreshSnapshotIfExists_ExistingSnapshot_OverwritesWithComputedTargets() {
+        final DayTargetSnapshotEntity existing = new DayTargetSnapshotEntity();
+        existing.setEntryDate(today);
+        existing.setBmr(1700);
+        existing.setMaintenanceKcal(2100);
+        existing.setTargetKcal(2000);
+        existing.setProteinG(150);
+        existing.setFatG(67);
+        existing.setCarbsG(248);
+        existing.setBasis("BASAL_KCAL");
+
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(existing));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(today);
+
+        dayTargetSnapshotService.refreshSnapshotIfExists(today);
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.equals(snapshot.getEntryDate())
+                        && snapshot.getBmr() == 1750
+                        && snapshot.getMaintenanceKcal() == 2160
+                        && snapshot.getTargetKcal() == 2160
+                        && snapshot.getProteinG() == 160
+                        && snapshot.getFatG() == 72
+                        && snapshot.getCarbsG() == 252
+                        && "MIFFLIN_ST_JEOR".equals(snapshot.getBasis())
+        ));
+    }
+
+    @Test
+    @DisplayName("refreshSnapshotIfExists does nothing when no snapshot exists for the date")
+    void refreshSnapshotIfExists_NoSnapshot_DoesNothing() {
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
+
+        dayTargetSnapshotService.refreshSnapshotIfExists(today);
+
+        verify(dayTargetSnapshotRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(nutritionTargetService, never()).getTargetsSync(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("refreshSnapshotIfExists leaves the existing snapshot untouched when targets cannot be computed")
+    void refreshSnapshotIfExists_TargetsUnavailable_LeavesExistingSnapshotUntouched() {
+        final DayTargetSnapshotEntity existing = new DayTargetSnapshotEntity();
+        existing.setEntryDate(today);
+        existing.setBmr(1700);
+        existing.setMaintenanceKcal(2100);
+        existing.setTargetKcal(2000);
+        existing.setProteinG(150);
+        existing.setFatG(67);
+        existing.setCarbsG(248);
+        existing.setBasis("BASAL_KCAL");
+
+        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(existing));
+        when(nutritionTargetService.getTargetsSync(today)).thenThrow(new TargetCalculationException("No profile"));
+
+        dayTargetSnapshotService.refreshSnapshotIfExists(today);
+
+        verify(dayTargetSnapshotRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +57,9 @@ class MealEntryServiceTest {
     @Mock
     private DayTargetSnapshotRepository dayTargetSnapshotRepository;
 
+    @Mock
+    private DayTargetSnapshotService dayTargetSnapshotService;
+
     @InjectMocks
     private MealEntryService mealEntryService;
 
@@ -97,9 +98,6 @@ class MealEntryServiceTest {
                 new BigDecimal("300.00"), new BigDecimal("30.00"),
                 new BigDecimal("15.00"), new BigDecimal("7.50"), "Test Food"
         );
-
-        lenient().when(nutritionTargetService.getTargetsSync(any(LocalDate.class)))
-                .thenThrow(new TargetCalculationException("No profile"));
     }
 
     // -----------------------------------------------------------------------
@@ -264,53 +262,8 @@ class MealEntryServiceTest {
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("addEntry persists a day target snapshot when none exists yet and targets can be computed")
-    void addEntry_NoExistingSnapshot_PersistsSnapshotFromComputedTargets() {
-        final CreateMealEntryRequest req = new CreateMealEntryRequest(
-                MealType.SNACK, null, null, "Homemade soup",
-                new BigDecimal("250.00"), new BigDecimal("15.00"),
-                new BigDecimal("30.00"), new BigDecimal("8.00")
-        );
-
-        final MealEntryEntity saved = new MealEntryEntity();
-        saved.setDescription("Homemade soup");
-        saved.setKcal(new BigDecimal("250.00"));
-        saved.setProteinG(new BigDecimal("15.00"));
-        saved.setCarbsG(new BigDecimal("30.00"));
-        saved.setFatG(new BigDecimal("8.00"));
-
-        final MealEntryDTO adHocDTO = new MealEntryDTO(
-                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
-                new BigDecimal("250.00"), new BigDecimal("15.00"),
-                new BigDecimal("30.00"), new BigDecimal("8.00"), null
-        );
-
-        final TargetsDTO targets = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
-
-        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
-        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
-        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
-        doReturn(targets).when(nutritionTargetService).getTargetsSync(today);
-
-        StepVerifier.create(mealEntryService.addEntry(today, req))
-                .expectNext(adHocDTO)
-                .verifyComplete();
-
-        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
-                today.equals(snapshot.getEntryDate())
-                        && snapshot.getBmr() == 1750
-                        && snapshot.getMaintenanceKcal() == 2160
-                        && snapshot.getTargetKcal() == 2160
-                        && snapshot.getProteinG() == 160
-                        && snapshot.getFatG() == 72
-                        && snapshot.getCarbsG() == 252
-                        && "MIFFLIN_ST_JEOR".equals(snapshot.getBasis())
-        ));
-    }
-
-    @Test
-    @DisplayName("addEntry does not overwrite an existing day target snapshot")
-    void addEntry_ExistingSnapshot_DoesNotOverwrite() {
+    @DisplayName("addEntry delegates day-target snapshot creation to DayTargetSnapshotService")
+    void addEntry_DelegatesSnapshotCreationToDayTargetSnapshotService() {
         final CreateMealEntryRequest req = new CreateMealEntryRequest(
                 MealType.SNACK, null, null, "Homemade soup",
                 new BigDecimal("250.00"), new BigDecimal("15.00"),
@@ -332,47 +285,12 @@ class MealEntryServiceTest {
 
         when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
         when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
-        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.of(new DayTargetSnapshotEntity()));
 
         StepVerifier.create(mealEntryService.addEntry(today, req))
                 .expectNext(adHocDTO)
                 .verifyComplete();
 
-        verify(dayTargetSnapshotRepository, never()).save(any());
-        verify(nutritionTargetService, never()).getTargetsSync(any(LocalDate.class));
-    }
-
-    @Test
-    @DisplayName("addEntry skips snapshotting silently when targets cannot be computed yet")
-    void addEntry_TargetsUnavailable_SkipsSnapshotSilently() {
-        final CreateMealEntryRequest req = new CreateMealEntryRequest(
-                MealType.SNACK, null, null, "Homemade soup",
-                new BigDecimal("250.00"), new BigDecimal("15.00"),
-                new BigDecimal("30.00"), new BigDecimal("8.00")
-        );
-
-        final MealEntryEntity saved = new MealEntryEntity();
-        saved.setDescription("Homemade soup");
-        saved.setKcal(new BigDecimal("250.00"));
-        saved.setProteinG(new BigDecimal("15.00"));
-        saved.setCarbsG(new BigDecimal("30.00"));
-        saved.setFatG(new BigDecimal("8.00"));
-
-        final MealEntryDTO adHocDTO = new MealEntryDTO(
-                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
-                new BigDecimal("250.00"), new BigDecimal("15.00"),
-                new BigDecimal("30.00"), new BigDecimal("8.00"), null
-        );
-
-        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(saved);
-        when(mealEntryMapper.toDTO(saved)).thenReturn(adHocDTO);
-        when(dayTargetSnapshotRepository.findById(today)).thenReturn(Optional.empty());
-
-        StepVerifier.create(mealEntryService.addEntry(today, req))
-                .expectNext(adHocDTO)
-                .verifyComplete();
-
-        verify(dayTargetSnapshotRepository, never()).save(any());
+        verify(dayTargetSnapshotService).ensureSnapshot(today);
     }
 
     // -----------------------------------------------------------------------

--- a/nutrition/src/test/java/com/marvin/nutrition/service/WeightServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/WeightServiceTest.java
@@ -1,0 +1,165 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateWeightEntryRequest;
+import com.marvin.nutrition.dto.WeightEntryDTO;
+import com.marvin.nutrition.entity.WeightEntryEntity;
+import com.marvin.nutrition.mapper.WeightEntryMapper;
+import com.marvin.nutrition.repository.WeightEntryRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link WeightService} covering CRUD and day-target snapshot refresh side effects. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WeightService Tests")
+class WeightServiceTest {
+
+    @Mock
+    private WeightEntryRepository weightEntryRepository;
+
+    @Mock
+    private WeightEntryMapper weightEntryMapper;
+
+    @Mock
+    private DayTargetSnapshotService dayTargetSnapshotService;
+
+    @InjectMocks
+    private WeightService weightService;
+
+    private LocalDate today;
+    private WeightEntryDTO weightEntryDTO;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        today = LocalDate.of(2026, 6, 7);
+        weightEntryDTO = new WeightEntryDTO(1L, today, new BigDecimal("80.50"));
+    }
+
+    // -----------------------------------------------------------------------
+    // create
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create persists the entry and refreshes the day-target snapshot for the entry date")
+    void create_PersistsEntryAndRefreshesSnapshotForEntryDate() {
+        final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
+        final WeightEntryEntity saved = new WeightEntryEntity();
+        saved.setEntryDate(today);
+        saved.setWeightKg(new BigDecimal("80.50"));
+
+        when(weightEntryRepository.save(any(WeightEntryEntity.class))).thenReturn(saved);
+        when(weightEntryMapper.toDTO(saved)).thenReturn(weightEntryDTO);
+
+        StepVerifier.create(weightService.create(request))
+                .expectNext(weightEntryDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
+    }
+
+    // -----------------------------------------------------------------------
+    // update
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("update emits NoSuchElementException when entry not found")
+    void update_NotFound_EmitsNoSuchElementException() {
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.empty());
+
+        final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
+
+        StepVerifier.create(weightService.update(1L, request))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(weightEntryRepository, never()).save(any());
+        verify(dayTargetSnapshotService, never()).refreshSnapshotIfExists(any());
+    }
+
+    @Test
+    @DisplayName("update refreshes the snapshot only for the new date when the entry date is unchanged")
+    void update_DateUnchanged_RefreshesSnapshotOnceForNewDate() {
+        final WeightEntryEntity existing = new WeightEntryEntity();
+        existing.setId(1L);
+        existing.setEntryDate(today);
+        existing.setWeightKg(new BigDecimal("79.00"));
+
+        final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
+
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(weightEntryRepository.save(any(WeightEntryEntity.class))).thenReturn(existing);
+        when(weightEntryMapper.toDTO(existing)).thenReturn(weightEntryDTO);
+
+        StepVerifier.create(weightService.update(1L, request))
+                .expectNext(weightEntryDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
+        verify(dayTargetSnapshotService, org.mockito.Mockito.times(1)).refreshSnapshotIfExists(any());
+    }
+
+    @Test
+    @DisplayName("update refreshes the snapshot for both the old and new date when the entry date changes")
+    void update_DateChanged_RefreshesSnapshotForOldAndNewDate() {
+        final LocalDate oldDate = today.minusDays(1);
+        final WeightEntryEntity existing = new WeightEntryEntity();
+        existing.setId(1L);
+        existing.setEntryDate(oldDate);
+        existing.setWeightKg(new BigDecimal("79.00"));
+
+        final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
+
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(weightEntryRepository.save(any(WeightEntryEntity.class))).thenReturn(existing);
+        when(weightEntryMapper.toDTO(existing)).thenReturn(weightEntryDTO);
+
+        StepVerifier.create(weightService.update(1L, request))
+                .expectNext(weightEntryDTO)
+                .verifyComplete();
+
+        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
+        verify(dayTargetSnapshotService).refreshSnapshotIfExists(oldDate);
+    }
+
+    // -----------------------------------------------------------------------
+    // sanity: entity mutation reflects request values
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("update applies the new entry date and weight to the persisted entity")
+    void update_AppliesNewEntryDateAndWeight() {
+        final WeightEntryEntity existing = new WeightEntryEntity();
+        existing.setId(1L);
+        existing.setEntryDate(today.minusDays(1));
+        existing.setWeightKg(new BigDecimal("79.00"));
+
+        final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
+
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(weightEntryRepository.save(any(WeightEntryEntity.class))).thenReturn(existing);
+        when(weightEntryMapper.toDTO(existing)).thenReturn(weightEntryDTO);
+
+        StepVerifier.create(weightService.update(1L, request))
+                .expectNext(weightEntryDTO)
+                .verifyComplete();
+
+        assertEquals(today, existing.getEntryDate());
+        assertEquals(new BigDecimal("80.50"), existing.getWeightKg());
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted `DayTargetSnapshotService` from `MealEntryService.ensureDayTargetSnapshot`, with:
  - `ensureSnapshot(date)` — creates a snapshot for `date` if absent and targets are computable (unchanged behavior, moved from `MealEntryService`).
  - `refreshSnapshotIfExists(date)` — overwrites an existing snapshot for `date` with freshly computed targets; no-op if no snapshot exists or targets aren't computable.
- `MealEntryService.addEntry` now delegates snapshot creation to `dayTargetSnapshotService.ensureSnapshot(date)`.
- `WeightService.create`/`update` now call `refreshSnapshotIfExists` for the affected date(s) — including both the old and new date on `update` when the entry's date changes — so a same-day weight logged after the first meal entry is reflected in that day's targets.

Closes #153

## Test plan
- [x] `./gradlew :nutrition:test` (162 tests pass)
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest`
- [x] New `DayTargetSnapshotServiceTest` and `WeightServiceTest` cover the new/changed behavior