### PR TITLE
fix(vocabulary): configure DeepL ApiClient once at startup instead of per-request

### DIFF
--- a/vocabulary/src/main/java/com/marvin/vocabulary/configuration/DeepLApiClientConfiguration.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/configuration/DeepLApiClientConfiguration.java
@@ -1,0 +1,49 @@
+package com.marvin.vocabulary.configuration;
+
+import com.generated.deepl.ApiClient;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configures the shared DeepL {@link ApiClient} bean once at startup with the base path and authentication
+ * header, so that request-handling code does not need to mutate the shared singleton on every call.
+ */
+@Component
+public class DeepLApiClientConfiguration {
+
+    private static final String DEFAULT_DEEPL_URL = "https://api-free.deepl.com";
+    private static final String DEEPL_AUTH_HEADER_FORMAT = "DeepL-Auth-Key %s";
+
+    private final String deepLApiUrl;
+    private final String deepLApiKey;
+    private final ApiClient apiClient;
+
+    /**
+     * Constructs a new DeepLApiClientConfiguration with required dependencies.
+     *
+     * @param deepLApiUrl the DeepL API URL
+     * @param deepLApiKey the DeepL API key
+     * @param apiClient   the shared DeepL API client to configure
+     */
+    public DeepLApiClientConfiguration(
+            @Value("${vocabulary.deepl.url:" + DEFAULT_DEEPL_URL + "}") String deepLApiUrl,
+            @Value("${vocabulary.deepl.api-key:}") String deepLApiKey,
+            ApiClient apiClient
+    ) {
+        this.deepLApiUrl = deepLApiUrl;
+        this.deepLApiKey = deepLApiKey;
+        this.apiClient = apiClient;
+    }
+
+    /**
+     * Configures the shared DeepL API client with the base path and authentication header once at startup.
+     */
+    @PostConstruct
+    public void configureApiClient() {
+        apiClient.setBasePath(deepLApiUrl);
+        apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, String.format(DEEPL_AUTH_HEADER_FORMAT, deepLApiKey));
+    }
+
+}

