### PR TITLE
feat(nutrition): log meal template entries into a day's diary (#184)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealEntryController.java
@@ -5,7 +5,9 @@ import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.DaySummaryDTO;
 import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.UpdateMealEntryRequest;
+import com.marvin.nutrition.entity.MealType;
 import com.marvin.nutrition.service.MealEntryService;
+import com.marvin.nutrition.service.MealTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -43,14 +45,17 @@ public class MealEntryController {
     private static final String ENTRIES_LOCATION_PREFIX = "/nutrition/entries/";
 
     private final MealEntryService mealEntryService;
+    private final MealTemplateService mealTemplateService;
 
     /**
-     * Creates a new MealEntryController with the required service.
+     * Creates a new MealEntryController with the required services.
      *
-     * @param mealEntryService the service handling meal entry operations
+     * @param mealEntryService    the service handling meal entry operations
+     * @param mealTemplateService the service handling meal template operations
      */
-    public MealEntryController(MealEntryService mealEntryService) {
+    public MealEntryController(MealEntryService mealEntryService, MealTemplateService mealTemplateService) {
         this.mealEntryService = mealEntryService;
+        this.mealTemplateService = mealTemplateService;
     }
 
     /**
@@ -122,6 +127,41 @@ public class MealEntryController {
             @Parameter(description = "Date of the meal entries (ISO-8601)", example = "2026-06-07") LocalDate date,
             @Valid @RequestBody CreateMealEntriesRequest req) {
         return mealEntryService.addEntries(date, req.entries())
+                .map(created -> ResponseEntity.status(HttpStatus.CREATED).body(created))
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Logs all items of a meal template as meal entries for the given date and meal type.
+     *
+     * @param date       the date to log the entries for
+     * @param templateId the UUID of the meal template to log
+     * @param mealType   the meal category to assign to each created entry
+     * @return a Mono with 201 Created and the created meal entry DTOs, or 404 if the template is not found
+     */
+    @PostMapping("/nutrition/days/{date}/entries/from-template/{templateId}")
+    @Operation(
+            summary = "Log a meal template into a day",
+            description = "Creates a meal entry for each item of the given meal template, for the given "
+                    + "date and meal type. Reuses the same snapshot logic as the batch entry endpoint: "
+                    + "macros are snapshotted from the food catalog and the day-target snapshot is "
+                    + "ensured exactly once.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Meal entries created",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = MealEntryDTO.class)))
+                ),
+                @ApiResponse(responseCode = "404", description = "Meal template not found")
+            }
+    )
+    public Mono<ResponseEntity<List<MealEntryDTO>>> addEntriesFromTemplate(
+            @PathVariable
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "Date of the meal entries (ISO-8601)", example = "2026-06-07") LocalDate date,
+            @PathVariable @Parameter(description = "UUID of the meal template to log") UUID templateId,
+            @RequestParam @Parameter(description = "Meal category", example = "LUNCH") MealType mealType) {
+        return mealTemplateService.logToDay(date, templateId, mealType)
                 .map(created -> ResponseEntity.status(HttpStatus.CREATED).body(created))
                 .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
@@ -1,18 +1,22 @@
 package com.marvin.nutrition.service;
 
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.MealTemplateDTO;
 import com.marvin.nutrition.dto.MealTemplateItemDTO;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealTemplateEntity;
 import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.entity.MealType;
 import com.marvin.nutrition.mapper.MealTemplateMapper;
 import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealTemplateItemRepository;
 import com.marvin.nutrition.repository.MealTemplateRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -33,6 +37,7 @@ public class MealTemplateService {
     private final FoodRepository foodRepository;
     private final MealTemplateMapper mealTemplateMapper;
     private final MealTemplateWriteService mealTemplateWriteService;
+    private final MealEntryWriteService mealEntryWriteService;
 
     /**
      * Creates a new MealTemplateService with the required dependencies.
@@ -42,18 +47,21 @@ public class MealTemplateService {
      * @param foodRepository             JPA repository for food catalog entries
      * @param mealTemplateMapper         MapStruct mapper for entity/DTO conversion
      * @param mealTemplateWriteService   service owning transactional meal template write operations
+     * @param mealEntryWriteService      service owning transactional meal entry write operations
      */
     public MealTemplateService(
             MealTemplateRepository mealTemplateRepository,
             MealTemplateItemRepository mealTemplateItemRepository,
             FoodRepository foodRepository,
             MealTemplateMapper mealTemplateMapper,
-            MealTemplateWriteService mealTemplateWriteService) {
+            MealTemplateWriteService mealTemplateWriteService,
+            MealEntryWriteService mealEntryWriteService) {
         this.mealTemplateRepository = mealTemplateRepository;
         this.mealTemplateItemRepository = mealTemplateItemRepository;
         this.foodRepository = foodRepository;
         this.mealTemplateMapper = mealTemplateMapper;
         this.mealTemplateWriteService = mealTemplateWriteService;
+        this.mealEntryWriteService = mealEntryWriteService;
     }
 
     /**
@@ -137,6 +145,36 @@ public class MealTemplateService {
             mealTemplateWriteService.delete(id);
             return null;
         }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    /**
+     * Logs all items of the meal template with the given id as meal entries for the given date and
+     * meal type, reusing the existing entry-creation and day-target snapshot logic.
+     * Emits {@link NoSuchElementException} if no template with that id exists.
+     *
+     * @param date       the date to log the entries for
+     * @param templateId the UUID of the meal template to log
+     * @param mealType   the meal category to assign to each created entry
+     * @return a Mono emitting the created meal entry DTOs, or an empty list if the template has no items
+     */
+    public Mono<List<MealEntryDTO>> logToDay(LocalDate date, UUID templateId, MealType mealType) {
+        return Mono.fromCallable(() -> {
+            if (mealTemplateRepository.findById(templateId).isEmpty()) {
+                throw new NoSuchElementException("Meal template not found: " + templateId);
+            }
+
+            final List<MealTemplateItemEntity> items = mealTemplateItemRepository.findByMealTemplateId(templateId);
+            if (items.isEmpty()) {
+                return List.<MealEntryDTO>of();
+            }
+
+            final List<CreateMealEntryRequest> requests = items.stream()
+                    .map(item -> new CreateMealEntryRequest(
+                            mealType, item.getFoodId(), item.getQuantityG(), null, null, null, null, null))
+                    .collect(Collectors.toList());
+
+            return mealEntryWriteService.createEntries(date, requests);
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEntryControllerTest.java
@@ -17,6 +17,7 @@ import com.marvin.nutrition.dto.TargetsDTO;
 import com.marvin.nutrition.dto.UpdateMealEntryRequest;
 import com.marvin.nutrition.entity.MealType;
 import com.marvin.nutrition.service.MealEntryService;
+import com.marvin.nutrition.service.MealTemplateService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
@@ -40,6 +41,9 @@ class MealEntryControllerTest {
 
     @Mock
     private MealEntryService mealEntryService;
+
+    @Mock
+    private MealTemplateService mealTemplateService;
 
     @InjectMocks
     private MealEntryController mealEntryController;
@@ -292,5 +296,49 @@ class MealEntryControllerTest {
                 .verifyComplete();
 
         verify(mealEntryService).deleteEntry(entryId);
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/days/{date}/entries/from-template/{templateId}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addEntriesFromTemplate returns 201 Created with list body")
+    void addEntriesFromTemplate_Valid_Returns201WithListBody() {
+        final UUID templateId = UUID.randomUUID();
+
+        when(mealTemplateService.logToDay(today, templateId, MealType.LUNCH))
+                .thenReturn(Mono.just(List.of(mealEntryDTO)));
+
+        final Mono<ResponseEntity<List<MealEntryDTO>>> result =
+                mealEntryController.addEntriesFromTemplate(today, templateId, MealType.LUNCH);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(1, response.getBody().size());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).logToDay(today, templateId, MealType.LUNCH);
+    }
+
+    @Test
+    @DisplayName("addEntriesFromTemplate returns 404 when template not found")
+    void addEntriesFromTemplate_UnknownTemplate_Returns404() {
+        final UUID templateId = UUID.randomUUID();
+
+        when(mealTemplateService.logToDay(today, templateId, MealType.LUNCH))
+                .thenReturn(Mono.error(new NoSuchElementException("Meal template not found: " + templateId)));
+
+        final Mono<ResponseEntity<List<MealEntryDTO>>> result =
+                mealEntryController.addEntriesFromTemplate(today, templateId, MealType.LUNCH);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(mealTemplateService).logToDay(today, templateId, MealType.LUNCH);
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
@@ -1,11 +1,15 @@
 package com.marvin.nutrition.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marvin.nutrition.dto.CreateMealEntryRequest;
 import com.marvin.nutrition.dto.CreateMealTemplateRequest;
+import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.MealTemplateDTO;
 import com.marvin.nutrition.dto.MealTemplateItemDTO;
 import com.marvin.nutrition.dto.MealTemplateItemRequest;
@@ -13,11 +17,13 @@ import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealTemplateEntity;
 import com.marvin.nutrition.entity.MealTemplateItemEntity;
+import com.marvin.nutrition.entity.MealType;
 import com.marvin.nutrition.mapper.MealTemplateMapper;
 import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealTemplateItemRepository;
 import com.marvin.nutrition.repository.MealTemplateRepository;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -50,6 +56,9 @@ class MealTemplateServiceTest {
 
     @Mock
     private MealTemplateWriteService mealTemplateWriteService;
+
+    @Mock
+    private MealEntryWriteService mealEntryWriteService;
 
     @InjectMocks
     private MealTemplateService mealTemplateService;
@@ -277,5 +286,61 @@ class MealTemplateServiceTest {
         StepVerifier.create(mealTemplateService.findAll())
                 .assertNext(list -> assertEquals(0, list.size()))
                 .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // logToDay
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("logToDay maps template items to create requests and delegates to MealEntryWriteService")
+    void logToDay_TemplateWithItems_DelegatesToMealEntryWriteService() {
+        final LocalDate date = LocalDate.of(2026, 6, 7);
+        final CreateMealEntryRequest expectedRequest = new CreateMealEntryRequest(
+                MealType.LUNCH, foodId, itemEntity.getQuantityG(), null, null, null, null, null
+        );
+        final MealEntryDTO createdEntry = new MealEntryDTO(
+                UUID.randomUUID(), date, MealType.LUNCH, foodId, null, itemEntity.getQuantityG(),
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50"), "Oatmeal"
+        );
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(mealTemplateItemRepository.findByMealTemplateId(templateId)).thenReturn(List.of(itemEntity));
+        when(mealEntryWriteService.createEntries(date, List.of(expectedRequest)))
+                .thenReturn(List.of(createdEntry));
+
+        StepVerifier.create(mealTemplateService.logToDay(date, templateId, MealType.LUNCH))
+                .assertNext(created -> assertEquals(List.of(createdEntry), created))
+                .verifyComplete();
+
+        verify(mealEntryWriteService).createEntries(date, List.of(expectedRequest));
+    }
+
+    @Test
+    @DisplayName("logToDay returns an empty list without calling MealEntryWriteService when template has no items")
+    void logToDay_TemplateWithoutItems_ReturnsEmptyList() {
+        final LocalDate date = LocalDate.of(2026, 6, 7);
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.of(templateEntity));
+        when(mealTemplateItemRepository.findByMealTemplateId(templateId)).thenReturn(List.of());
+
+        StepVerifier.create(mealTemplateService.logToDay(date, templateId, MealType.LUNCH))
+                .assertNext(created -> assertEquals(List.of(), created))
+                .verifyComplete();
+
+        verify(mealEntryWriteService, never()).createEntries(any(), any());
+    }
+
+    @Test
+    @DisplayName("logToDay emits NoSuchElementException when template not found")
+    void logToDay_TemplateNotFound_EmitsNoSuchElementException() {
+        final LocalDate date = LocalDate.of(2026, 6, 7);
+
+        when(mealTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealTemplateService.logToDay(date, templateId, MealType.LUNCH))
+                .expectError(NoSuchElementException.class)
+                .verify();
     }
 }


### PR DESCRIPTION
## Summary
- Adds `MealTemplateService.logToDay(LocalDate date, UUID templateId, MealType mealType)`, which loads a meal template's items and maps each to a `CreateMealEntryRequest`, delegating to the existing `MealEntryWriteService.createEntries` to reuse macro snapshotting and the single day-target snapshot call.
- Adds `POST /nutrition/days/{date}/entries/from-template/{templateId}?mealType=...` on `MealEntryController`, returning 201 with the created entries, or 404 if the template does not exist.

Closes #184

## Test plan
- [x] New unit tests in `MealTemplateServiceTest` for `logToDay`: happy path (verifies `createEntries` called with correctly mapped requests), empty template (returns `[]` without calling `createEntries`), unknown template (`NoSuchElementException`)
- [x] New unit tests in `MealEntryControllerTest` for `addEntriesFromTemplate`: 201 + body, 404 for unknown template
- [x] `./gradlew :nutrition:test --tests "*MealTemplateServiceTest*" --tests "*MealEntryControllerTest*"` passes
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes