### PR TITLE
fix(vocabulary): handle race condition in getOrCreateReverseDeck/getOrCreateDeck

### DIFF
--- a/vocabulary/src/main/java/com/marvin/vocabulary/service/FlashcardService.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/service/FlashcardService.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -237,12 +238,7 @@ public class FlashcardService {
     }
 
     private DeckEntity getOrCreateDeck(String name) {
-        return deckRepository.findByName(name)
-                .orElseGet(() -> {
-                    DeckEntity entity = new DeckEntity();
-                    entity.setName(name);
-                    return deckRepository.save(entity);
-                });
+        return findOrCreateDeckByName(name);
     }
 
     private DeckEntity getOrCreateReverseDeck(DeckEntity deck) {
@@ -251,17 +247,25 @@ public class FlashcardService {
         }
 
         String reverseName = deck.getName() + "_reversed";
-        DeckEntity reverseDeck = deckRepository.findByName(reverseName)
-                .orElseGet(() -> {
-                    DeckEntity entity = new DeckEntity();
-                    entity.setName(reverseName);
-                    return deckRepository.save(entity);
-                });
+        DeckEntity reverseDeck = findOrCreateDeckByName(reverseName);
         deck.setReverseDeck(reverseDeck);
         reverseDeck.setReverseDeck(deck);
         deckRepository.save(deck);
         deckRepository.save(reverseDeck);
         return reverseDeck;
+    }
+
+    private DeckEntity findOrCreateDeckByName(String name) {
+        return deckRepository.findByName(name)
+                .orElseGet(() -> {
+                    DeckEntity entity = new DeckEntity();
+                    entity.setName(name);
+                    try {
+                        return deckRepository.save(entity);
+                    } catch (DataIntegrityViolationException e) {
+                        return deckRepository.findByName(name).orElseThrow(() -> e);
+                    }
+                });
     }
 
 }

--- a/vocabulary/src/test/java/com/marvin/vocabulary/service/FlashcardServiceTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/service/FlashcardServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class FlashcardServiceTest {
@@ -68,6 +69,52 @@ class FlashcardServiceTest {
         final FlashcardEntity result = flashcardService.save(flashcard);
 
         verify(flashcardRepository, times(2)).save(any(FlashcardEntity.class));
+        assertThat(result).isEqualTo(savedOriginal);
+        assertThat(result.getReverseFlashcard()).isEqualTo(savedReverse);
+        assertThat(savedReverse.getReverseFlashcard()).isEqualTo(savedOriginal);
+    }
+
+    @Test
+    void saveShouldRecoverWhenConcurrentInsertCreatesReverseDeckFirst() {
+        final DeckEntity deckWithoutReverse = new DeckEntity(1, "deck", null);
+        final String reverseName = "deck_reversed";
+        final DeckEntity winningReverseDeck = new DeckEntity(2, reverseName, deckWithoutReverse);
+
+        final Flashcard flashcard = new Flashcard(
+                null,
+                deckWithoutReverse.getId(),
+                deckWithoutReverse.getName(),
+                "anki-1",
+                "front",
+                "back",
+                "description",
+                false
+        );
+
+        when(deckRepository.findById(deckWithoutReverse.getId())).thenReturn(Optional.of(deckWithoutReverse));
+        when(deckRepository.findByName(reverseName))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(winningReverseDeck));
+        when(deckRepository.save(any(DeckEntity.class)))
+                .thenAnswer(invocation -> {
+                    final DeckEntity entity = invocation.getArgument(0);
+                    if (entity.getId() == null) {
+                        throw new DataIntegrityViolationException("duplicate key value violates unique constraint");
+                    }
+                    return entity;
+                });
+
+        final FlashcardEntity savedOriginal = new FlashcardEntity(
+                10, deckWithoutReverse, null, "anki-1", "front", "back", "description", false);
+        final FlashcardEntity savedReverse = new FlashcardEntity(
+                11, winningReverseDeck, null, null, "back", "front", "description", false);
+
+        when(flashcardRepository.save(any(FlashcardEntity.class)))
+                .thenReturn(savedOriginal)
+                .thenReturn(savedReverse);
+
+        final FlashcardEntity result = flashcardService.save(flashcard);
+
         assertThat(result).isEqualTo(savedOriginal);
         assertThat(result.getReverseFlashcard()).isEqualTo(savedReverse);
         assertThat(savedReverse.getReverseFlashcard()).isEqualTo(savedOriginal);


### PR DESCRIPTION
## Summary
- Two concurrent saves for a deck lacking a reverse deck could both observe an empty `deckRepository.findByName(reverseName)` and attempt to insert the same `<name>_reversed` deck, hitting the unique constraint on `DeckEntity.name`. The same find-or-create race existed in `getOrCreateDeck`.
- Extracted a shared private helper `findOrCreateDeckByName(String name)` used by both `getOrCreateDeck` and `getOrCreateReverseDeck`.
- On the `orElseGet` save path, catch `DataIntegrityViolationException` from `deckRepository.save(...)`, re-query `deckRepository.findByName(name)` and return that result. Re-throws the original exception if still not found (different problem).

Closes #175

## Test plan
- [x] New unit test `saveShouldRecoverWhenConcurrentInsertCreatesReverseDeckFirst` simulates the race and verifies `save()` returns the deck that "won" the race without propagating the exception
- [x] Confirmed the new test fails without the fix (DataIntegrityViolationException propagates)
- [x] `./gradlew :vocabulary:test` passes (existing test `saveShouldPersistBothFlashcardsExactlyOnceAndWireReverseReferences` unmodified and still passing)
- [x] `./gradlew :vocabulary:checkstyleMain :vocabulary:checkstyleTest` introduces no new warnings (3 pre-existing warnings in FlashcardService.save() at lines 70-71 predate this change)