### PR TITLE
feat(nutrition): add meal template CRUD endpoints (#183)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealTemplateController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealTemplateController.java
@@ -1,0 +1,187 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateDTO;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.service.MealTemplateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for managing reusable meal templates.
+ * Provides endpoints to create, read, update and delete meal templates and their item composition.
+ */
+@RestController
+@RequestMapping("/nutrition/meal-templates")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class MealTemplateController {
+
+    private static final String TEMPLATES_LOCATION_PREFIX = "/nutrition/meal-templates/";
+
+    private final MealTemplateService mealTemplateService;
+
+    /**
+     * Creates a new MealTemplateController with the required service.
+     *
+     * @param mealTemplateService the service handling meal template operations
+     */
+    public MealTemplateController(MealTemplateService mealTemplateService) {
+        this.mealTemplateService = mealTemplateService;
+    }
+
+    /**
+     * Lists all meal templates ordered alphabetically by name, with each item's macros live-computed
+     * from the current food catalog.
+     *
+     * @return a Mono emitting the list of meal template DTOs
+     */
+    @GetMapping
+    @Operation(
+            summary = "List meal templates",
+            description = "Returns all meal templates ordered by name, with each item's macros live-computed "
+                    + "from the current food catalog.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal template list returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = MealTemplateDTO.class)))
+                )
+            }
+    )
+    public Mono<List<MealTemplateDTO>> listTemplates() {
+        return mealTemplateService.findAll();
+    }
+
+    /**
+     * Returns the meal template with the given id, or 404 if not found.
+     *
+     * @param id the UUID of the meal template
+     * @return a Mono with 200 and the meal template DTO, or 404 if not found
+     */
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a meal template by id",
+            description = "Returns a single meal template by its UUID, with each item's macros live-computed "
+                    + "from the current food catalog.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal template returned",
+                        content = @Content(schema = @Schema(implementation = MealTemplateDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Meal template not found")
+            }
+    )
+    public Mono<ResponseEntity<MealTemplateDTO>> getTemplateById(
+            @PathVariable @Parameter(description = "UUID of the meal template") UUID id) {
+        return mealTemplateService.findById(id)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates a new meal template and returns 201 Created with a Location header.
+     *
+     * @param req the create request body
+     * @return a Mono with 201 Created, Location header, and the created meal template DTO
+     */
+    @PostMapping
+    @Operation(
+            summary = "Create a meal template",
+            description = "Creates a new meal template with the given name and items. An empty items list is "
+                    + "allowed. Every referenced foodId must exist in the food catalog.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Meal template created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = MealTemplateDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "A referenced food was not found")
+            }
+    )
+    public Mono<ResponseEntity<MealTemplateDTO>> createTemplate(@Valid @RequestBody CreateMealTemplateRequest req) {
+        return mealTemplateService.create(req)
+                .map(created -> {
+                    final URI location = URI.create(TEMPLATES_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                });
+    }
+
+    /**
+     * Replaces the name and entire item composition of an existing meal template, or returns 404 if not found.
+     *
+     * @param id  the UUID of the meal template to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated meal template DTO, or 404 if not found
+     */
+    @PutMapping("/{id}")
+    @Operation(
+            summary = "Update a meal template",
+            description = "Fully replaces an existing meal template: renames it and replaces its entire item "
+                    + "composition in one call. Items not present in the request are removed, and all items in "
+                    + "the request are (re-)created. An empty items list removes all items. Every referenced "
+                    + "foodId must exist in the food catalog.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal template updated",
+                        content = @Content(schema = @Schema(implementation = MealTemplateDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Meal template not found, or a referenced food was not found")
+            }
+    )
+    public Mono<ResponseEntity<MealTemplateDTO>> updateTemplate(
+            @PathVariable @Parameter(description = "UUID of the meal template to update") UUID id,
+            @Valid @RequestBody UpdateMealTemplateRequest req) {
+        return mealTemplateService.update(id, req)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes the meal template with the given id, or returns 404 if not found.
+     *
+     * @param id the UUID of the meal template to delete
+     * @return a Mono with 204 No Content on success, or 404 if not found
+     */
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a meal template",
+            description = "Permanently removes the meal template and its items.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Meal template deleted"),
+                @ApiResponse(responseCode = "404", description = "Meal template not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteTemplate(
+            @PathVariable @Parameter(description = "UUID of the meal template to delete") UUID id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return mealTemplateService.delete(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealTemplateRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealTemplateRequest.java
@@ -1,0 +1,29 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * Request body for creating a new meal template.
+ * An empty {@code items} list is allowed, creating a template with no items yet.
+ *
+ * @param name  the display name of the template (required, max 255 characters)
+ * @param items the food items and quantities making up the template (required, may be empty)
+ */
+@Schema(description = "Request to create a new meal template")
+public record CreateMealTemplateRequest(
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "Display name of the template", example = "Breakfast Bowl")
+        String name,
+
+        @NotNull
+        @Valid
+        @Schema(description = "Food items and quantities making up the template")
+        List<MealTemplateItemRequest> items
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateDTO.java
@@ -1,0 +1,25 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a reusable meal template, a named collection of food items and quantities.
+ *
+ * @param id    server-assigned unique identifier
+ * @param name  the template's display name
+ * @param items the food items and quantities making up this template
+ */
+@Schema(description = "A reusable meal template, a named collection of food items and quantities")
+public record MealTemplateDTO(
+        @Schema(description = "Meal template identifier")
+        UUID id,
+
+        @Schema(description = "Display name of the template", example = "Breakfast Bowl")
+        String name,
+
+        @Schema(description = "Food items and quantities making up this template")
+        List<MealTemplateItemDTO> items
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateItemDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateItemDTO.java
@@ -1,0 +1,45 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a single food item with quantity within a meal template.
+ *
+ * @param id        server-assigned unique identifier of the template item
+ * @param foodId    UUID of the referenced food item
+ * @param foodName  resolved name of the referenced food item
+ * @param quantityG portion size in grams
+ * @param kcal      live-computed kilocalories for the given quantity, derived from the food catalog
+ * @param proteinG  live-computed grams of protein for the given quantity, derived from the food catalog
+ * @param carbsG    live-computed grams of carbohydrates for the given quantity, derived from the food catalog
+ * @param fatG      live-computed grams of fat for the given quantity, derived from the food catalog
+ */
+@Schema(description = "A food item with quantity within a meal template")
+public record MealTemplateItemDTO(
+        @Schema(description = "Meal template item identifier")
+        UUID id,
+
+        @Schema(description = "Referenced food item UUID")
+        UUID foodId,
+
+        @Schema(description = "Resolved name of the referenced food item", example = "Oatmeal")
+        String foodName,
+
+        @Schema(description = "Portion size in grams", example = "50.00")
+        BigDecimal quantityG,
+
+        @Schema(description = "Live-computed kilocalories for this quantity", example = "185.00")
+        BigDecimal kcal,
+
+        @Schema(description = "Live-computed grams of protein for this quantity", example = "6.50")
+        BigDecimal proteinG,
+
+        @Schema(description = "Live-computed grams of carbohydrates for this quantity", example = "30.00")
+        BigDecimal carbsG,
+
+        @Schema(description = "Live-computed grams of fat for this quantity", example = "3.50")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateItemRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealTemplateItemRequest.java
@@ -1,0 +1,26 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Request entry describing a single food item with quantity to include in a meal template.
+ *
+ * @param foodId    UUID of the food catalog item (required)
+ * @param quantityG portion size in grams (required, must be positive)
+ */
+@Schema(description = "A food item with quantity to include in a meal template")
+public record MealTemplateItemRequest(
+        @NotNull
+        @Schema(description = "Food catalog item UUID")
+        UUID foodId,
+
+        @NotNull
+        @Positive
+        @Schema(description = "Portion size in grams", example = "50.00")
+        BigDecimal quantityG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealTemplateRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealTemplateRequest.java
@@ -1,0 +1,33 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * Request body for updating an existing meal template.
+ *
+ * <p>This is a full replacement: the template is renamed to {@code name} and its entire item
+ * composition is replaced with {@code items} in a single call — existing items not present in
+ * {@code items} are removed, and all entries in {@code items} are (re-)created. An empty
+ * {@code items} list removes all items from the template.</p>
+ *
+ * @param name  the new display name of the template (required, max 255 characters)
+ * @param items the complete replacement set of food items and quantities (required, may be empty)
+ */
+@Schema(description = "Request to fully replace an existing meal template's name and item composition")
+public record UpdateMealTemplateRequest(
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "New display name of the template", example = "Breakfast Bowl")
+        String name,
+
+        @NotNull
+        @Valid
+        @Schema(description = "Complete replacement set of food items and quantities")
+        List<MealTemplateItemRequest> items
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/MealTemplateMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/MealTemplateMapper.java
@@ -1,0 +1,33 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.MealTemplateItemDTO;
+import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import java.math.BigDecimal;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/** MapStruct mapper for converting {@link MealTemplateItemEntity} into {@link MealTemplateItemDTO}. */
+@Mapper(componentModel = "spring")
+public interface MealTemplateMapper {
+
+    /**
+     * Maps a meal template item entity to its DTO representation, supplying the resolved food name
+     * and the live-computed macro values for the item's quantity.
+     *
+     * @param item     the meal template item entity to map
+     * @param foodName the resolved name of the referenced food item
+     * @param kcal     the live-computed kilocalories for this item's quantity
+     * @param proteinG the live-computed grams of protein for this item's quantity
+     * @param carbsG   the live-computed grams of carbohydrates for this item's quantity
+     * @param fatG     the live-computed grams of fat for this item's quantity
+     * @return the corresponding DTO with resolved food name and macros populated
+     */
+    @Mapping(target = "foodName", source = "foodName")
+    @Mapping(target = "kcal", source = "kcal")
+    @Mapping(target = "proteinG", source = "proteinG")
+    @Mapping(target = "carbsG", source = "carbsG")
+    @Mapping(target = "fatG", source = "fatG")
+    MealTemplateItemDTO toItemDTO(
+            MealTemplateItemEntity item, String foodName, BigDecimal kcal, BigDecimal proteinG,
+            BigDecimal carbsG, BigDecimal fatG);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
@@ -1,0 +1,213 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateDTO;
+import com.marvin.nutrition.dto.MealTemplateItemDTO;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealTemplateEntity;
+import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.mapper.MealTemplateMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealTemplateItemRepository;
+import com.marvin.nutrition.repository.MealTemplateRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates CRUD operations for meal templates, including live macro computation for their items. */
+@Service
+public class MealTemplateService {
+
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    private final MealTemplateRepository mealTemplateRepository;
+    private final MealTemplateItemRepository mealTemplateItemRepository;
+    private final FoodRepository foodRepository;
+    private final MealTemplateMapper mealTemplateMapper;
+    private final MealTemplateWriteService mealTemplateWriteService;
+
+    /**
+     * Creates a new MealTemplateService with the required dependencies.
+     *
+     * @param mealTemplateRepository     JPA repository for meal templates
+     * @param mealTemplateItemRepository JPA repository for meal template items
+     * @param foodRepository             JPA repository for food catalog entries
+     * @param mealTemplateMapper         MapStruct mapper for entity/DTO conversion
+     * @param mealTemplateWriteService   service owning transactional meal template write operations
+     */
+    public MealTemplateService(
+            MealTemplateRepository mealTemplateRepository,
+            MealTemplateItemRepository mealTemplateItemRepository,
+            FoodRepository foodRepository,
+            MealTemplateMapper mealTemplateMapper,
+            MealTemplateWriteService mealTemplateWriteService) {
+        this.mealTemplateRepository = mealTemplateRepository;
+        this.mealTemplateItemRepository = mealTemplateItemRepository;
+        this.foodRepository = foodRepository;
+        this.mealTemplateMapper = mealTemplateMapper;
+        this.mealTemplateWriteService = mealTemplateWriteService;
+    }
+
+    /**
+     * Returns all meal templates ordered alphabetically by name, with each item's macros
+     * live-computed from the current food catalog.
+     *
+     * @return a Mono emitting the list of meal template DTOs
+     */
+    public Mono<List<MealTemplateDTO>> findAll() {
+        return Mono.fromCallable(() -> {
+            final List<MealTemplateEntity> templates = mealTemplateRepository.findAllByOrderByNameAsc();
+            final Map<UUID, List<MealTemplateItemEntity>> itemsByTemplateId = templates.stream()
+                    .collect(Collectors.toMap(MealTemplateEntity::getId,
+                            t -> mealTemplateItemRepository.findByMealTemplateId(t.getId())));
+            final List<MealTemplateItemEntity> allItems = itemsByTemplateId.values().stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            final Map<UUID, FoodEntity> foodById = loadFoodsByIds(allItems);
+
+            return templates.stream()
+                    .map(template -> toDTO(template, itemsByTemplateId.get(template.getId()), foodById))
+                    .collect(Collectors.toList());
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Returns the meal template with the given id, with each item's macros live-computed from the
+     * current food catalog.
+     * Emits {@link NoSuchElementException} if no template with that id exists.
+     *
+     * @param id the UUID of the meal template
+     * @return a Mono emitting the meal template DTO
+     */
+    public Mono<MealTemplateDTO> findById(UUID id) {
+        return Mono.fromCallable(() -> {
+            final MealTemplateEntity template = mealTemplateRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Meal template not found: " + id));
+            final List<MealTemplateItemEntity> items = mealTemplateItemRepository.findByMealTemplateId(id);
+            final Map<UUID, FoodEntity> foodById = loadFoodsByIds(items);
+            return toDTO(template, items, foodById);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Creates a new meal template.
+     * Emits {@link NoSuchElementException} if any referenced food is not found.
+     *
+     * @param req the create request containing the template name and items
+     * @return a Mono emitting the created meal template DTO
+     */
+    public Mono<MealTemplateDTO> create(CreateMealTemplateRequest req) {
+        return Mono.fromCallable(() -> mealTemplateWriteService.create(req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(this::toDTO);
+    }
+
+    /**
+     * Replaces the name and entire item composition of an existing meal template.
+     * Emits {@link NoSuchElementException} if the template does not exist or if any referenced
+     * food is not found.
+     *
+     * @param id  the UUID of the template to update
+     * @param req the update request containing the new name and the replacement items
+     * @return a Mono emitting the updated meal template DTO
+     */
+    public Mono<MealTemplateDTO> update(UUID id, UpdateMealTemplateRequest req) {
+        return Mono.fromCallable(() -> mealTemplateWriteService.update(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(this::toDTO);
+    }
+
+    /**
+     * Deletes the meal template with the given id.
+     * Emits {@link NoSuchElementException} if no template with that id exists.
+     *
+     * @param id the UUID of the template to delete
+     * @return an empty Mono on success
+     */
+    public Mono<Void> delete(UUID id) {
+        return Mono.fromCallable(() -> {
+            mealTemplateWriteService.delete(id);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    /**
+     * Assembles a {@link MealTemplateDTO} from a write-service result, resolving food names and
+     * macros for the saved items.
+     *
+     * @param writeResult the saved template together with its saved items
+     * @return the assembled meal template DTO
+     */
+    private MealTemplateDTO toDTO(MealTemplateWriteService.MealTemplateWithItems writeResult) {
+        final Map<UUID, FoodEntity> foodById = loadFoodsByIds(writeResult.items());
+        return toDTO(writeResult.template(), writeResult.items(), foodById);
+    }
+
+    /**
+     * Assembles a {@link MealTemplateDTO} from a template entity and its items, resolving food
+     * names and live-computed macros via the given food lookup map.
+     *
+     * @param template the meal template entity
+     * @param items    the template's item entities
+     * @param foodById foods referenced by the items, keyed by id
+     * @return the assembled meal template DTO
+     */
+    private MealTemplateDTO toDTO(MealTemplateEntity template, List<MealTemplateItemEntity> items, Map<UUID, FoodEntity> foodById) {
+        final List<MealTemplateItemDTO> itemDTOs = items.stream()
+                .map(item -> toItemDTO(item, foodById.get(item.getFoodId())))
+                .collect(Collectors.toList());
+        return new MealTemplateDTO(template.getId(), template.getName(), itemDTOs);
+    }
+
+    /**
+     * Maps a single template item to its DTO, live-computing macros from the referenced food.
+     *
+     * @param item the template item entity
+     * @param food the referenced food entity
+     * @return the mapped item DTO with live-computed macros
+     */
+    private MealTemplateItemDTO toItemDTO(MealTemplateItemEntity item, FoodEntity food) {
+        return mealTemplateMapper.toItemDTO(
+                item,
+                food.getName(),
+                snapshot(food.getKcalPer100(), item.getQuantityG()),
+                snapshot(food.getProteinPer100(), item.getQuantityG()),
+                snapshot(food.getCarbsPer100(), item.getQuantityG()),
+                snapshot(food.getFatPer100(), item.getQuantityG())
+        );
+    }
+
+    /**
+     * Loads all foods referenced by the given items in a single query, keyed by id.
+     *
+     * @param items the template items whose referenced foods should be loaded
+     * @return a map of food id to food entity
+     */
+    private Map<UUID, FoodEntity> loadFoodsByIds(List<MealTemplateItemEntity> items) {
+        final List<UUID> foodIds = items.stream()
+                .map(MealTemplateItemEntity::getFoodId)
+                .distinct()
+                .collect(Collectors.toList());
+        return foodRepository.findAllById(foodIds).stream()
+                .collect(Collectors.toMap(FoodEntity::getId, food -> food));
+    }
+
+    /**
+     * Computes the live macro value: {@code per100 × quantityG / 100}, rounded half-up to 2 decimals.
+     *
+     * @param per100    the per-100-g value from the food catalog
+     * @param quantityG the portion size in grams
+     * @return the computed value
+     */
+    private BigDecimal snapshot(BigDecimal per100, BigDecimal quantityG) {
+        return per100.multiply(quantityG).divide(HUNDRED, 2, RoundingMode.HALF_UP);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
@@ -1,0 +1,159 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealTemplateEntity;
+import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealTemplateItemRepository;
+import com.marvin.nutrition.repository.MealTemplateRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the transactional write operations for meal templates.
+ *
+ * <p>All methods in this service perform blocking repository access and must only be called from
+ * a thread already running on a blocking-friendly scheduler (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}),
+ * and must be invoked from outside this bean so that Spring's transactional proxy is applied.</p>
+ */
+@Service
+public class MealTemplateWriteService {
+
+    private final MealTemplateRepository mealTemplateRepository;
+    private final MealTemplateItemRepository mealTemplateItemRepository;
+    private final FoodRepository foodRepository;
+
+    /**
+     * Creates a new MealTemplateWriteService with the required dependencies.
+     *
+     * @param mealTemplateRepository     JPA repository for meal templates
+     * @param mealTemplateItemRepository JPA repository for meal template items
+     * @param foodRepository             JPA repository for food catalog entries
+     */
+    public MealTemplateWriteService(
+            MealTemplateRepository mealTemplateRepository,
+            MealTemplateItemRepository mealTemplateItemRepository,
+            FoodRepository foodRepository) {
+        this.mealTemplateRepository = mealTemplateRepository;
+        this.mealTemplateItemRepository = mealTemplateItemRepository;
+        this.foodRepository = foodRepository;
+    }
+
+    /**
+     * Creates a new meal template with the given name and items.
+     * Every {@code foodId} referenced by an item must exist in the food catalog.
+     * Throws {@link NoSuchElementException} if any referenced food is not found.
+     *
+     * @param req the create request containing the template name and items
+     * @return the saved template together with its saved items
+     */
+    @Transactional
+    public MealTemplateWithItems create(CreateMealTemplateRequest req) {
+        validateFoodIds(req.items());
+
+        final MealTemplateEntity template = new MealTemplateEntity();
+        template.setName(req.name());
+        final MealTemplateEntity savedTemplate = mealTemplateRepository.save(template);
+
+        final List<MealTemplateItemEntity> savedItems = saveItems(savedTemplate.getId(), req.items());
+        return new MealTemplateWithItems(savedTemplate, savedItems);
+    }
+
+    /**
+     * Replaces the name and entire item composition of an existing meal template.
+     * Every {@code foodId} referenced by an item must exist in the food catalog.
+     * Throws {@link NoSuchElementException} if the template does not exist or if any referenced
+     * food is not found.
+     *
+     * @param id  the UUID of the template to update
+     * @param req the update request containing the new name and the replacement items
+     * @return the updated template together with its newly saved items
+     */
+    @Transactional
+    public MealTemplateWithItems update(UUID id, UpdateMealTemplateRequest req) {
+        final MealTemplateEntity template = mealTemplateRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal template not found: " + id));
+
+        validateFoodIds(req.items());
+
+        template.setName(req.name());
+        final MealTemplateEntity savedTemplate = mealTemplateRepository.save(template);
+
+        mealTemplateItemRepository.deleteByMealTemplateId(id);
+        final List<MealTemplateItemEntity> savedItems = saveItems(id, req.items());
+        return new MealTemplateWithItems(savedTemplate, savedItems);
+    }
+
+    /**
+     * Deletes the meal template with the given id. Deleting the template cascades to remove its items.
+     * Throws {@link NoSuchElementException} if no template with that id exists.
+     *
+     * @param id the UUID of the template to delete
+     */
+    @Transactional
+    public void delete(UUID id) {
+        final MealTemplateEntity template = mealTemplateRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal template not found: " + id));
+        mealTemplateRepository.delete(template);
+    }
+
+    /**
+     * Verifies that every {@code foodId} referenced by the given items exists in the food catalog.
+     *
+     * @param items the requested template items
+     * @throws NoSuchElementException if any referenced food is not found
+     */
+    private void validateFoodIds(List<MealTemplateItemRequest> items) {
+        final List<UUID> requestedFoodIds = items.stream()
+                .map(MealTemplateItemRequest::foodId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        final List<UUID> existingFoodIds = foodRepository.findAllById(requestedFoodIds).stream()
+                .map(FoodEntity::getId)
+                .collect(Collectors.toList());
+
+        for (final UUID foodId : requestedFoodIds) {
+            if (!existingFoodIds.contains(foodId)) {
+                throw new NoSuchElementException("Food not found: " + foodId);
+            }
+        }
+    }
+
+    /**
+     * Saves a {@link MealTemplateItemEntity} for each requested item, linked to the given template.
+     *
+     * @param templateId the id of the owning meal template
+     * @param items      the requested items to persist
+     * @return the saved item entities, in the same order as {@code items}
+     */
+    private List<MealTemplateItemEntity> saveItems(UUID templateId, List<MealTemplateItemRequest> items) {
+        final List<MealTemplateItemEntity> savedItems = new ArrayList<>();
+        for (final MealTemplateItemRequest itemReq : items) {
+            final MealTemplateItemEntity item = new MealTemplateItemEntity();
+            item.setMealTemplateId(templateId);
+            item.setFoodId(itemReq.foodId());
+            item.setQuantityG(itemReq.quantityG());
+            savedItems.add(mealTemplateItemRepository.save(item));
+        }
+        return savedItems;
+    }
+
+    /**
+     * Holds a saved meal template together with its saved items, for assembly into a response DTO
+     * by the reactive {@link MealTemplateService}.
+     *
+     * @param template the saved meal template entity
+     * @param items    the saved meal template item entities belonging to the template
+     */
+    public record MealTemplateWithItems(MealTemplateEntity template, List<MealTemplateItemEntity> items) {
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealTemplateControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealTemplateControllerTest.java
@@ -1,0 +1,228 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateDTO;
+import com.marvin.nutrition.dto.MealTemplateItemDTO;
+import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.service.MealTemplateService;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealTemplateController} covering all endpoints. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealTemplateController Tests")
+class MealTemplateControllerTest {
+
+    @Mock
+    private MealTemplateService mealTemplateService;
+
+    @InjectMocks
+    private MealTemplateController mealTemplateController;
+
+    private UUID templateId;
+    private UUID foodId;
+    private MealTemplateDTO templateDTO;
+    private CreateMealTemplateRequest createRequest;
+    private UpdateMealTemplateRequest updateRequest;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        templateId = UUID.randomUUID();
+        foodId = UUID.randomUUID();
+
+        final MealTemplateItemDTO itemDTO = new MealTemplateItemDTO(
+                UUID.randomUUID(), foodId, "Oatmeal", new BigDecimal("50"),
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        );
+
+        templateDTO = new MealTemplateDTO(templateId, "Breakfast Bowl", List.of(itemDTO));
+
+        createRequest = new CreateMealTemplateRequest(
+                "Breakfast Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("50")))
+        );
+
+        updateRequest = new UpdateMealTemplateRequest(
+                "Renamed Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("80")))
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /nutrition/meal-templates
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("listTemplates returns 200 with all templates")
+    void listTemplates_Returns200WithAllTemplates() {
+        when(mealTemplateService.findAll()).thenReturn(Mono.just(List.of(templateDTO)));
+
+        final Mono<List<MealTemplateDTO>> result = mealTemplateController.listTemplates();
+
+        StepVerifier.create(result)
+                .assertNext(list -> {
+                    assertEquals(1, list.size());
+                    assertEquals(templateId, list.get(0).id());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).findAll();
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /nutrition/meal-templates/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getTemplateById returns 200 with template when found")
+    void getTemplateById_Found_Returns200() {
+        when(mealTemplateService.findById(templateId)).thenReturn(Mono.just(templateDTO));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result = mealTemplateController.getTemplateById(templateId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Breakfast Bowl", response.getBody().name());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).findById(templateId);
+    }
+
+    @Test
+    @DisplayName("getTemplateById returns 404 when not found")
+    void getTemplateById_NotFound_Returns404() {
+        when(mealTemplateService.findById(templateId))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal template not found: " + templateId)));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result = mealTemplateController.getTemplateById(templateId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealTemplateService).findById(templateId);
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/meal-templates
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createTemplate returns 201 Created with Location header pointing to new template")
+    void createTemplate_Valid_Returns201WithLocation() {
+        when(mealTemplateService.create(any(CreateMealTemplateRequest.class))).thenReturn(Mono.just(templateDTO));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result = mealTemplateController.createTemplate(createRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Breakfast Bowl", response.getBody().name());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString().contains(templateId.toString()));
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).create(eq(createRequest));
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-templates/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateTemplate returns 200 with updated DTO when template exists")
+    void updateTemplate_Found_Returns200WithUpdatedDTO() {
+        final MealTemplateDTO updatedDTO = new MealTemplateDTO(templateId, "Renamed Bowl", templateDTO.items());
+
+        when(mealTemplateService.update(eq(templateId), any(UpdateMealTemplateRequest.class)))
+                .thenReturn(Mono.just(updatedDTO));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result =
+                mealTemplateController.updateTemplate(templateId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Renamed Bowl", response.getBody().name());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).update(eq(templateId), eq(updateRequest));
+    }
+
+    @Test
+    @DisplayName("updateTemplate returns 404 when template not found")
+    void updateTemplate_NotFound_Returns404() {
+        when(mealTemplateService.update(eq(templateId), any(UpdateMealTemplateRequest.class)))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal template not found: " + templateId)));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result =
+                mealTemplateController.updateTemplate(templateId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealTemplateService).update(eq(templateId), eq(updateRequest));
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE /nutrition/meal-templates/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteTemplate returns 204 No Content when template exists")
+    void deleteTemplate_Exists_Returns204() {
+        when(mealTemplateService.delete(templateId)).thenReturn(Mono.empty());
+
+        final Mono<ResponseEntity<Void>> result = mealTemplateController.deleteTemplate(templateId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(204, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealTemplateService).delete(templateId);
+    }
+
+    @Test
+    @DisplayName("deleteTemplate returns 404 when template not found")
+    void deleteTemplate_NotFound_Returns404() {
+        when(mealTemplateService.delete(templateId))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal template not found: " + templateId)));
+
+        final Mono<ResponseEntity<Void>> result = mealTemplateController.deleteTemplate(templateId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealTemplateService).delete(templateId);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
@@ -1,0 +1,281 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateDTO;
+import com.marvin.nutrition.dto.MealTemplateItemDTO;
+import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealTemplateEntity;
+import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.mapper.MealTemplateMapper;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealTemplateItemRepository;
+import com.marvin.nutrition.repository.MealTemplateRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealTemplateService} covering CRUD and macro computation. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealTemplateService Tests")
+class MealTemplateServiceTest {
+
+    @Mock
+    private MealTemplateRepository mealTemplateRepository;
+
+    @Mock
+    private MealTemplateItemRepository mealTemplateItemRepository;
+
+    @Mock
+    private FoodRepository foodRepository;
+
+    @Mock
+    private MealTemplateMapper mealTemplateMapper;
+
+    @Mock
+    private MealTemplateWriteService mealTemplateWriteService;
+
+    @InjectMocks
+    private MealTemplateService mealTemplateService;
+
+    private UUID templateId;
+    private UUID itemId;
+    private UUID foodId;
+    private FoodEntity foodEntity;
+    private MealTemplateEntity templateEntity;
+    private MealTemplateItemEntity itemEntity;
+    private MealTemplateItemDTO itemDTO;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        templateId = UUID.randomUUID();
+        itemId = UUID.randomUUID();
+        foodId = UUID.randomUUID();
+
+        foodEntity = new FoodEntity();
+        foodEntity.setId(foodId);
+        foodEntity.setName("Oatmeal");
+        foodEntity.setKcalPer100(new BigDecimal("370.00"));
+        foodEntity.setProteinPer100(new BigDecimal("13.00"));
+        foodEntity.setCarbsPer100(new BigDecimal("60.00"));
+        foodEntity.setFatPer100(new BigDecimal("7.00"));
+
+        templateEntity = new MealTemplateEntity();
+        templateEntity.setId(templateId);
+        templateEntity.setName("Breakfast Bowl");
+
+        itemEntity = new MealTemplateItemEntity();
+        itemEntity.setId(itemId);
+        itemEntity.setMealTemplateId(templateId);
+        itemEntity.setFoodId(foodId);
+        itemEntity.setQuantityG(new BigDecimal("50"));
+
+        // kcalPer100=370, qty=50 -> 185.00; protein 6.50; carbs 30.00; fat 3.50
+        itemDTO = new MealTemplateItemDTO(
+                itemId, foodId, "Oatmeal", new BigDecimal("50"),
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // findAll
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findAll returns templates ordered by name with live-computed item macros")
+    void findAll_ReturnsTemplatesWithMacros() {
+        when(mealTemplateRepository.findAllByOrderByNameAsc()).thenReturn(List.of(templateEntity));
+        when(mealTemplateItemRepository.findByMealTemplateId(templateId)).thenReturn(List.of(itemEntity));
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateMapper.toItemDTO(
+                itemEntity, "Oatmeal",
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        )).thenReturn(itemDTO);
+
+        StepVerifier.create(mealTemplateService.findAll())
+                .assertNext(list -> {
+                    assertEquals(1, list.size());
+                    final MealTemplateDTO dto = list.get(0);
+                    assertEquals(templateId, dto.id());
+                    assertEquals("Breakfast Bowl", dto.name());
+                    assertEquals(1, dto.items().size());
+                    assertEquals(itemDTO, dto.items().get(0));
+                })
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // findById
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findById returns template with live-computed item macros")
+    void findById_Found_ReturnsTemplateWithMacros() {
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(mealTemplateItemRepository.findByMealTemplateId(templateId)).thenReturn(List.of(itemEntity));
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateMapper.toItemDTO(
+                itemEntity, "Oatmeal",
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        )).thenReturn(itemDTO);
+
+        StepVerifier.create(mealTemplateService.findById(templateId))
+                .assertNext(dto -> {
+                    assertEquals(templateId, dto.id());
+                    assertEquals("Breakfast Bowl", dto.name());
+                    assertEquals(List.of(itemDTO), dto.items());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("findById emits NoSuchElementException when template not found")
+    void findById_NotFound_EmitsNoSuchElementException() {
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealTemplateService.findById(templateId))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    // -----------------------------------------------------------------------
+    // create
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create delegates to write service and assembles response DTO")
+    void create_DelegatesAndAssemblesDTO() {
+        final CreateMealTemplateRequest req = new CreateMealTemplateRequest(
+                "Breakfast Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("50")))
+        );
+        final MealTemplateWriteService.MealTemplateWithItems writeResult =
+                new MealTemplateWriteService.MealTemplateWithItems(templateEntity, List.of(itemEntity));
+
+        when(mealTemplateWriteService.create(req)).thenReturn(writeResult);
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateMapper.toItemDTO(
+                itemEntity, "Oatmeal",
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        )).thenReturn(itemDTO);
+
+        StepVerifier.create(mealTemplateService.create(req))
+                .assertNext(dto -> {
+                    assertEquals(templateId, dto.id());
+                    assertEquals("Breakfast Bowl", dto.name());
+                    assertEquals(List.of(itemDTO), dto.items());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateWriteService).create(req);
+    }
+
+    // -----------------------------------------------------------------------
+    // update
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("update delegates to write service and assembles response DTO")
+    void update_DelegatesAndAssemblesDTO() {
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest(
+                "Renamed Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("50")))
+        );
+        final MealTemplateEntity renamed = new MealTemplateEntity();
+        renamed.setId(templateId);
+        renamed.setName("Renamed Bowl");
+
+        final MealTemplateItemDTO renamedItemDTO = new MealTemplateItemDTO(
+                itemId, foodId, "Oatmeal", new BigDecimal("50"),
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        );
+        final MealTemplateWriteService.MealTemplateWithItems writeResult =
+                new MealTemplateWriteService.MealTemplateWithItems(renamed, List.of(itemEntity));
+
+        when(mealTemplateWriteService.update(templateId, req)).thenReturn(writeResult);
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateMapper.toItemDTO(
+                itemEntity, "Oatmeal",
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        )).thenReturn(renamedItemDTO);
+
+        StepVerifier.create(mealTemplateService.update(templateId, req))
+                .assertNext(dto -> {
+                    assertEquals(templateId, dto.id());
+                    assertEquals("Renamed Bowl", dto.name());
+                    assertEquals(List.of(renamedItemDTO), dto.items());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateWriteService).update(templateId, req);
+    }
+
+    @Test
+    @DisplayName("update emits NoSuchElementException when write service throws")
+    void update_NotFound_EmitsNoSuchElementException() {
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest("Renamed Bowl", List.of());
+
+        when(mealTemplateWriteService.update(templateId, req))
+                .thenThrow(new NoSuchElementException("Meal template not found: " + templateId));
+
+        StepVerifier.create(mealTemplateService.update(templateId, req))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    // -----------------------------------------------------------------------
+    // delete
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("delete delegates to write service and completes")
+    void delete_DelegatesToWriteService() {
+        StepVerifier.create(mealTemplateService.delete(templateId))
+                .verifyComplete();
+
+        verify(mealTemplateWriteService).delete(templateId);
+    }
+
+    @Test
+    @DisplayName("delete emits NoSuchElementException when write service throws")
+    void delete_NotFound_EmitsNoSuchElementException() {
+        doThrow(new NoSuchElementException("Meal template not found: " + templateId))
+                .when(mealTemplateWriteService).delete(templateId);
+
+        StepVerifier.create(mealTemplateService.delete(templateId))
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("findAll returns empty list when no templates exist")
+    void findAll_NoTemplates_ReturnsEmptyList() {
+        when(mealTemplateRepository.findAllByOrderByNameAsc()).thenReturn(List.of());
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
+
+        StepVerifier.create(mealTemplateService.findAll())
+                .assertNext(list -> assertEquals(0, list.size()))
+                .verifyComplete();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
@@ -1,0 +1,231 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
+import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.MealTemplateEntity;
+import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.repository.FoodRepository;
+import com.marvin.nutrition.repository.MealTemplateItemRepository;
+import com.marvin.nutrition.repository.MealTemplateRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link MealTemplateWriteService} covering the transactional write operations. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealTemplateWriteService Tests")
+class MealTemplateWriteServiceTest {
+
+    @Mock
+    private MealTemplateRepository mealTemplateRepository;
+
+    @Mock
+    private MealTemplateItemRepository mealTemplateItemRepository;
+
+    @Mock
+    private FoodRepository foodRepository;
+
+    @InjectMocks
+    private MealTemplateWriteService mealTemplateWriteService;
+
+    private UUID templateId;
+    private UUID foodId;
+    private FoodEntity foodEntity;
+    private MealTemplateEntity templateEntity;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        templateId = UUID.randomUUID();
+        foodId = UUID.randomUUID();
+
+        foodEntity = new FoodEntity();
+        foodEntity.setId(foodId);
+        foodEntity.setName("Oatmeal");
+        foodEntity.setKcalPer100(new BigDecimal("370.00"));
+        foodEntity.setProteinPer100(new BigDecimal("13.00"));
+        foodEntity.setCarbsPer100(new BigDecimal("60.00"));
+        foodEntity.setFatPer100(new BigDecimal("7.00"));
+
+        templateEntity = new MealTemplateEntity();
+        templateEntity.setId(templateId);
+        templateEntity.setName("Breakfast Bowl");
+    }
+
+    // -----------------------------------------------------------------------
+    // create
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create saves template and its items when all foodIds exist")
+    void create_AllFoodsExist_SavesTemplateAndItems() {
+        final CreateMealTemplateRequest req = new CreateMealTemplateRequest(
+                "Breakfast Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("50")))
+        );
+
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class))).thenReturn(templateEntity);
+        when(mealTemplateItemRepository.save(any(MealTemplateItemEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        final MealTemplateWriteService.MealTemplateWithItems result = mealTemplateWriteService.create(req);
+
+        assertEquals(templateEntity, result.template());
+        assertEquals(1, result.items().size());
+        verify(mealTemplateRepository).save(argThat(e -> "Breakfast Bowl".equals(e.getName())));
+        verify(mealTemplateItemRepository).save(argThat(item ->
+                templateId.equals(item.getMealTemplateId())
+                        && foodId.equals(item.getFoodId())
+                        && new BigDecimal("50").compareTo(item.getQuantityG()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("create allows an empty items list")
+    void create_EmptyItems_SavesTemplateWithNoItems() {
+        final CreateMealTemplateRequest req = new CreateMealTemplateRequest("Empty Template", List.of());
+
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class))).thenReturn(templateEntity);
+
+        final MealTemplateWriteService.MealTemplateWithItems result = mealTemplateWriteService.create(req);
+
+        assertEquals(templateEntity, result.template());
+        assertEquals(0, result.items().size());
+        verify(mealTemplateItemRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("create throws NoSuchElementException when a referenced food does not exist")
+    void create_UnknownFoodId_ThrowsNoSuchElementException() {
+        final UUID unknownFoodId = UUID.randomUUID();
+        final CreateMealTemplateRequest req = new CreateMealTemplateRequest(
+                "Breakfast Bowl", List.of(new MealTemplateItemRequest(unknownFoodId, new BigDecimal("50")))
+        );
+
+        when(foodRepository.findAllById(List.of(unknownFoodId))).thenReturn(List.of());
+
+        assertThrows(NoSuchElementException.class, () -> mealTemplateWriteService.create(req));
+
+        verify(mealTemplateRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // update
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("update renames template, replaces items, and validates foodIds")
+    void update_Found_RenamesAndReplacesItems() {
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest(
+                "Renamed Bowl", List.of(new MealTemplateItemRequest(foodId, new BigDecimal("80")))
+        );
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class))).thenReturn(templateEntity);
+        when(mealTemplateItemRepository.save(any(MealTemplateItemEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        final MealTemplateWriteService.MealTemplateWithItems result = mealTemplateWriteService.update(templateId, req);
+
+        assertEquals("Renamed Bowl", result.template().getName());
+        assertEquals(1, result.items().size());
+        verify(mealTemplateItemRepository).deleteByMealTemplateId(templateId);
+        verify(mealTemplateItemRepository).save(argThat(item ->
+                templateId.equals(item.getMealTemplateId())
+                        && foodId.equals(item.getFoodId())
+                        && new BigDecimal("80").compareTo(item.getQuantityG()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("update throws NoSuchElementException when template not found")
+    void update_NotFound_ThrowsNoSuchElementException() {
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest("Renamed Bowl", List.of());
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> mealTemplateWriteService.update(templateId, req));
+
+        verify(mealTemplateItemRepository, never()).deleteByMealTemplateId(any());
+        verify(mealTemplateRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("update throws NoSuchElementException when a referenced food does not exist")
+    void update_UnknownFoodId_ThrowsNoSuchElementException() {
+        final UUID unknownFoodId = UUID.randomUUID();
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest(
+                "Renamed Bowl", List.of(new MealTemplateItemRequest(unknownFoodId, new BigDecimal("50")))
+        );
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(foodRepository.findAllById(List.of(unknownFoodId))).thenReturn(List.of());
+
+        assertThrows(NoSuchElementException.class, () -> mealTemplateWriteService.update(templateId, req));
+
+        verify(mealTemplateItemRepository, never()).deleteByMealTemplateId(any());
+        verify(mealTemplateRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("update with empty items list removes all items")
+    void update_EmptyItems_RemovesAllItems() {
+        final UpdateMealTemplateRequest req = new UpdateMealTemplateRequest("Renamed Bowl", List.of());
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(foodRepository.findAllById(List.of())).thenReturn(List.of());
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class))).thenReturn(templateEntity);
+
+        final MealTemplateWriteService.MealTemplateWithItems result = mealTemplateWriteService.update(templateId, req);
+
+        assertEquals(0, result.items().size());
+        verify(mealTemplateItemRepository).deleteByMealTemplateId(templateId);
+        verify(mealTemplateItemRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // delete
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("delete throws NoSuchElementException when template not found")
+    void delete_NotFound_ThrowsNoSuchElementException() {
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> mealTemplateWriteService.delete(templateId));
+
+        verify(mealTemplateRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("delete removes template when found")
+    void delete_Found_RemovesTemplate() {
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+
+        mealTemplateWriteService.delete(templateId);
+
+        verify(mealTemplateRepository, times(1)).delete(templateEntity);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds full CRUD for meal templates under `/nutrition/meal-templates`, building on the persistence layer merged in #182 (MealTemplateEntity, MealTemplateItemEntity, repositories).
- New DTOs (`MealTemplateDTO`, `MealTemplateItemDTO`, `CreateMealTemplateRequest`, `UpdateMealTemplateRequest`, `MealTemplateItemRequest`), `MealTemplateMapper`, and a read/write service split (`MealTemplateService` reactive, `MealTemplateWriteService` blocking/transactional), mirroring the existing `FoodService`/`MealEntryWriteService` patterns.
- Item macros (kcal/protein/carbs/fat) are live-computed from the food catalog (`per100 * quantityG / 100`, half-up to 2 decimals) for display only — never persisted.
- `PUT /nutrition/meal-templates/{id}` performs a full replace: renames the template and replaces its entire item composition (delete + recreate) in one transaction.

## Test plan
- [x] New unit tests for `MealTemplateWriteService`, `MealTemplateService`, and `MealTemplateController` (Mockito + StepVerifier), covering CRUD, not-found paths, and macro computation correctness.
- [x] `./gradlew :nutrition:test :nutrition:checkstyleMain :nutrition:checkstyleTest` — all green (only the pre-existing Docker/Testcontainers-based `MealTemplateRepositoryTest` is skipped, as no local Docker is available).
- [x] `tdd-test-guardian` confirmed no existing tests were modified.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)