### PR TITLE
feat(nutrition): batch meal entry creation endpoint (#168)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
@@ -1,5 +1,6 @@
 package com.marvin.nutrition.controller;
 
+import com.marvin.nutrition.dto.CreateMealEntriesRequest;
 import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.DaySummaryDTO;
 import com.marvin.nutrition.dto.MealEntryDTO;
@@ -85,6 +86,44 @@ public class MealEntryController {
                     final URI location = URI.create(ENTRIES_LOCATION_PREFIX + created.id());
                     return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
                 });
+    }
+
+    /**
+     * Logs multiple new meal entries for the given date in a single database transaction and
+     * returns 201 Created with the created entries as a JSON array (no Location header).
+     *
+     * @param date the date to log the entries for
+     * @param req  the batch create request body, containing a non-empty list of entries
+     * @return a Mono with 201 Created and the created meal entry DTOs, or 404 if any referenced food is not found
+     */
+    @PostMapping("/nutrition/days/{date}/entries/batch")
+    @Operation(
+            summary = "Log multiple meal entries in one transaction",
+            description = "Adds multiple meal entries for the given day in a single database transaction. "
+                    + "Each entry follows the same rules as POST /nutrition/days/{date}/entries: "
+                    + "supply foodId for food-backed entries (macros are snapshotted); "
+                    + "omit foodId and supply description + macros for ad-hoc entries. "
+                    + "Unlike the single-entry endpoint, the response body is a JSON array and no "
+                    + "Location header is set. If any entry references an unknown food, the whole "
+                    + "batch is rolled back.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Meal entries created",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = MealEntryDTO.class)))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed: empty list or invalid entry"),
+                @ApiResponse(responseCode = "404", description = "Referenced food not found; nothing was persisted")
+            }
+    )
+    public Mono<ResponseEntity<List<MealEntryDTO>>> addEntries(
+            @PathVariable
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "Date of the meal entries (ISO-8601)", example = "2026-06-07") LocalDate date,
+            @Valid @RequestBody CreateMealEntriesRequest req) {
+        return mealEntryService.addEntries(date, req.entries())
+                .map(created -> ResponseEntity.status(HttpStatus.CREATED).body(created))
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntriesRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntriesRequest.java
@@ -3,18 +3,20 @@ package com.marvin.nutrition.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 /**
  * Request body for creating multiple meal log entries for a given day in a single transaction.
  *
- * @param entries non-empty list of meal entries to create; each element is validated individually
+ * @param entries non-empty list (max 50) of meal entries to create; each element is validated individually
  */
 @Schema(description = "Request to log multiple meal entries for a given day in one transaction")
 public record CreateMealEntriesRequest(
         @NotEmpty
+        @Size(max = 50)
         @Valid
-        @Schema(description = "Non-empty list of meal entries to create")
+        @Schema(description = "Non-empty list of meal entries to create (max 50)")
         List<CreateMealEntryRequest> entries
 ) {
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntriesRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealEntriesRequest.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+/**
+ * Request body for creating multiple meal log entries for a given day in a single transaction.
+ *
+ * @param entries non-empty list of meal entries to create; each element is validated individually
+ */
+@Schema(description = "Request to log multiple meal entries for a given day in one transaction")
+public record CreateMealEntriesRequest(
+        @NotEmpty
+        @Valid
+        @Schema(description = "Non-empty list of meal entries to create")
+        List<CreateMealEntryRequest> entries
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -80,6 +80,22 @@ public class MealEntryService {
     }
 
     /**
+     * Logs multiple new meal entries for the given date in a single transaction.
+     * Each request is processed the same way as {@link #addEntry(LocalDate, CreateMealEntryRequest)}.
+     * Emits {@link NoSuchElementException} if any referenced food is not found, in which case
+     * nothing is persisted.
+     * Emits {@link IllegalArgumentException} if required fields are missing for any entry's mode.
+     *
+     * @param date     the date to log the entries for
+     * @param requests the create requests, one per entry to be logged
+     * @return a Mono emitting the created meal entry DTOs, in the same order as {@code requests}
+     */
+    public Mono<List<MealEntryDTO>> addEntries(LocalDate date, List<CreateMealEntryRequest> requests) {
+        return Mono.fromCallable(() -> mealEntryWriteService.createEntries(date, requests))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
      * Updates an existing meal entry.
      * For food-backed entries, a new {@code quantityG} triggers macro re-snapshotting from the food catalog.
      * For ad-hoc entries, any non-null macro values and description from the request are applied directly;

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryWriteService.java
@@ -11,6 +11,8 @@ import com.marvin.nutrition.repository.MealEntryRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -81,6 +83,42 @@ public class MealEntryWriteService {
 
         dayTargetSnapshotService.ensureSnapshot(date);
         return dto;
+    }
+
+    /**
+     * Logs multiple new meal entries for the given date in a single transaction and ensures a
+     * day-target snapshot exists for it. Each request is processed the same way as
+     * {@link #createEntry(LocalDate, CreateMealEntryRequest)}: food-backed entries (non-null
+     * {@code foodId}) have their macros snapshotted from the food catalog, ad-hoc entries persist
+     * the supplied macro values directly. The day-target snapshot is ensured exactly once after
+     * all entries have been saved.
+     * Throws {@link NoSuchElementException} if any referenced food is not found, rolling back the
+     * whole batch.
+     * Throws {@link IllegalArgumentException} if required fields are missing for any entry's mode.
+     *
+     * @param date     the date to log the entries for
+     * @param requests the create requests, one per entry to be logged
+     * @return the created meal entry DTOs, in the same order as {@code requests}
+     */
+    @Transactional
+    public List<MealEntryDTO> createEntries(LocalDate date, List<CreateMealEntryRequest> requests) {
+        final List<MealEntryDTO> created = new ArrayList<>();
+        for (final CreateMealEntryRequest req : requests) {
+            final MealEntryEntity entity = new MealEntryEntity();
+            entity.setEntryDate(date);
+            entity.setMealType(req.mealType());
+
+            if (req.foodId() != null) {
+                final String foodName = buildFoodEntry(entity, req);
+                created.add(mealEntryMapper.toDTO(mealEntryRepository.save(entity), foodName));
+            } else {
+                buildAdHocEntry(entity, req);
+                created.add(mealEntryMapper.toDTO(mealEntryRepository.save(entity)));
+            }
+        }
+
+        dayTargetSnapshotService.ensureSnapshot(date);
+        return created;
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marvin.nutrition.dto.CreateMealEntriesRequest;
 import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.DaySummaryDTO;
 import com.marvin.nutrition.dto.MacrosDTO;
@@ -97,6 +98,57 @@ class MealEntryControllerTest {
                 .verifyComplete();
 
         verify(mealEntryService).addEntry(eq(today), any(CreateMealEntryRequest.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/days/{date}/entries/batch
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntries returns 201 Created with list body")
+    void addEntries_Valid_Returns201WithListBody() {
+        final MealEntryDTO second = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.DINNER, null, "Soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+        final List<CreateMealEntryRequest> requests = List.of(createRequest, createRequest);
+        final CreateMealEntriesRequest batchRequest = new CreateMealEntriesRequest(requests);
+
+        when(mealEntryService.addEntries(eq(today), eq(requests)))
+                .thenReturn(Mono.just(List.of(mealEntryDTO, second)));
+
+        final Mono<ResponseEntity<List<MealEntryDTO>>> result =
+                mealEntryController.addEntries(today, batchRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(2, response.getBody().size());
+                })
+                .verifyComplete();
+
+        verify(mealEntryService).addEntries(eq(today), eq(requests));
+    }
+
+    @Test
+    @DisplayName("addEntries returns 404 when service emits NoSuchElementException")
+    void addEntries_UnknownFoodId_Returns404() {
+        final List<CreateMealEntryRequest> requests = List.of(createRequest);
+        final CreateMealEntriesRequest batchRequest = new CreateMealEntriesRequest(requests);
+
+        when(mealEntryService.addEntries(eq(today), eq(requests)))
+                .thenReturn(Mono.error(new NoSuchElementException("Food not found")));
+
+        final Mono<ResponseEntity<List<MealEntryDTO>>> result =
+                mealEntryController.addEntries(today, batchRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealEntryService).addEntries(eq(today), eq(requests));
     }
 
     // -----------------------------------------------------------------------

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryWriteServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,7 @@ import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealEntryRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
@@ -508,5 +510,99 @@ class MealEntryWriteServiceTest {
         mealEntryWriteService.updateEntry(entryId, req);
 
         verify(mealEntryRepository).save(argThat(e -> "Test Food".equals(e.getFoodName())));
+    }
+
+    // -----------------------------------------------------------------------
+    // createEntries — batch creation
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createEntries saves macros for multiple food-backed entries and ensures snapshot once")
+    void createEntries_MultipleFoodEntries_SnapshotsMacrosAndEnsuresSnapshotOnce() {
+        final CreateMealEntryRequest req1 = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+        final CreateMealEntryRequest req2 = new CreateMealEntryRequest(
+                MealType.DINNER, foodId, new BigDecimal("100"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        final List<MealEntryDTO> result =
+                mealEntryWriteService.createEntries(today, List.of(req1, req2));
+
+        assertEquals(2, result.size());
+        assertEquals(mealEntryDTO, result.get(0));
+        assertEquals(mealEntryDTO, result.get(1));
+        verify(mealEntryRepository, times(2)).save(argThat(e ->
+                foodId.equals(e.getFoodId())
+        ));
+        verify(dayTargetSnapshotService, times(1)).ensureSnapshot(today);
+    }
+
+    @Test
+    @DisplayName("createEntries saves a mix of food-backed and ad-hoc entries correctly")
+    void createEntries_MixOfFoodAndAdHocEntries_SavesBothCorrectly() {
+        final CreateMealEntryRequest foodReq = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+        final CreateMealEntryRequest adHocReq = new CreateMealEntryRequest(
+                MealType.SNACK, null, null, "Homemade soup",
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00")
+        );
+
+        final MealEntryEntity adHocSaved = new MealEntryEntity();
+        adHocSaved.setDescription("Homemade soup");
+        adHocSaved.setKcal(new BigDecimal("250.00"));
+        adHocSaved.setProteinG(new BigDecimal("15.00"));
+        adHocSaved.setCarbsG(new BigDecimal("30.00"));
+        adHocSaved.setFatG(new BigDecimal("8.00"));
+
+        final MealEntryDTO adHocDTO = new MealEntryDTO(
+                UUID.randomUUID(), today, MealType.SNACK, null, "Homemade soup", null,
+                new BigDecimal("250.00"), new BigDecimal("15.00"),
+                new BigDecimal("30.00"), new BigDecimal("8.00"), null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenAnswer(invocation -> {
+            final MealEntryEntity entity = invocation.getArgument(0);
+            return entity.getFoodId() != null ? mealEntryEntity : adHocSaved;
+        });
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+        when(mealEntryMapper.toDTO(adHocSaved)).thenReturn(adHocDTO);
+
+        final List<MealEntryDTO> result =
+                mealEntryWriteService.createEntries(today, List.of(foodReq, adHocReq));
+
+        assertEquals(2, result.size());
+        assertEquals(mealEntryDTO, result.get(0));
+        assertEquals(adHocDTO, result.get(1));
+        verify(dayTargetSnapshotService, times(1)).ensureSnapshot(today);
+    }
+
+    @Test
+    @DisplayName("createEntries throws NoSuchElementException for unknown foodId and never calls ensureSnapshot")
+    void createEntries_UnknownFoodId_ThrowsAndNeverEnsuresSnapshot() {
+        final UUID unknownFoodId = UUID.randomUUID();
+        final CreateMealEntryRequest validReq = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, new BigDecimal("150"), null, null, null, null, null
+        );
+        final CreateMealEntryRequest invalidReq = new CreateMealEntryRequest(
+                MealType.DINNER, unknownFoodId, new BigDecimal("100"), null, null, null, null, null
+        );
+
+        when(foodRepository.findById(foodId)).thenReturn(Optional.of(foodEntity));
+        when(foodRepository.findById(unknownFoodId)).thenReturn(Optional.empty());
+        when(mealEntryRepository.save(any(MealEntryEntity.class))).thenReturn(mealEntryEntity);
+        when(mealEntryMapper.toDTO(mealEntryEntity, "Test Food")).thenReturn(mealEntryDTO);
+
+        assertThrows(NoSuchElementException.class, () ->
+                mealEntryWriteService.createEntries(today, List.of(validReq, invalidReq)));
+
+        verify(dayTargetSnapshotService, never()).ensureSnapshot(any());
     }
 }


### PR DESCRIPTION
## Summary
- Add `POST /nutrition/days/{date}/entries/batch`, accepting a non-empty list of `CreateMealEntryRequest` via the new `CreateMealEntriesRequest` wrapper DTO, and creating all entries in a single `@Transactional` method.
- Returns `201 Created` with a JSON array of `MealEntryDTO` (no `Location` header). `400` on empty list or invalid entries (bean validation). `404` if any referenced `foodId` is unknown — `NoSuchElementException` rolls back the whole batch, mirroring the existing `updateEntry`/`deleteEntry` error mapping.
- `MealEntryWriteService.createEntries` reuses the existing `buildFoodEntry`/`buildAdHocEntry` helpers and calls `dayTargetSnapshotService.ensureSnapshot(date)` exactly once after the loop.
- Does not modify the existing single-entry endpoint, its DTO, or any existing tests.

## Test plan
- [x] New unit tests in `MealEntryWriteServiceTest`: multi food-backed entries snapshot macros correctly and `ensureSnapshot` called once; mix of food + ad-hoc entries saved correctly; unknown `foodId` throws `NoSuchElementException` and `ensureSnapshot` is never called.
- [x] New unit tests in `MealEntryControllerTest`: valid batch returns 201 with list body; `NoSuchElementException` from service maps to 404.
- [x] `./gradlew :nutrition:test` passes (189+ tests, all green).
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — zero warnings.
- [x] tdd-test-guardian confirmed no existing tests were modified.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)