### PR TITLE
fix(nutrition): getDays uses date-aware targets for snapshot-less days

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -206,24 +206,41 @@ public class MealEntryService {
                         .collect(Collectors.toMap(DayTargetSnapshotEntity::getEntryDate, this::toTargetsDTO))
         ).subscribeOn(Schedulers.boundedElastic());
 
-        final Mono<Optional<TargetsDTO>> liveTargetsMono = nutritionTargetService.getTargets()
-                .map(Optional::of)
-                .onErrorReturn(TargetCalculationException.class, Optional.empty());
-
-        return Mono.zip(entriesByDateMono, snapshotsByDateMono, liveTargetsMono)
-                .map(tuple -> {
+        return Mono.zip(entriesByDateMono, snapshotsByDateMono)
+                .flatMap(tuple -> {
                     final Map<LocalDate, List<MealEntryDTO>> entriesByDate = tuple.getT1();
                     final Map<LocalDate, TargetsDTO> snapshotsByDate = tuple.getT2();
-                    final TargetsDTO liveTargets = tuple.getT3().orElse(null);
 
-                    final List<DaySummaryDTO> summaries = new ArrayList<>();
-                    for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
-                        final List<MealEntryDTO> entries = entriesByDate.getOrDefault(date, List.of());
-                        final TargetsDTO targets = snapshotsByDate.getOrDefault(date, liveTargets);
-                        summaries.add(buildDaySummary(date, entries, targets));
-                    }
-                    return summaries;
+                    return Mono.fromCallable(() -> {
+                        final List<DaySummaryDTO> summaries = new ArrayList<>();
+                        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+                            final List<MealEntryDTO> entries = entriesByDate.getOrDefault(date, List.of());
+                            final TargetsDTO targets = resolveTargets(date, snapshotsByDate);
+                            summaries.add(buildDaySummary(date, entries, targets));
+                        }
+                        return summaries;
+                    }).subscribeOn(Schedulers.boundedElastic());
                 });
