### PR TITLE
feat(nutrition): add POST /nutrition/meal-templates/from-estimate endpoint

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealTemplateController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealTemplateController.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.controller;
 
 import com.marvin.nutrition.dto.CreateMealTemplateRequest;
 import com.marvin.nutrition.dto.MealTemplateDTO;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.service.MealTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -123,6 +124,35 @@ public class MealTemplateController {
     )
     public Mono<ResponseEntity<MealTemplateDTO>> createTemplate(@Valid @RequestBody CreateMealTemplateRequest req) {
         return mealTemplateService.create(req)
+                .map(created -> {
+                    final URI location = URI.create(TEMPLATES_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                });
+    }
+
+    /**
+     * Atomically creates a synthetic food entry and a meal template from a canteen AI estimate,
+     * returning 201 Created with a Location header.
+     *
+     * @param req the estimate request body
+     * @return a Mono with 201 Created, Location header, and the created meal template DTO
+     */
+    @PostMapping("/from-estimate")
+    @Operation(
+            summary = "Create a meal template from a canteen AI estimate",
+            description = "Atomically creates a synthetic food entry (source=ESTIMATE) and a meal template "
+                    + "containing that food at 100 g. The macro values are stored as-is on the food entry.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Meal template created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = MealTemplateDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed")
+            }
+    )
+    public Mono<ResponseEntity<MealTemplateDTO>> createFromEstimate(@Valid @RequestBody SaveEstimateAsTemplateRequest req) {
+        return mealTemplateService.createFromEstimate(req)
                 .map(created -> {
                     final URI location = URI.create(TEMPLATES_LOCATION_PREFIX + created.id());
                     return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/SaveEstimateAsTemplateRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/SaveEstimateAsTemplateRequest.java
@@ -1,0 +1,48 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+/**
+ * Request body for creating a synthetic food entry and meal template from a canteen AI estimate.
+ * All macro values represent the total meal (not per-100 g), and are stored as-is since
+ * the synthetic food entry uses a fixed 100 g default serving.
+ *
+ * @param name      the display name of the resulting meal template
+ * @param kcal      estimated total kilocalories
+ * @param proteinG  estimated total protein in grams
+ * @param carbsG    estimated total carbohydrates in grams
+ * @param fatG      estimated total fat in grams
+ */
+@Schema(description = "Request to save a canteen AI estimate as a reusable meal template")
+public record SaveEstimateAsTemplateRequest(
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "Display name of the resulting meal template", example = "Canteen Lunch")
+        String name,
+
+        @NotNull
+        @DecimalMin("0")
+        @Schema(description = "Estimated total kilocalories", example = "650")
+        BigDecimal kcal,
+
+        @NotNull
+        @DecimalMin("0")
+        @Schema(description = "Estimated total protein in grams", example = "35")
+        BigDecimal proteinG,
+
+        @NotNull
+        @DecimalMin("0")
+        @Schema(description = "Estimated total carbohydrates in grams", example = "70")
+        BigDecimal carbsG,
+
+        @NotNull
+        @DecimalMin("0")
+        @Schema(description = "Estimated total fat in grams", example = "20")
+        BigDecimal fatG
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateService.java
@@ -5,6 +5,7 @@ import com.marvin.nutrition.dto.CreateMealTemplateRequest;
 import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.MealTemplateDTO;
 import com.marvin.nutrition.dto.MealTemplateItemDTO;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealTemplateEntity;
@@ -114,6 +115,18 @@ public class MealTemplateService {
      */
     public Mono<MealTemplateDTO> create(CreateMealTemplateRequest req) {
         return Mono.fromCallable(() -> mealTemplateWriteService.create(req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(this::toDTO);
+    }
+
+    /**
+     * Atomically creates a synthetic food entry and a meal template from a canteen AI estimate.
+     *
+     * @param req the estimate request containing the template name and macro values
+     * @return a Mono emitting the created meal template DTO
+     */
+    public Mono<MealTemplateDTO> createFromEstimate(SaveEstimateAsTemplateRequest req) {
+        return Mono.fromCallable(() -> mealTemplateWriteService.createFromEstimate(req))
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(this::toDTO);
     }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
@@ -113,7 +113,7 @@ public class MealTemplateWriteService {
      * {@link MealTemplateEntity} with that food as its sole item at 100 g.
      *
      * <p>The food entry is created with {@link FoodSource#ESTIMATE}, all per-100-g macro fields set
-     * to the estimate values, a fixed {@code defaultServingG} of 100, and no brand.
+     * to the estimate values, a fixed {@code defaultServingG} of 100, and no brand.</p>
      *
      * @param req the estimate request containing the template name and macro values
      * @return the saved template together with its single saved item

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealTemplateWriteService.java
@@ -2,13 +2,16 @@ package com.marvin.nutrition.service;
 
 import com.marvin.nutrition.dto.CreateMealTemplateRequest;
 import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.FoodSource;
 import com.marvin.nutrition.entity.MealTemplateEntity;
 import com.marvin.nutrition.entity.MealTemplateItemEntity;
 import com.marvin.nutrition.repository.FoodRepository;
 import com.marvin.nutrition.repository.MealTemplateItemRepository;
 import com.marvin.nutrition.repository.MealTemplateRepository;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -103,6 +106,42 @@ public class MealTemplateWriteService {
         final MealTemplateEntity template = mealTemplateRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Meal template not found: " + id));
         mealTemplateRepository.delete(template);
+    }
+
+    /**
+     * Atomically creates a synthetic {@link FoodEntity} from the given estimate, then creates a
+     * {@link MealTemplateEntity} with that food as its sole item at 100 g.
+     *
+     * <p>The food entry is created with {@link FoodSource#ESTIMATE}, all per-100-g macro fields set
+     * to the estimate values, a fixed {@code defaultServingG} of 100, and no brand.
+     *
+     * @param req the estimate request containing the template name and macro values
+     * @return the saved template together with its single saved item
+     */
+    @Transactional
+    public MealTemplateWithItems createFromEstimate(SaveEstimateAsTemplateRequest req) {
+        final FoodEntity food = new FoodEntity();
+        food.setName(req.name());
+        food.setBrand(null);
+        food.setSource(FoodSource.ESTIMATE);
+        food.setKcalPer100(req.kcal());
+        food.setProteinPer100(req.proteinG());
+        food.setCarbsPer100(req.carbsG());
+        food.setFatPer100(req.fatG());
+        food.setDefaultServingG(BigDecimal.valueOf(100));
+        final FoodEntity savedFood = foodRepository.save(food);
+
+        final MealTemplateEntity template = new MealTemplateEntity();
+        template.setName(req.name());
+        final MealTemplateEntity savedTemplate = mealTemplateRepository.save(template);
+
+        final MealTemplateItemEntity item = new MealTemplateItemEntity();
+        item.setMealTemplateId(savedTemplate.getId());
+        item.setFoodId(savedFood.getId());
+        item.setQuantityG(BigDecimal.valueOf(100));
+        final MealTemplateItemEntity savedItem = mealTemplateItemRepository.save(item);
+
+        return new MealTemplateWithItems(savedTemplate, List.of(savedItem));
     }
 
     /**

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealTemplateControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealTemplateControllerTest.java
@@ -12,6 +12,7 @@ import com.marvin.nutrition.dto.CreateMealTemplateRequest;
 import com.marvin.nutrition.dto.MealTemplateDTO;
 import com.marvin.nutrition.dto.MealTemplateItemDTO;
 import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.service.MealTemplateService;
 import java.math.BigDecimal;
@@ -224,5 +225,37 @@ class MealTemplateControllerTest {
                 .verifyComplete();
 
         verify(mealTemplateService).delete(templateId);
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/meal-templates/from-estimate
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createFromEstimate returns 201 Created with Location header pointing to new template")
+    void createFromEstimate_Valid_Returns201WithLocation() {
+        final SaveEstimateAsTemplateRequest req = new SaveEstimateAsTemplateRequest(
+                "Canteen Lunch",
+                new BigDecimal("650"),
+                new BigDecimal("35"),
+                new BigDecimal("70"),
+                new BigDecimal("20")
+        );
+        when(mealTemplateService.createFromEstimate(any(SaveEstimateAsTemplateRequest.class)))
+                .thenReturn(Mono.just(templateDTO));
+
+        final Mono<ResponseEntity<MealTemplateDTO>> result = mealTemplateController.createFromEstimate(req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Breakfast Bowl", response.getBody().name());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString().contains(templateId.toString()));
+                })
+                .verifyComplete();
+
+        verify(mealTemplateService).createFromEstimate(eq(req));
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateServiceTest.java
@@ -13,6 +13,7 @@ import com.marvin.nutrition.dto.MealEntryDTO;
 import com.marvin.nutrition.dto.MealTemplateDTO;
 import com.marvin.nutrition.dto.MealTemplateItemDTO;
 import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
 import com.marvin.nutrition.entity.MealTemplateEntity;
@@ -197,6 +198,42 @@ class MealTemplateServiceTest {
                 .verifyComplete();
 
         verify(mealTemplateWriteService).create(req);
+    }
+
+    // -----------------------------------------------------------------------
+    // createFromEstimate
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createFromEstimate delegates to write service and assembles response DTO")
+    void createFromEstimate_DelegatesAndAssemblesDTO() {
+        final SaveEstimateAsTemplateRequest req = new SaveEstimateAsTemplateRequest(
+                "Canteen Lunch",
+                new BigDecimal("650"),
+                new BigDecimal("35"),
+                new BigDecimal("70"),
+                new BigDecimal("20")
+        );
+        final MealTemplateWriteService.MealTemplateWithItems writeResult =
+                new MealTemplateWriteService.MealTemplateWithItems(templateEntity, List.of(itemEntity));
+
+        when(mealTemplateWriteService.createFromEstimate(req)).thenReturn(writeResult);
+        when(foodRepository.findAllById(List.of(foodId))).thenReturn(List.of(foodEntity));
+        when(mealTemplateMapper.toItemDTO(
+                itemEntity, "Oatmeal",
+                new BigDecimal("185.00"), new BigDecimal("6.50"),
+                new BigDecimal("30.00"), new BigDecimal("3.50")
+        )).thenReturn(itemDTO);
+
+        StepVerifier.create(mealTemplateService.createFromEstimate(req))
+                .assertNext(dto -> {
+                    assertEquals(templateId, dto.id());
+                    assertEquals("Breakfast Bowl", dto.name());
+                    assertEquals(List.of(itemDTO), dto.items());
+                })
+                .verifyComplete();
+
+        verify(mealTemplateWriteService).createFromEstimate(req);
     }
 
     // -----------------------------------------------------------------------

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
@@ -11,8 +11,10 @@ import static org.mockito.Mockito.when;
 
 import com.marvin.nutrition.dto.CreateMealTemplateRequest;
 import com.marvin.nutrition.dto.MealTemplateItemRequest;
+import com.marvin.nutrition.dto.SaveEstimateAsTemplateRequest;
 import com.marvin.nutrition.dto.UpdateMealTemplateRequest;
 import com.marvin.nutrition.entity.FoodEntity;
+import com.marvin.nutrition.entity.FoodSource;
 import com.marvin.nutrition.entity.MealTemplateEntity;
 import com.marvin.nutrition.entity.MealTemplateItemEntity;
 import com.marvin.nutrition.repository.FoodRepository;
@@ -202,6 +204,71 @@ class MealTemplateWriteServiceTest {
 
         assertEquals(0, result.items().size());
         verify(mealTemplateItemRepository).deleteByMealTemplateId(templateId);
+        verify(mealTemplateItemRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // createFromEstimate
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createFromEstimate saves food, template and item with correct field values")
+    void createFromEstimate_SavesFoodTemplateAndItem() {
+        final SaveEstimateAsTemplateRequest req = new SaveEstimateAsTemplateRequest(
+                "Canteen Lunch",
+                new BigDecimal("650"),
+                new BigDecimal("35"),
+                new BigDecimal("70"),
+                new BigDecimal("20")
+        );
+        final UUID savedFoodId = UUID.randomUUID();
+        final FoodEntity savedFood = new FoodEntity();
+        savedFood.setId(savedFoodId);
+
+        when(foodRepository.save(any(FoodEntity.class))).thenReturn(savedFood);
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class))).thenReturn(templateEntity);
+        when(mealTemplateItemRepository.save(any(MealTemplateItemEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        final MealTemplateWriteService.MealTemplateWithItems result = mealTemplateWriteService.createFromEstimate(req);
+
+        assertEquals(templateEntity, result.template());
+        assertEquals(1, result.items().size());
+
+        verify(foodRepository).save(argThat(food ->
+                "Canteen Lunch".equals(food.getName())
+                        && food.getBrand() == null
+                        && FoodSource.ESTIMATE.equals(food.getSource())
+                        && new BigDecimal("650").compareTo(food.getKcalPer100()) == 0
+                        && new BigDecimal("35").compareTo(food.getProteinPer100()) == 0
+                        && new BigDecimal("70").compareTo(food.getCarbsPer100()) == 0
+                        && new BigDecimal("20").compareTo(food.getFatPer100()) == 0
+                        && BigDecimal.valueOf(100).compareTo(food.getDefaultServingG()) == 0
+        ));
+        verify(mealTemplateRepository).save(argThat(t -> "Canteen Lunch".equals(t.getName())));
+        verify(mealTemplateItemRepository).save(argThat(item ->
+                templateId.equals(item.getMealTemplateId())
+                        && savedFoodId.equals(item.getFoodId())
+                        && BigDecimal.valueOf(100).compareTo(item.getQuantityG()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("createFromEstimate does not save template or item when food save fails")
+    void createFromEstimate_FoodSaveFails_DoesNotSaveTemplateOrItem() {
+        final SaveEstimateAsTemplateRequest req = new SaveEstimateAsTemplateRequest(
+                "Canteen Lunch",
+                new BigDecimal("650"),
+                new BigDecimal("35"),
+                new BigDecimal("70"),
+                new BigDecimal("20")
+        );
+
+        when(foodRepository.save(any(FoodEntity.class))).thenThrow(new RuntimeException("DB error"));
+
+        assertThrows(RuntimeException.class, () -> mealTemplateWriteService.createFromEstimate(req));
+
+        verify(mealTemplateRepository, never()).save(any());
         verify(mealTemplateItemRepository, never()).save(any());
     }
 

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealTemplateWriteServiceTest.java
@@ -272,6 +272,28 @@ class MealTemplateWriteServiceTest {
         verify(mealTemplateItemRepository, never()).save(any());
     }
 
+    @Test
+    @DisplayName("createFromEstimate does not save item when template save fails")
+    void createFromEstimate_TemplateSaveFails_DoesNotSaveItem() {
+        final SaveEstimateAsTemplateRequest req = new SaveEstimateAsTemplateRequest(
+                "Canteen Lunch",
+                new BigDecimal("650"),
+                new BigDecimal("35"),
+                new BigDecimal("70"),
+                new BigDecimal("20")
+        );
+        final FoodEntity savedFood = new FoodEntity();
+        savedFood.setId(UUID.randomUUID());
+
+        when(foodRepository.save(any(FoodEntity.class))).thenReturn(savedFood);
+        when(mealTemplateRepository.save(any(MealTemplateEntity.class)))
+                .thenThrow(new RuntimeException("DB error"));
+
+        assertThrows(RuntimeException.class, () -> mealTemplateWriteService.createFromEstimate(req));
+
+        verify(mealTemplateItemRepository, never()).save(any());
+    }
+
     // -----------------------------------------------------------------------
     // delete
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `SaveEstimateAsTemplateRequest` DTO with `@NotBlank`/`@Size` on `name` and `@NotNull`/`@DecimalMin("0")` on all four macro fields
- Adds `MealTemplateWriteService.createFromEstimate()` — a single `@Transactional` method that creates a `FoodEntity` (`source=ESTIMATE`, per-100-g fields set to the estimate values, `defaultServingG=100`, `brand=null`), a `MealTemplateEntity`, and a `MealTemplateItemEntity` linking both at `quantityG=100`
- Adds `MealTemplateService.createFromEstimate()` following the existing reactive pattern (`Mono.fromCallable` + `boundedElastic` + `map(toDTO)`)
- Adds `POST /nutrition/meal-templates/from-estimate` endpoint in `MealTemplateController`, returning 201 Created with a Location header

## Test plan
- [x] Unit test `createFromEstimate_Valid_Returns201WithLocation` added to `MealTemplateControllerTest` — mocks `MealTemplateService.createFromEstimate()`, asserts 201 status, body, and Location header
- [x] `./gradlew :nutrition:test --tests "*.MealTemplateControllerTest" --tests "*.MealTemplateServiceTest" --tests "*.MealTemplateWriteServiceTest"` — all green
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — zero warnings

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)