### PR TITLE
fix(nutrition): refresh affected day-target snapshot ranges on weight/profile changes (#165)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/repository/DayTargetSnapshotRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/DayTargetSnapshotRepository.java
@@ -16,4 +16,12 @@ public interface DayTargetSnapshotRepository extends JpaRepository<DayTargetSnap
      * @return list of snapshots within the range
      */
     List<DayTargetSnapshotEntity> findByEntryDateBetween(LocalDate from, LocalDate to);
+
+    /**
+     * Returns all target snapshots whose date is on or after the given date.
+     *
+     * @param from the first date to include
+     * @return list of snapshots on or after the given date
+     */
+    List<DayTargetSnapshotEntity> findByEntryDateGreaterThanEqual(LocalDate from);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/WeightEntryRepository.java
@@ -31,4 +31,14 @@ public interface WeightEntryRepository extends JpaRepository<WeightEntryEntity, 
      * @return list of all weight entries, newest first
      */
     List<WeightEntryEntity> findAllByOrderByEntryDateDesc();
+
+    /**
+     * Returns the earliest weight entry with an entry date strictly after the given date, ordered
+     * by entry date ascending. Used to determine the upper bound (exclusive) of the date range for
+     * which a given weight entry is applicable.
+     *
+     * @param date the date to find the next weight entry after
+     * @return an Optional containing the next entry, or empty if no entry exists after that date
+     */
+    Optional<WeightEntryEntity> findTopByEntryDateGreaterThanOrderByEntryDateAsc(LocalDate date);
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/DayTargetSnapshotService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/DayTargetSnapshotService.java
@@ -2,8 +2,11 @@ package com.marvin.nutrition.service;
 
 import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
+import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
+import com.marvin.nutrition.repository.WeightEntryRepository;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -20,18 +23,22 @@ public class DayTargetSnapshotService {
 
     private final DayTargetSnapshotRepository dayTargetSnapshotRepository;
     private final NutritionTargetService nutritionTargetService;
+    private final WeightEntryRepository weightEntryRepository;
 
     /**
      * Creates a new DayTargetSnapshotService.
      *
      * @param dayTargetSnapshotRepository JPA repository for per-day nutrition target snapshots
      * @param nutritionTargetService      service for computing daily nutrition targets
+     * @param weightEntryRepository       JPA repository for weight entries
      */
     public DayTargetSnapshotService(
             DayTargetSnapshotRepository dayTargetSnapshotRepository,
-            NutritionTargetService nutritionTargetService) {
+            NutritionTargetService nutritionTargetService,
+            WeightEntryRepository weightEntryRepository) {
         this.dayTargetSnapshotRepository = dayTargetSnapshotRepository;
         this.nutritionTargetService = nutritionTargetService;
+        this.weightEntryRepository = weightEntryRepository;
     }
 
     /**
@@ -98,6 +105,57 @@ public class DayTargetSnapshotService {
             return;
         }
         dayTargetSnapshotRepository.save(toSnapshot(existing, date, targets));
+    }
+
+    /**
+     * Recomputes and overwrites all existing day-target snapshots whose date falls within the range
+     * affected by a weight entry change starting at {@code fromDate}.
+     *
+     * <p>The affected range is {@code [fromDate, nextWeightEntryDate)} if a later weight entry
+     * exists, or {@code [fromDate, +inf)} otherwise. For each existing snapshot in that range, the
+     * targets are recomputed via {@link NutritionTargetService#getTargetsSync(LocalDate)} and saved.
+     * Snapshots for dates where targets cannot currently be computed (e.g. no profile data) are left
+     * untouched. Dates without an existing snapshot are not created.</p>
+     *
+     * @param fromDate the first date (inclusive) of the affected range
+     */
+    @Transactional
+    public void refreshSnapshotsFrom(LocalDate fromDate) {
+        final List<DayTargetSnapshotEntity> snapshots = weightEntryRepository
+                .findTopByEntryDateGreaterThanOrderByEntryDateAsc(fromDate)
+                .map(WeightEntryEntity::getEntryDate)
+                .map(nextWeightDate -> dayTargetSnapshotRepository.findByEntryDateBetween(fromDate, nextWeightDate.minusDays(1)))
+                .orElseGet(() -> dayTargetSnapshotRepository.findByEntryDateGreaterThanEqual(fromDate));
+
+        snapshots.forEach(this::refreshSnapshot);
+    }
+
+    /**
+     * Recomputes and overwrites every existing day-target snapshot.
+     *
+     * <p>Snapshots for dates where targets cannot currently be computed (e.g. no profile data) are
+     * left untouched.</p>
+     */
+    @Transactional
+    public void refreshAllSnapshots() {
+        dayTargetSnapshotRepository.findAll().forEach(this::refreshSnapshot);
+    }
+
+    /**
+     * Recomputes the given existing snapshot's targets and saves it, unless targets cannot
+     * currently be computed for its date, in which case it is left untouched.
+     *
+     * @param snapshot the existing snapshot entity to refresh
+     */
+    private void refreshSnapshot(DayTargetSnapshotEntity snapshot) {
+        final LocalDate date = snapshot.getEntryDate();
+        final TargetsDTO targets;
+        try {
+            targets = nutritionTargetService.getTargetsSync(date);
+        } catch (TargetCalculationException e) {
+            return;
+        }
+        dayTargetSnapshotRepository.save(toSnapshot(snapshot, date, targets));
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/NutritionProfileService.java
@@ -15,16 +15,22 @@ public class NutritionProfileService {
 
     private final ProfileRepository profileRepository;
     private final ProfileMapper profileMapper;
+    private final DayTargetSnapshotService dayTargetSnapshotService;
 
     /**
      * Creates a new NutritionProfileService.
      *
-     * @param profileRepository JPA repository for the profile row
-     * @param profileMapper     MapStruct mapper for entity/DTO conversion
+     * @param profileRepository        JPA repository for the profile row
+     * @param profileMapper            MapStruct mapper for entity/DTO conversion
+     * @param dayTargetSnapshotService service for refreshing per-day nutrition target snapshots
      */
-    public NutritionProfileService(ProfileRepository profileRepository, ProfileMapper profileMapper) {
+    public NutritionProfileService(
+            ProfileRepository profileRepository,
+            ProfileMapper profileMapper,
+            DayTargetSnapshotService dayTargetSnapshotService) {
         this.profileRepository = profileRepository;
         this.profileMapper = profileMapper;
+        this.dayTargetSnapshotService = dayTargetSnapshotService;
     }
 
     /**
@@ -41,6 +47,8 @@ public class NutritionProfileService {
 
     /**
      * Creates or replaces the single nutrition profile row.
+     * Refreshes all existing day-target snapshots afterwards, since any profile change can affect
+     * the daily targets computed for previously snapshotted days.
      *
      * @param dto the profile data to persist
      * @return a Mono emitting the saved profile DTO
@@ -58,7 +66,9 @@ public class NutritionProfileService {
             entity.setProteinPerKg(dto.proteinPerKg() != null ? dto.proteinPerKg() : java.math.BigDecimal.valueOf(2.0));
             entity.setFatPct(dto.fatPct() != null ? dto.fatPct() : java.math.BigDecimal.valueOf(0.30));
             entity.setBasalKcal(dto.basalKcal());
-            return profileMapper.toDTO(profileRepository.save(entity));
+            final ProfileDTO saved = profileMapper.toDTO(profileRepository.save(entity));
+            dayTargetSnapshotService.refreshAllSnapshots();
+            return saved;
         }).subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/WeightService.java
@@ -52,8 +52,9 @@ public class WeightService {
 
     /**
      * Creates a new weight entry.
-     * Refreshes the day-target snapshot for the entry date if one already exists, so that the
-     * newly recorded weight is reflected in that day's targets.
+     * Refreshes existing day-target snapshots for the date range affected by this entry (from its
+     * entry date up to, but not including, the next later weight entry's date, or to the end if
+     * none exists), so that the newly recorded weight is reflected in those days' targets.
      *
      * @param request the entry date and weight in kg
      * @return a Mono emitting the created weight entry DTO
@@ -64,16 +65,16 @@ public class WeightService {
             entity.setEntryDate(request.entryDate());
             entity.setWeightKg(request.weightKg());
             final WeightEntryDTO dto = weightEntryMapper.toDTO(weightEntryRepository.save(entity));
-            dayTargetSnapshotService.refreshSnapshotIfExists(request.entryDate());
+            dayTargetSnapshotService.refreshSnapshotsFrom(request.entryDate());
             return dto;
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
     /**
      * Updates an existing weight entry.
-     * Refreshes the day-target snapshot for the new entry date if one already exists. If the entry
-     * date changed, also refreshes the snapshot for the previous date, since the applicable weight
-     * for that day may now differ.
+     * Refreshes existing day-target snapshots for the date range affected by the new entry date. If
+     * the entry date changed, also refreshes the range affected by the previous date, since the
+     * applicable weight for those days may now differ.
      * Emits {@link NoSuchElementException} if no entry with the given id exists.
      *
      * @param id      the id of the entry to update
@@ -88,9 +89,9 @@ public class WeightService {
             entity.setEntryDate(request.entryDate());
             entity.setWeightKg(request.weightKg());
             final WeightEntryDTO dto = weightEntryMapper.toDTO(weightEntryRepository.save(entity));
-            dayTargetSnapshotService.refreshSnapshotIfExists(request.entryDate());
+            dayTargetSnapshotService.refreshSnapshotsFrom(request.entryDate());
             if (!oldEntryDate.equals(request.entryDate())) {
-                dayTargetSnapshotService.refreshSnapshotIfExists(oldEntryDate);
+                dayTargetSnapshotService.refreshSnapshotsFrom(oldEntryDate);
             }
             return dto;
         }).subscribeOn(Schedulers.boundedElastic());
@@ -98,6 +99,8 @@ public class WeightService {
 
     /**
      * Deletes the weight entry with the given id.
+     * Refreshes existing day-target snapshots for the date range that was affected by the deleted
+     * entry, since the applicable weight for those days may now differ.
      * Emits {@link NoSuchElementException} if no entry with the given id exists.
      *
      * @param id the id of the entry to delete
@@ -105,10 +108,11 @@ public class WeightService {
      */
     public Mono<Void> delete(Long id) {
         return Mono.fromCallable(() -> {
-            if (!weightEntryRepository.existsById(id)) {
-                throw new NoSuchElementException("Weight entry not found: " + id);
-            }
+            final WeightEntryEntity entity = weightEntryRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Weight entry not found: " + id));
+            final LocalDate entryDate = entity.getEntryDate();
             weightEntryRepository.deleteById(id);
+            dayTargetSnapshotService.refreshSnapshotsFrom(entryDate);
             return null;
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/DayTargetSnapshotServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/DayTargetSnapshotServiceTest.java
@@ -10,8 +10,11 @@ import static org.mockito.Mockito.when;
 
 import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.entity.DayTargetSnapshotEntity;
+import com.marvin.nutrition.entity.WeightEntryEntity;
 import com.marvin.nutrition.repository.DayTargetSnapshotRepository;
+import com.marvin.nutrition.repository.WeightEntryRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +35,9 @@ class DayTargetSnapshotServiceTest {
 
     @Mock
     private NutritionTargetService nutritionTargetService;
+
+    @Mock
+    private WeightEntryRepository weightEntryRepository;
 
     @InjectMocks
     private DayTargetSnapshotService dayTargetSnapshotService;
@@ -168,5 +174,147 @@ class DayTargetSnapshotServiceTest {
         dayTargetSnapshotService.refreshSnapshotIfExists(today);
 
         verify(dayTargetSnapshotRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // refreshSnapshotsFrom
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("refreshSnapshotsFrom refreshes all existing snapshots from the given date up to "
+            + "(but not including) the next weight entry's date")
+    void refreshSnapshotsFrom_NextWeightEntryExists_RefreshesSnapshotsUpToNextWeightDate() {
+        final LocalDate from = today;
+        final LocalDate nextWeightDate = today.plusDays(5);
+        final WeightEntryEntity nextWeightEntry = new WeightEntryEntity();
+        nextWeightEntry.setEntryDate(nextWeightDate);
+
+        final DayTargetSnapshotEntity snapshotDay1 = new DayTargetSnapshotEntity();
+        snapshotDay1.setEntryDate(today.plusDays(1));
+        final DayTargetSnapshotEntity snapshotDay3 = new DayTargetSnapshotEntity();
+        snapshotDay3.setEntryDate(today.plusDays(3));
+
+        when(weightEntryRepository.findTopByEntryDateGreaterThanOrderByEntryDateAsc(from))
+                .thenReturn(Optional.of(nextWeightEntry));
+        when(dayTargetSnapshotRepository.findByEntryDateBetween(from, nextWeightDate.minusDays(1)))
+                .thenReturn(List.of(snapshotDay1, snapshotDay3));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(any(LocalDate.class));
+
+        dayTargetSnapshotService.refreshSnapshotsFrom(from);
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.plusDays(1).equals(snapshot.getEntryDate()) && snapshot.getBmr() == 1750));
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.plusDays(3).equals(snapshot.getEntryDate()) && snapshot.getBmr() == 1750));
+        verify(dayTargetSnapshotRepository, never()).findByEntryDateGreaterThanEqual(any());
+    }
+
+    @Test
+    @DisplayName("refreshSnapshotsFrom refreshes all existing snapshots from the given date onward "
+            + "when there is no later weight entry")
+    void refreshSnapshotsFrom_NoNextWeightEntry_RefreshesSnapshotsToEndOfRange() {
+        final LocalDate from = today;
+        final DayTargetSnapshotEntity snapshotFar = new DayTargetSnapshotEntity();
+        snapshotFar.setEntryDate(today.plusDays(30));
+
+        when(weightEntryRepository.findTopByEntryDateGreaterThanOrderByEntryDateAsc(from))
+                .thenReturn(Optional.empty());
+        when(dayTargetSnapshotRepository.findByEntryDateGreaterThanEqual(from))
+                .thenReturn(List.of(snapshotFar));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(any(LocalDate.class));
+
+        dayTargetSnapshotService.refreshSnapshotsFrom(from);
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.plusDays(30).equals(snapshot.getEntryDate()) && snapshot.getBmr() == 1750));
+        verify(dayTargetSnapshotRepository, never()).findByEntryDateBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("refreshSnapshotsFrom does nothing when there are no existing snapshots in range")
+    void refreshSnapshotsFrom_NoSnapshotsInRange_DoesNothing() {
+        final LocalDate from = today;
+
+        when(weightEntryRepository.findTopByEntryDateGreaterThanOrderByEntryDateAsc(from))
+                .thenReturn(Optional.empty());
+        when(dayTargetSnapshotRepository.findByEntryDateGreaterThanEqual(from)).thenReturn(List.of());
+
+        dayTargetSnapshotService.refreshSnapshotsFrom(from);
+
+        verify(dayTargetSnapshotRepository, never()).save(any());
+        verify(nutritionTargetService, never()).getTargetsSync(any());
+    }
+
+    @Test
+    @DisplayName("refreshSnapshotsFrom leaves a snapshot untouched when targets cannot be computed for its date")
+    void refreshSnapshotsFrom_TargetsUnavailableForDate_LeavesThatSnapshotUntouched() {
+        final LocalDate from = today;
+        final DayTargetSnapshotEntity snapshotDay1 = new DayTargetSnapshotEntity();
+        snapshotDay1.setEntryDate(today.plusDays(1));
+        final DayTargetSnapshotEntity snapshotDay2 = new DayTargetSnapshotEntity();
+        snapshotDay2.setEntryDate(today.plusDays(2));
+
+        when(weightEntryRepository.findTopByEntryDateGreaterThanOrderByEntryDateAsc(from))
+                .thenReturn(Optional.empty());
+        when(dayTargetSnapshotRepository.findByEntryDateGreaterThanEqual(from))
+                .thenReturn(List.of(snapshotDay1, snapshotDay2));
+        when(nutritionTargetService.getTargetsSync(today.plusDays(1)))
+                .thenThrow(new TargetCalculationException("No profile"));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(today.plusDays(2));
+
+        dayTargetSnapshotService.refreshSnapshotsFrom(from);
+
+        verify(dayTargetSnapshotRepository, never()).save(argThat(snapshot ->
+                today.plusDays(1).equals(snapshot.getEntryDate())));
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.plusDays(2).equals(snapshot.getEntryDate())));
+    }
+
+    // -----------------------------------------------------------------------
+    // refreshAllSnapshots
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("refreshAllSnapshots refreshes every existing snapshot")
+    void refreshAllSnapshots_RefreshesEveryExistingSnapshot() {
+        final DayTargetSnapshotEntity snapshot1 = new DayTargetSnapshotEntity();
+        snapshot1.setEntryDate(today);
+        final DayTargetSnapshotEntity snapshot2 = new DayTargetSnapshotEntity();
+        snapshot2.setEntryDate(today.plusDays(10));
+
+        when(dayTargetSnapshotRepository.findAll()).thenReturn(List.of(snapshot1, snapshot2));
+        doReturn(targets).when(nutritionTargetService).getTargetsSync(any(LocalDate.class));
+
+        dayTargetSnapshotService.refreshAllSnapshots();
+
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.equals(snapshot.getEntryDate()) && snapshot.getBmr() == 1750));
+        verify(dayTargetSnapshotRepository).save(argThat(snapshot ->
+                today.plusDays(10).equals(snapshot.getEntryDate()) && snapshot.getBmr() == 1750));
+    }
+
+    @Test
+    @DisplayName("refreshAllSnapshots leaves a snapshot untouched when targets cannot be computed for its date")
+    void refreshAllSnapshots_TargetsUnavailableForDate_LeavesThatSnapshotUntouched() {
+        final DayTargetSnapshotEntity snapshot1 = new DayTargetSnapshotEntity();
+        snapshot1.setEntryDate(today);
+
+        when(dayTargetSnapshotRepository.findAll()).thenReturn(List.of(snapshot1));
+        when(nutritionTargetService.getTargetsSync(today)).thenThrow(new TargetCalculationException("No profile"));
+
+        dayTargetSnapshotService.refreshAllSnapshots();
+
+        verify(dayTargetSnapshotRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("refreshAllSnapshots does nothing when no snapshots exist")
+    void refreshAllSnapshots_NoSnapshots_DoesNothing() {
+        when(dayTargetSnapshotRepository.findAll()).thenReturn(List.of());
+
+        dayTargetSnapshotService.refreshAllSnapshots();
+
+        verify(dayTargetSnapshotRepository, never()).save(any());
+        verify(nutritionTargetService, never()).getTargetsSync(any());
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/NutritionProfileServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/NutritionProfileServiceTest.java
@@ -37,11 +37,14 @@ class NutritionProfileServiceTest {
     @Mock
     private ProfileMapper profileMapper;
 
+    @Mock
+    private DayTargetSnapshotService dayTargetSnapshotService;
+
     private NutritionProfileService nutritionProfileService;
 
     @BeforeEach
     void setUp() {
-        nutritionProfileService = new NutritionProfileService(profileRepository, profileMapper);
+        nutritionProfileService = new NutritionProfileService(profileRepository, profileMapper, dayTargetSnapshotService);
     }
 
     private ProfileDTO dto() {
@@ -102,6 +105,7 @@ class NutritionProfileServiceTest {
         final ArgumentCaptor<ProfileEntity> captor = ArgumentCaptor.forClass(ProfileEntity.class);
         verify(profileRepository).save(captor.capture());
         assertEquals(ProfileEntity.SINGLETON_ID, captor.getValue().getId());
+        verify(dayTargetSnapshotService).refreshAllSnapshots();
     }
 
     @Test
@@ -123,6 +127,7 @@ class NutritionProfileServiceTest {
         verify(profileRepository).save(captor.capture());
         assertEquals(ProfileEntity.SINGLETON_ID, captor.getValue().getId());
         verify(profileRepository, never()).findAll();
+        verify(dayTargetSnapshotService).refreshAllSnapshots();
     }
 
     @Test

--- a/nutrition/src/test/java/com/marvin/nutrition/service/WeightServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/WeightServiceTest.java
@@ -56,8 +56,8 @@ class WeightServiceTest {
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("create persists the entry and refreshes the day-target snapshot for the entry date")
-    void create_PersistsEntryAndRefreshesSnapshotForEntryDate() {
+    @DisplayName("create persists the entry and refreshes the day-target snapshot range starting at the entry date")
+    void create_PersistsEntryAndRefreshesSnapshotRangeForEntryDate() {
         final CreateWeightEntryRequest request = new CreateWeightEntryRequest(today, new BigDecimal("80.50"));
         final WeightEntryEntity saved = new WeightEntryEntity();
         saved.setEntryDate(today);
@@ -70,7 +70,7 @@ class WeightServiceTest {
                 .expectNext(weightEntryDTO)
                 .verifyComplete();
 
-        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
+        verify(dayTargetSnapshotService).refreshSnapshotsFrom(today);
     }
 
     // -----------------------------------------------------------------------
@@ -89,12 +89,12 @@ class WeightServiceTest {
                 .verify();
 
         verify(weightEntryRepository, never()).save(any());
-        verify(dayTargetSnapshotService, never()).refreshSnapshotIfExists(any());
+        verify(dayTargetSnapshotService, never()).refreshSnapshotsFrom(any());
     }
 
     @Test
-    @DisplayName("update refreshes the snapshot only for the new date when the entry date is unchanged")
-    void update_DateUnchanged_RefreshesSnapshotOnceForNewDate() {
+    @DisplayName("update refreshes the snapshot range only starting at the new date when the entry date is unchanged")
+    void update_DateUnchanged_RefreshesSnapshotRangeOnceForNewDate() {
         final WeightEntryEntity existing = new WeightEntryEntity();
         existing.setId(1L);
         existing.setEntryDate(today);
@@ -110,13 +110,13 @@ class WeightServiceTest {
                 .expectNext(weightEntryDTO)
                 .verifyComplete();
 
-        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
-        verify(dayTargetSnapshotService, org.mockito.Mockito.times(1)).refreshSnapshotIfExists(any());
+        verify(dayTargetSnapshotService).refreshSnapshotsFrom(today);
+        verify(dayTargetSnapshotService, org.mockito.Mockito.times(1)).refreshSnapshotsFrom(any());
     }
 
     @Test
-    @DisplayName("update refreshes the snapshot for both the old and new date when the entry date changes")
-    void update_DateChanged_RefreshesSnapshotForOldAndNewDate() {
+    @DisplayName("update refreshes the snapshot ranges for both the old and new date when the entry date changes")
+    void update_DateChanged_RefreshesSnapshotRangesForOldAndNewDate() {
         final LocalDate oldDate = today.minusDays(1);
         final WeightEntryEntity existing = new WeightEntryEntity();
         existing.setId(1L);
@@ -133,8 +133,42 @@ class WeightServiceTest {
                 .expectNext(weightEntryDTO)
                 .verifyComplete();
 
-        verify(dayTargetSnapshotService).refreshSnapshotIfExists(today);
-        verify(dayTargetSnapshotService).refreshSnapshotIfExists(oldDate);
+        verify(dayTargetSnapshotService).refreshSnapshotsFrom(today);
+        verify(dayTargetSnapshotService).refreshSnapshotsFrom(oldDate);
+    }
+
+    // -----------------------------------------------------------------------
+    // delete
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("delete emits NoSuchElementException when entry not found")
+    void delete_NotFound_EmitsNoSuchElementException() {
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.empty());
+
+        StepVerifier.create(weightService.delete(1L))
+                .expectError(NoSuchElementException.class)
+                .verify();
+
+        verify(weightEntryRepository, never()).deleteById(any());
+        verify(dayTargetSnapshotService, never()).refreshSnapshotsFrom(any());
+    }
+
+    @Test
+    @DisplayName("delete removes the entry and refreshes the day-target snapshot range starting at its entry date")
+    void delete_RemovesEntryAndRefreshesSnapshotRangeForEntryDate() {
+        final WeightEntryEntity existing = new WeightEntryEntity();
+        existing.setId(1L);
+        existing.setEntryDate(today);
+        existing.setWeightKg(new BigDecimal("79.00"));
+
+        when(weightEntryRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+        StepVerifier.create(weightService.delete(1L))
+                .verifyComplete();
+
+        verify(weightEntryRepository).deleteById(1L);
+        verify(dayTargetSnapshotService).refreshSnapshotsFrom(today);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The applicable weight for a given day is the most recent weight entry **on or before** that day (see `NutritionTargetService.getTargetsSync`). A single weight entry therefore influences targets for a whole range of subsequent days, until the next weight entry's date. Previously, refresh logic only ever touched the snapshot for the exact date of a changed weight entry, leaving later snapshots stale after:

- backfilling a weight for an earlier date
- updating a weight entry (including changing its date)
- deleting a weight entry
- editing the nutrition profile

## Changes

- `WeightEntryRepository`: add `findTopByEntryDateGreaterThanOrderByEntryDateAsc(date)` to find the next weight entry after a given date.
- `DayTargetSnapshotRepository`: add `findByEntryDateGreaterThanEqual(from)` for the open-ended range case.
- `DayTargetSnapshotService`:
  - `refreshSnapshotsFrom(fromDate)` - recomputes all existing snapshots in `[fromDate, nextWeightEntryDate)` or `[fromDate, +inf)` if no later weight entry exists. Snapshots that don't exist are not created; snapshots whose targets can't currently be computed are left untouched (same semantics as the existing `refreshSnapshotIfExists`).
  - `refreshAllSnapshots()` - recomputes every existing snapshot, with the same untouched-on-failure semantics.
  - `refreshSnapshotIfExists` is retained (existing coverage untouched).
- `WeightService`:
  - `create`/`update` now call `refreshSnapshotsFrom` for the new date (and the old date too, on update, if it changed).
  - `delete` now captures the entry's date before deleting and calls `refreshSnapshotsFrom` afterwards.
- `NutritionProfileService.upsertProfile` now injects `DayTargetSnapshotService` and calls `refreshAllSnapshots()` after saving, since any profile change can affect previously snapshotted days.

Closes #165

## Test plan

- [x] New failing tests written first (TDD) for `refreshSnapshotsFrom` and `refreshAllSnapshots` covering: range bounded by next weight entry, open-ended range, no snapshots in range, and targets-unavailable-for-one-date cases.
- [x] `WeightServiceTest` updated/extended for create/update/delete using `refreshSnapshotsFrom`.
- [x] `NutritionProfileServiceTest` updated/extended to verify `refreshAllSnapshots()` is called on upsert.
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes.
- [x] `./gradlew :nutrition:test` passes (200/200 tests green).
- [x] No existing tests modified in a way that weakens the contract (verified via tdd-test-guardian).

🤖 Generated with [Claude Code](https://claude.com/claude-code)