--- a/vocabulary/src/main/java/com/marvin/vocabulary/configuration/DeepLApiClientConfiguration.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/configuration/DeepLApiClientConfiguration.java
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Component;
 /**
  * Configures the shared DeepL {@link ApiClient} bean once at startup with the base path and authentication
  * header, so that request-handling code does not need to mutate the shared singleton on every call.
+ *
+ * <p>This relies on {@code ApiClient} being injected as a singleton bean (the {@code generateClientAsBean}
+ * OpenAPI generator option) and shared with {@code TranslateTextApi}, so the configuration applied here is
+ * visible to every request handled by that API client.</p>
  */
 @Component
 public class DeepLApiClientConfiguration {

--- a/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
@@ -1,6 +1,5 @@
 package com.marvin.vocabulary.controller;
 
-import com.generated.deepl.ApiClient;
 import com.generated.deepl.api.TranslateTextApi;
 import com.generated.deepl.model.SourceLanguageText;
 import com.generated.deepl.model.TargetLanguageText;
@@ -22,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -52,13 +50,9 @@ import reactor.core.scheduler.Schedulers;
 @RequestMapping("/vocabulary")
 public class FlashcardController {
 
-    private static final String DEFAULT_DEEPL_URL = "https://api-free.deepl.com";
     private static final String CSV_FILENAME = "Standard.csv";
     private static final String CSV_MEDIA_TYPE = "text/csv";
-    private static final String DEEPL_AUTH_HEADER_FORMAT = "DeepL-Auth-Key %s";
 
-    private final String deepLApiUrl;
-    private final String deepLApiKey;
     private final DictionaryClient dictionaryClient;
     private final FlashcardService flashcardService;
     private final TranslateTextApi translateTextApi;
@@ -66,21 +60,15 @@ public class FlashcardController {
     /**
      * Constructs a new FlashcardController with required dependencies.
      *
-     * @param deepLApiUrl      the DeepL API URL
-     * @param deepLApiKey      the DeepL API key
      * @param dictionaryClient the dictionary service client
      * @param flashcardService the flashcard service
      * @param translateTextApi the translation API client
      */
     public FlashcardController(
-            @Value("${vocabulary.deepl.url:" + DEFAULT_DEEPL_URL + "}") String deepLApiUrl,
-            @Value("${vocabulary.deepl.api-key:}") String deepLApiKey,
             DictionaryClient dictionaryClient,
             FlashcardService flashcardService,
             TranslateTextApi translateTextApi
     ) {
-        this.deepLApiUrl = deepLApiUrl;
-        this.deepLApiKey = deepLApiKey;
         this.dictionaryClient = dictionaryClient;
         this.flashcardService = flashcardService;
         this.translateTextApi = translateTextApi;
@@ -148,17 +136,6 @@ public class FlashcardController {
                     DataBufferUtils.release(dataBuffer);
                     return Mono.just(bytes);
                 });
-    }
-
-    /**
-     * Configures DeepL API client with authentication and base URL.
-     *
-     * @param apiClient the API client to configure
-     */
-    private void configureDeepLApiClient(ApiClient apiClient) {
-        apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION,
-                String.format(DEEPL_AUTH_HEADER_FORMAT, deepLApiKey));
-        apiClient.setBasePath(deepLApiUrl);
     }
 
     /**
@@ -410,9 +387,6 @@ public class FlashcardController {
         TranslateTextRequest translationRequest = createTranslationRequest(
                 word, context, sourceLanguage, targetLanguage
         );
-
-        ApiClient apiClient = translateTextApi.getApiClient();
-        configureDeepLApiClient(apiClient);
 
         return translateTextApi.translateText(translationRequest)
                 .flatMapMany(translationResponse -> {

--- a/vocabulary/src/test/java/com/marvin/vocabulary/configuration/DeepLApiClientConfigurationTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/configuration/DeepLApiClientConfigurationTest.java
@@ -1,0 +1,33 @@
+package com.marvin.vocabulary.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generated.deepl.ApiClient;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class DeepLApiClientConfigurationTest {
+
+    @Test
+    void configureShouldSetBasePathAndAuthorizationHeaderOnApiClient() throws ReflectiveOperationException {
+        final ApiClient apiClient = new ApiClient();
+        final DeepLApiClientConfiguration configuration = new DeepLApiClientConfiguration(
+                "https://api-free.deepl.com",
+                "test-api-key",
+                apiClient
+        );
+
+        configuration.configureApiClient();
+
+        assertThat(apiClient.getBasePath()).isEqualTo("https://api-free.deepl.com");
+        assertThat(readDefaultHeaders(apiClient).getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("DeepL-Auth-Key test-api-key");
+    }
+
+    private HttpHeaders readDefaultHeaders(ApiClient apiClient) throws ReflectiveOperationException {
+        final Field field = ApiClient.class.getDeclaredField("defaultHeaders");
+        field.setAccessible(true);
+        return (HttpHeaders) field.get(apiClient);
+    }
+
+}

--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
@@ -4,9 +4,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import com.generated.deepl.ApiClient;
+import com.generated.deepl.api.TranslateTextApi;
+import com.generated.deepl.model.TranslateText200Response;
+import com.generated.deepl.model.TranslateText200ResponseTranslationsInner;
 import com.marvin.vocabulary.dictionaryapi.DictionaryClient;
 import com.marvin.vocabulary.dto.DictionaryEntry;
 import com.marvin.vocabulary.dto.Flashcard;
+import com.marvin.vocabulary.dto.Translation;
 import com.marvin.vocabulary.model.DeckEntity;
 import com.marvin.vocabulary.model.FlashcardEntity;
 import com.marvin.vocabulary.service.FlashcardService;
@@ -19,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
@@ -58,6 +64,8 @@ class FlashcardControllerTest {
     private DictionaryClient dictionaryClient;
     @Mock
     private FlashcardService flashcardService;
+    @Mock
+    private TranslateTextApi translateTextApi;
     @InjectMocks
     private FlashcardController flashcardController;
     private WebTestClient webTestClient;
@@ -86,6 +94,26 @@ class FlashcardControllerTest {
                 .expectStatus().isOk()
                 .expectBodyList(DictionaryEntry.class)
                 .isEqualTo(expectedEntries);
+    }
+
+    @Test
+    void getTranslationShouldReturnTranslationsWithoutMutatingSharedApiClient() {
+        final TranslateText200ResponseTranslationsInner translationItem = new TranslateText200ResponseTranslationsInner();
+        translationItem.setText("Hallo");
+        final TranslateText200Response response = new TranslateText200Response();
+        response.setTranslations(List.of(translationItem));
+
+        when(translateTextApi.translateText(any())).thenReturn(Mono.just(response));
+
+        webTestClient.get()
+                .uri("/vocabulary/flashcards/translations?word=hello&context=greeting&sourceLanguage=EN&targetLanguage=DE")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(Translation.class)
+                .isEqualTo(List.of(new Translation("Hallo")));
+
+        Mockito.verify(translateTextApi, Mockito.never()).getApiClient();
+        Mockito.verify(translateTextApi, Mockito.never()).setApiClient(Mockito.any(ApiClient.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `getTranslation` previously called `translateTextApi.getApiClient()` and mutated the shared singleton `ApiClient`'s base path and `Authorization` header on every request, racing across concurrent requests.
- Added `DeepLApiClientConfiguration`, a `@Component` that configures the shared `ApiClient`'s base path and auth header once via `@PostConstruct`.
- `getTranslation` no longer touches the `ApiClient` at all — it only builds and sends the translation request.
- Removed now-unused `deepLApiUrl`/`deepLApiKey` constructor parameters and the `configureDeepLApiClient` helper from `FlashcardController`.

Fixes #172

## Test plan
- [x] Added `DeepLApiClientConfigurationTest` verifying base path and `Authorization` header are set on the shared `ApiClient`.
- [x] Added `getTranslationShouldReturnTranslationsWithoutMutatingSharedApiClient` to `FlashcardControllerTest`, asserting translations are returned correctly and `getApiClient()`/`setApiClient()` are never called during request handling.
- [x] `./gradlew :vocabulary:test`
- [x] `./gradlew :vocabulary:checkstyleMain :vocabulary:checkstyleTest` (no new violations introduced; pre-existing FinalLocalVariable warnings in unrelated code remain)