+    }
+
+    /**
+     * Resolves the nutrition targets applicable to the given date: the persisted snapshot if present,
+     * otherwise the date-aware live targets, or {@code null} if those cannot be computed.
+     *
+     * @param date            the date to resolve targets for
+     * @param snapshotsByDate persisted snapshot targets keyed by date
+     * @return the resolved targets, or null if unavailable
+     */
+    private TargetsDTO resolveTargets(LocalDate date, Map<LocalDate, TargetsDTO> snapshotsByDate) {
+        final TargetsDTO snapshot = snapshotsByDate.get(date);
+        if (snapshot != null) {
+            return snapshot;
+        }
+        try {
+            return nutritionTargetService.getTargetsSync(date);
+        } catch (final TargetCalculationException e) {
+            return null;
+        }
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealEntryService.java
@@ -172,10 +172,11 @@ public class MealEntryService {
 
     /**
      * Returns day summaries for every date within the given range (inclusive), in ascending date order.
-     * Entries, food names and target snapshots for the whole range are loaded in a single query each,
-     * so the cost does not grow with the number of days requested.
-     * If the nutrition target service cannot compute live targets (e.g. missing profile/weight),
-     * days without a persisted snapshot will have null targets and remaining.
+     * Entries, food names and target snapshots for the whole range are loaded in a single query each.
+     * For each date without a persisted snapshot, date-aware targets are resolved individually (as of
+     * that date's applicable weight/age), so the cost of resolving targets grows with the number of
+     * snapshot-less days in the range. If the nutrition target service cannot compute targets for a
+     * given date (e.g. missing profile/weight), that day's targets and remaining will be null.
      *
      * @param from the first date to include (inclusive)
      * @param to   the last date to include (inclusive)

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealEntryServiceTest.java
@@ -357,7 +357,7 @@ class MealEntryServiceTest {
         when(foodRepository.findAllById(any())).thenReturn(List.of());
         when(mealEntryMapper.toDTO(any(MealEntryEntity.class), isNull())).thenReturn(dto);
         when(dayTargetSnapshotRepository.findByEntryDateBetween(from, to)).thenReturn(List.of());
-        when(nutritionTargetService.getTargets()).thenReturn(Mono.just(liveTargets));
+        when(nutritionTargetService.getTargetsSync(any(LocalDate.class))).thenReturn(liveTargets);
 
         StepVerifier.create(mealEntryService.getDays(from, to))
                 .assertNext(summaries -> {
@@ -365,7 +365,7 @@ class MealEntryServiceTest {
                     assertEquals(from, summaries.get(0).date());
                     assertEquals(to, summaries.get(2).date());
 
-                    // days without entries have zero totals but still get the live targets
+                    // days without entries have zero totals but still get the date-aware live targets
                     assertEquals(0, BigDecimal.ZERO.compareTo(summaries.get(0).totals().kcal()));
                     assertEquals(2160, summaries.get(0).targets().targetKcal());
 
@@ -378,7 +378,9 @@ class MealEntryServiceTest {
 
         verify(mealEntryRepository).findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc(from, to);
         verify(dayTargetSnapshotRepository).findByEntryDateBetween(from, to);
-        verify(nutritionTargetService).getTargets();
+        verify(nutritionTargetService).getTargetsSync(from);
+        verify(nutritionTargetService).getTargetsSync(from.plusDays(1));
+        verify(nutritionTargetService).getTargetsSync(to);
     }
 
     @Test
@@ -403,7 +405,7 @@ class MealEntryServiceTest {
                 .thenReturn(List.of());
         when(foodRepository.findAllById(any())).thenReturn(List.of());
         when(dayTargetSnapshotRepository.findByEntryDateBetween(from, to)).thenReturn(List.of(snapshot));
-        when(nutritionTargetService.getTargets()).thenReturn(Mono.just(liveTargets));
+        when(nutritionTargetService.getTargetsSync(to)).thenReturn(liveTargets);
 
         StepVerifier.create(mealEntryService.getDays(from, to))
                 .assertNext(summaries -> {
@@ -411,6 +413,9 @@ class MealEntryServiceTest {
                     assertEquals(2160, summaries.get(1).targets().targetKcal());
                 })
                 .verifyComplete();
+
+        verify(nutritionTargetService, never()).getTargetsSync(from);
+        verify(nutritionTargetService).getTargetsSync(to);
     }
 
     @Test
@@ -423,14 +428,64 @@ class MealEntryServiceTest {
                 .thenReturn(List.of());
         when(foodRepository.findAllById(any())).thenReturn(List.of());
         when(dayTargetSnapshotRepository.findByEntryDateBetween(from, to)).thenReturn(List.of());
-        when(nutritionTargetService.getTargets())
-                .thenReturn(Mono.error(new TargetCalculationException("No profile")));
+        when(nutritionTargetService.getTargetsSync(today))
+                .thenThrow(new TargetCalculationException("No profile"));
 
         StepVerifier.create(mealEntryService.getDays(from, to))
                 .assertNext(summaries -> {
                     assertEquals(1, summaries.size());
                     assertNull(summaries.get(0).targets());
                     assertNull(summaries.get(0).remaining());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getDays applies a different date-aware target per snapshot-less day instead of one uniform value")
+    void getDays_AppliesDifferentDateAwareTargetsPerSnapshotLessDay() {
+        final LocalDate from = today.minusDays(1);
+        final LocalDate to = today;
+
+        final TargetsDTO targetsForFrom = new TargetsDTO(1700, 2100, 2000, 150, 67, 248, "MIFFLIN_ST_JEOR");
+        final TargetsDTO targetsForTo = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc(from, to))
+                .thenReturn(List.of());
+        when(foodRepository.findAllById(any())).thenReturn(List.of());
+        when(dayTargetSnapshotRepository.findByEntryDateBetween(from, to)).thenReturn(List.of());
+        when(nutritionTargetService.getTargetsSync(from)).thenReturn(targetsForFrom);
+        when(nutritionTargetService.getTargetsSync(to)).thenReturn(targetsForTo);
+
+        StepVerifier.create(mealEntryService.getDays(from, to))
+                .assertNext(summaries -> {
+                    assertEquals(2, summaries.size());
+                    assertEquals(2000, summaries.get(0).targets().targetKcal());
+                    assertEquals(2160, summaries.get(1).targets().targetKcal());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getDays returns null targets only for the day whose target calculation fails")
+    void getDays_TargetCalculationFailsForOneDay_OthersUnaffected() {
+        final LocalDate from = today.minusDays(1);
+        final LocalDate to = today;
+
+        final TargetsDTO targetsForTo = new TargetsDTO(1750, 2160, 2160, 160, 72, 252, "MIFFLIN_ST_JEOR");
+
+        when(mealEntryRepository.findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc(from, to))
+                .thenReturn(List.of());
+        when(foodRepository.findAllById(any())).thenReturn(List.of());
+        when(dayTargetSnapshotRepository.findByEntryDateBetween(from, to)).thenReturn(List.of());
+        when(nutritionTargetService.getTargetsSync(from)).thenThrow(new TargetCalculationException("No profile"));
+        when(nutritionTargetService.getTargetsSync(to)).thenReturn(targetsForTo);
+
+        StepVerifier.create(mealEntryService.getDays(from, to))
+                .assertNext(summaries -> {
+                    assertEquals(2, summaries.size());
+                    assertNull(summaries.get(0).targets());
+                    assertNull(summaries.get(0).remaining());
+                    assertEquals(2160, summaries.get(1).targets().targetKcal());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Summary
- `getDays` previously fell back to a single no-arg `nutritionTargetService.getTargets()` (today's weight/age) and applied that one value to every snapshot-less day in the requested range, while `getDay` correctly used the date-aware `getTargets(date)`. This caused the 14-day dashboard chart to show today's target for historical snapshot-less days, while opening the same day in the day view showed the date-correct target.
- `getDays` now resolves targets per date: persisted snapshot if present, otherwise `nutritionTargetService.getTargetsSync(date)` (date-aware weight/age), with `TargetCalculationException` for an individual date treated as `null` targets for that day only (matching `getDay`'s behavior) instead of failing the whole range.
- Dropped the `liveTargetsMono` no-arg `getTargets()` fallback entirely; the final summary list is now built inside a `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())` since `getTargetsSync` is a blocking call.

## Test plan
- [x] Updated the three existing `getDays` tests that previously mocked the no-arg `getTargets()` to mock per-date `getTargetsSync(date)` instead, asserting date-aware targets per snapshot-less day.
- [x] Added `getDays_AppliesDifferentDateAwareTargetsPerSnapshotLessDay`, proving two snapshot-less days in the same range get different date-aware targets (no more uniform "today's" target).
- [x] Added `getDays_TargetCalculationFailsForOneDay_OthersUnaffected`, proving a `TargetCalculationException` for one date only nulls out that day's targets/remaining without affecting other days in the range.
- [x] `./gradlew :nutrition:test` passes.
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes with zero warnings.

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)