### PR TITLE
fix(nutrition): add @Past birthDate and upper bounds to ProfileDTO

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/ProfileDTO.java
@@ -5,7 +5,9 @@ import com.marvin.nutrition.entity.Goal;
 import com.marvin.nutrition.entity.Sex;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -33,11 +35,13 @@ public record ProfileDTO(
         Sex sex,
 
         @NotNull
+        @Past
         @Schema(description = "Date of birth", example = "1990-05-15")
         LocalDate birthDate,
 
         @NotNull
         @Positive
+        @DecimalMax("300")
         @Schema(description = "Height in centimetres", example = "175")
         BigDecimal heightCm,
 
@@ -50,6 +54,7 @@ public record ProfileDTO(
         Goal goal,
 
         @Positive
+        @DecimalMax("10")
         @Schema(description = "Grams of protein per kg body weight", example = "2.0")
         BigDecimal proteinPerKg,
 
@@ -60,6 +65,7 @@ public record ProfileDTO(
         BigDecimal fatPct,
 
         @Positive
+        @Max(10000)
         @Schema(description = "Manual BMR override in kcal; null uses Mifflin–St Jeor formula", example = "1800")
         Integer basalKcal
 ) {

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/ProfileDTOValidationTest.java
@@ -10,6 +10,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -128,6 +129,102 @@ public class ProfileDTOValidationTest {
         assertTrue(
                 violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("fatPct")),
                 "Expected the violation to be on the 'fatPct' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with a future birthDate yields a violation")
+    void profile_futureBirthDate_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.now().plus(Period.ofDays(1)),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("0.30"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for a future birthDate");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("birthDate")),
+                "Expected the violation to be on the 'birthDate' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with heightCm above the sane upper bound yields a violation")
+    void profile_heightCmAboveUpperBound_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("301"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("0.30"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for heightCm above the sane upper bound");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("heightCm")),
+                "Expected the violation to be on the 'heightCm' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with proteinPerKg above the sane upper bound yields a violation")
+    void profile_proteinPerKgAboveUpperBound_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("10.5"),
+                new BigDecimal("0.30"),
+                1800
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for proteinPerKg above the sane upper bound");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("proteinPerKg")),
+                "Expected the violation to be on the 'proteinPerKg' property"
+        );
+    }
+
+    @Test
+    @DisplayName("ProfileDTO with basalKcal above the sane upper bound yields a violation")
+    void profile_basalKcalAboveUpperBound_yieldsViolation() {
+        final ProfileDTO profile = new ProfileDTO(
+                null,
+                Sex.MALE,
+                LocalDate.of(1990, 5, 15),
+                new BigDecimal("175"),
+                ActivityLevel.MODERATE,
+                Goal.MAINTAIN,
+                new BigDecimal("2.0"),
+                new BigDecimal("0.30"),
+                10001
+        );
+
+        final Set<ConstraintViolation<ProfileDTO>> violations = validator.validate(profile);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for basalKcal above the sane upper bound");
+        assertTrue(
+                violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("basalKcal")),
+                "Expected the violation to be on the 'basalKcal' property"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add `@Past` to `ProfileDTO.birthDate` so a future birth date is rejected with a 400 instead of producing a negative age (and thus an inflated BMR via `TargetService.computeMifflinBmr`).
- Add `@DecimalMax("300")` to `heightCm` and `@DecimalMax("10")` to `proteinPerKg`, and `@Max(10000)` to `basalKcal`, so out-of-range values are rejected as 400 validation errors before hitting the DB's NUMERIC(5,1)/NUMERIC(4,2) column limits (avoiding the mis-mapped 409).

Fixes #148

## Test plan
- [x] New tests in `ProfileDTOValidationTest` cover future birthDate, oversized heightCm, oversized proteinPerKg, oversized basalKcal — all rejected with a validation violation
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest :nutrition:test` passes