### PR TITLE
fix(nutrition): cap scan-label upload size (#149)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -55,6 +55,7 @@ public class FoodController {
     private static final String DEFAULT_PAGE = "0";
     private static final String DEFAULT_SIZE = "50";
     private static final long MAX_SIZE = 200;
+    private static final int MAX_LABEL_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
     private final FoodService foodService;
     private final LabelReader labelReader;
@@ -284,7 +285,7 @@ public class FoodController {
      * @return a Mono emitting the complete file bytes
      */
     private Mono<byte[]> extractBytes(FilePart filePart) {
-        return DataBufferUtils.join(filePart.content())
+        return DataBufferUtils.join(filePart.content(), MAX_LABEL_IMAGE_SIZE_BYTES)
                 .map(dataBuffer -> {
                     final byte[] bytes = new byte[dataBuffer.readableByteCount()];
                     dataBuffer.read(bytes);

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/FoodController.java
@@ -232,6 +232,7 @@ public class FoodController {
                         description = "Label successfully read; draft food returned",
                         content = @Content(schema = @Schema(implementation = FoodDraftDTO.class))
                 ),
+                @ApiResponse(responseCode = "413", description = "Uploaded file exceeds the maximum allowed size"),
                 @ApiResponse(responseCode = "422", description = "Label could not be read or parsed")
             }
     )

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -120,6 +121,18 @@ public class NutritionExceptionHandler {
     @ExceptionHandler(BarcodeLookupException.class)
     public ResponseEntity<String> handleBarcodeLookup(BarcodeLookupException ex) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
+    }
+
+    /**
+     * Maps {@link DataBufferLimitException} to HTTP 413 Payload Too Large.
+     *
+     * @param ex the exception indicating the uploaded file exceeded the configured byte limit
+     * @return 413 response with a message describing the maximum allowed size
+     */
+    @ExceptionHandler(DataBufferLimitException.class)
+    public ResponseEntity<String> handleDataBufferLimit(DataBufferLimitException ex) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body("Uploaded file exceeds the maximum allowed size of 10 MB");
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -293,6 +294,22 @@ class FoodControllerTest {
 
         StepVerifier.create(result)
                 .expectError(LabelReadException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("scanLabel propagates DataBufferLimitException when upload exceeds the maximum allowed size")
+    void scanLabel_UploadExceedsMaxSize_PropagatesError() {
+        // 10 MB cap configured in FoodController.MAX_LABEL_IMAGE_SIZE_BYTES; one byte over the cap.
+        final byte[] oversizedImageBytes = new byte[10 * 1024 * 1024 + 1];
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(oversizedImageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+
+        final Mono<ResponseEntity<FoodDraftDTO>> result = foodController.scanLabel(filePart);
+
+        StepVerifier.create(result)
+                .expectError(DataBufferLimitException.class)
                 .verify();
     }
 

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/NutritionExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,18 @@ import org.springframework.http.ResponseEntity;
 class NutritionExceptionHandlerTest {
 
     private final NutritionExceptionHandler handler = new NutritionExceptionHandler();
+
+    @Test
+    @DisplayName("handleDataBufferLimit returns 413 with a message about the maximum allowed size")
+    void handleDataBufferLimit_ReturnsPayloadTooLarge() {
+        final DataBufferLimitException ex = new DataBufferLimitException("Exceeded limit on max bytes to buffer");
+
+        final ResponseEntity<String> response = handler.handleDataBufferLimit(ex);
+
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("Uploaded file exceeds the maximum allowed size of 10 MB", response.getBody());
+    }
 
     @Test
     @DisplayName("handleConstraintViolation returns 400")


### PR DESCRIPTION
## Summary
- Cap `/nutrition/foods/scan-label` uploads to 10 MB by passing an explicit `maxByteCount` to `DataBufferUtils.join` in `FoodController.extractBytes`
- Add `MAX_LABEL_IMAGE_SIZE_BYTES` constant (10 MB)
- Map `DataBufferLimitException` to HTTP 413 Payload Too Large in `NutritionExceptionHandler` with a clear message

Fixes #149

## Test plan
- [x] New test: `FoodControllerTest.scanLabel_UploadExceedsMaxSize_PropagatesError` verifies `DataBufferLimitException` is propagated for an oversized upload
- [x] New test: `NutritionExceptionHandlerTest.handleDataBufferLimit_ReturnsPayloadTooLarge` verifies 413 mapping
- [x] Existing `scanLabel_Success_Returns200WithDraft` still passes unchanged
- [x] `./gradlew :nutrition:test --tests "*FoodControllerTest*" --tests "*NutritionExceptionHandlerTest*"` — BUILD SUCCESSFUL
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — BUILD SUCCESSFUL