### PR TITLE
fix(nutrition): signal infeasible macro split via TargetsDTO.macrosFeasible

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/TargetsDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/TargetsDTO.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @param fatG            daily fat target in grams
  * @param carbsG          daily carbohydrate target in grams
  * @param basis           how BMR was derived: BASAL_KCAL or MIFFLIN_ST_JEOR
+ * @param macrosFeasible  whether protein and fat kcal fit within targetKcal, leaving carbs &gt;= 0
  */
 @Schema(description = "Computed daily nutrition targets")
 public record TargetsDTO(
@@ -34,6 +35,29 @@ public record TargetsDTO(
         int carbsG,
 
         @Schema(description = "How BMR was derived", example = "MIFFLIN_ST_JEOR")
-        String basis
+        String basis,
+
+        @Schema(description = "False when protein + fat kcal exceed targetKcal, "
+                + "meaning carbs were floored to 0 and the macro split does not reconcile", example = "true")
+        boolean macrosFeasible
 ) {
+
+    private static final int KCAL_PER_GRAM_PROTEIN = 4;
+    private static final int KCAL_PER_GRAM_FAT = 9;
+
+    /**
+     * Convenience constructor that derives {@code macrosFeasible} from the given grams and target.
+     *
+     * @param bmr             basal metabolic rate in kcal
+     * @param maintenanceKcal maintenance calories (BMR × activity factor)
+     * @param targetKcal      daily target calories after goal adjustment
+     * @param proteinG        daily protein target in grams
+     * @param fatG            daily fat target in grams
+     * @param carbsG          daily carbohydrate target in grams
+     * @param basis           how BMR was derived: BASAL_KCAL or MIFFLIN_ST_JEOR
+     */
+    public TargetsDTO(int bmr, int maintenanceKcal, int targetKcal, int proteinG, int fatG, int carbsG, String basis) {
+        this(bmr, maintenanceKcal, targetKcal, proteinG, fatG, carbsG, basis,
+                proteinG * KCAL_PER_GRAM_PROTEIN + fatG * KCAL_PER_GRAM_FAT <= targetKcal);
+    }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -1,7 +1,9 @@
 package com.marvin.nutrition.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.entity.ActivityLevel;
@@ -327,7 +329,7 @@ class TargetServiceTest {
 
         final TargetsDTO result = targetService.computeTargets(p, w);
 
-        assertEquals(false, result.macrosFeasible());
+        assertFalse(result.macrosFeasible());
     }
 
     @Test
@@ -340,7 +342,8 @@ class TargetServiceTest {
 
         final TargetsDTO result = targetService.computeTargets(p, w);
 
-        assertEquals(true, result.macrosFeasible());
+        assertTrue(result.macrosFeasible());
+        assertTrue(result.carbsG() > 0);
     }
 
     // -----------------------------------------------------------------------

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -313,6 +313,36 @@ class TargetServiceTest {
         assertEquals(0, result.carbsG());
     }
 
+    /**
+     * Same scenario as {@link #compute_HighProteinFatExceedsTarget_CarbsClampedToZero()}: protein+fat
+     * kcal (1280) exceeds targetKcal (1180), so the macro split is infeasible and must be signalled.
+     */
+    @Test
+    @DisplayName("macrosFeasible is false when protein+fat kcal exceeds targetKcal")
+    void compute_HighProteinFatExceedsTarget_MacrosFeasibleIsFalse() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.FEMALE, birthDate, 160.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 3.5, 0.55, 1400);
+        final WeightEntryEntity w = weight(45.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(false, result.macrosFeasible());
+    }
+
+    @Test
+    @DisplayName("macrosFeasible is true when protein+fat kcal does not exceed targetKcal")
+    void compute_NormalMacros_MacrosFeasibleIsTrue() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.MODERATE, Goal.MAINTAIN, 2.0, 0.30, null);
+        final WeightEntryEntity w = weight(80.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(true, result.macrosFeasible());
+    }
+
     // -----------------------------------------------------------------------
     // Error cases
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds a `macrosFeasible` flag to `TargetsDTO` that is `false` when `proteinKcal + fatKcal > targetKcal`, signalling that carbs were floored to 0 and the macro split does not reconcile with `targetKcal`.
- Derived automatically via a backward-compatible 7-arg constructor overload, so all existing call sites (`TargetService`, snapshot reconstruction in `MealEntryService`) get the correct value without changes.

Closes #154

## Test plan
- [x] New unit tests in `TargetServiceTest`: `compute_HighProteinFatExceedsTarget_MacrosFeasibleIsFalse` and `compute_NormalMacros_MacrosFeasibleIsTrue`
- [x] `./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` passes
- [x] Verified no existing tests were modified (tdd-test-guardian)

🤖 Generated with [Claude Code](https://claude.com/claude-code)