### PR TITLE
fix(nutrition): return generic 409 for non-weight DataIntegrityViolationExceptions

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -44,13 +44,38 @@ public class NutritionExceptionHandler {
     /**
      * Maps {@link DataIntegrityViolationException} to HTTP 409 Conflict.
      *
+     * <p>If the violation originates from the {@code weight_entry} unique date constraint, a
+     * weight-specific message is returned. For any other constraint violation (e.g. day-target
+     * snapshot or profile singleton constraints), a generic conflict message is returned so
+     * callers are not misled.</p>
+     *
      * @param ex the exception
-     * @return 409 response indicating a duplicate weight entry for the same date
+     * @return 409 response with a message describing the conflict
      */
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<String> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        if (isWeightEntryDateConflict(ex)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("A weight entry for this date already exists");
+        }
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body("A weight entry for this date already exists");
+                .body("The request conflicts with existing data.");
+    }
+
+    /**
+     * Determines whether the given exception was caused by a violation of the
+     * {@code weight_entry} table's unique entry-date constraint.
+     *
+     * @param ex the exception to inspect
+     * @return {@code true} if the cause is a Hibernate constraint violation on the weight entry date
+     */
+    private boolean isWeightEntryDateConflict(DataIntegrityViolationException ex) {
+        final Throwable cause = ex.getCause();
+        if (!(cause instanceof org.hibernate.exception.ConstraintViolationException constraintViolation)) {
+            return false;
+        }
+        final String constraintName = constraintViolation.getConstraintName();
+        return constraintName != null && constraintName.startsWith("weight_entry");
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -26,5 +27,71 @@ class NutritionExceptionHandlerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNotNull(response.getBody());
+    }
+
+    @Test
+    @DisplayName("handleDataIntegrityViolation returns 409 with weight-specific message for duplicate weight entry date")
+    void handleDataIntegrityViolation_WeightEntryConstraint_ReturnsWeightSpecificMessage() {
+        final org.hibernate.exception.ConstraintViolationException cause =
+                new org.hibernate.exception.ConstraintViolationException(
+                        "duplicate key value violates unique constraint", null, "weight_entry_entry_date_key");
+        final DataIntegrityViolationException ex = new DataIntegrityViolationException("conflict", cause);
+
+        final ResponseEntity<String> response = handler.handleDataIntegrityViolation(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("A weight entry for this date already exists", response.getBody());
+    }
+
+    @Test
+    @DisplayName("handleDataIntegrityViolation returns 409 with generic message for other constraint violations")
+    void handleDataIntegrityViolation_OtherConstraint_ReturnsGenericMessage() {
+        final org.hibernate.exception.ConstraintViolationException cause =
+                new org.hibernate.exception.ConstraintViolationException(
+                        "duplicate key value violates unique constraint", null, "day_target_snapshot_pkey");
+        final DataIntegrityViolationException ex = new DataIntegrityViolationException("conflict", cause);
+
+        final ResponseEntity<String> response = handler.handleDataIntegrityViolation(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("The request conflicts with existing data.", response.getBody());
+    }
+
+    @Test
+    @DisplayName("handleDataIntegrityViolation returns 409 with generic message for profile singleton constraint")
+    void handleDataIntegrityViolation_ProfileSingletonConstraint_ReturnsGenericMessage() {
+        final org.hibernate.exception.ConstraintViolationException cause =
+                new org.hibernate.exception.ConstraintViolationException(
+                        "check constraint violation", null, "profile_single_row");
+        final DataIntegrityViolationException ex = new DataIntegrityViolationException("conflict", cause);
+
+        final ResponseEntity<String> response = handler.handleDataIntegrityViolation(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("The request conflicts with existing data.", response.getBody());
+    }
+
+    @Test
+    @DisplayName("handleDataIntegrityViolation returns 409 with generic message when cause is not a hibernate constraint violation")
+    void handleDataIntegrityViolation_NoRecognizableCause_ReturnsGenericMessage() {
+        final DataIntegrityViolationException ex = new DataIntegrityViolationException("some message");
+
+        final ResponseEntity<String> response = handler.handleDataIntegrityViolation(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("The request conflicts with existing data.", response.getBody());
+    }
+
+    @Test
+    @DisplayName("handleDataIntegrityViolation returns 409 with generic message when constraint name is null")
+    void handleDataIntegrityViolation_NullConstraintName_ReturnsGenericMessage() {
+        final org.hibernate.exception.ConstraintViolationException cause =
+                new org.hibernate.exception.ConstraintViolationException("some violation", null, null);
+        final DataIntegrityViolationException ex = new DataIntegrityViolationException("conflict", cause);
+
+        final ResponseEntity<String> response = handler.handleDataIntegrityViolation(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("The request conflicts with existing data.", response.getBody());
     }
 }


### PR DESCRIPTION
## Summary
- `NutritionExceptionHandler.handleDataIntegrityViolation` previously returned a hardcoded weight-entry-specific 409 message for **every** `DataIntegrityViolationException` raised anywhere in the `com.marvin.nutrition` package.
- Now it inspects the Hibernate constraint violation cause: only a `weight_entry` date-uniqueness violation gets the weight-specific message; any other constraint violation (day-target snapshot PK, profile singleton check, future NOT NULL/FK/range violations) gets a generic "The request conflicts with existing data." message.

## Test plan
- [x] Added unit tests in `NutritionExceptionHandlerTest` covering: weight_entry constraint → weight message, day_target_snapshot/profile constraints → generic message, no/unknown cause → generic message
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes
- [x] `./gradlew :nutrition:test --tests "*NutritionExceptionHandlerTest*"` passes (6 tests)

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)