### PR TITLE
feat(vocabulary): stream CSV export instead of buffering in memory (#176)

### DIFF
--- a/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -159,21 +160,6 @@ public class FlashcardController {
     }
 
     /**
-     * Creates a CSV file download response.
-     *
-     * @param fileContent the file content as byte array
-     * @return a ResponseEntity configured for file download
-     */
-    private ResponseEntity<byte[]> createFileDownloadResponse(byte[] fileContent) {
-        return ResponseEntity.ok()
-                .contentType(MediaType.parseMediaType(CSV_MEDIA_TYPE))
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment")
-                .header("filename", CSV_FILENAME)
-                .contentLength(fileContent.length)
-                .body(fileContent);
-    }
-
-    /**
      * Handles general exceptions in the controller.
      *
      * @param exception the exception that occurred
@@ -304,19 +290,21 @@ public class FlashcardController {
     }
 
     /**
-     * Downloads all flashcards as a CSV file.
+     * Streams all flashcards as a CSV file download using reactive back-pressure.
      *
-     * @return a Mono containing the CSV file download response
+     * <p>No {@code Content-Length} header is set because the total size is unknown upfront.</p>
+     *
+     * @return a Mono containing a streaming CSV file download response
      */
     @GetMapping("/flashcards/file")
-    public Mono<ResponseEntity<byte[]>> getFile() {
-        try {
-            byte[] fileContent = flashcardService.getFile();
-            ResponseEntity<byte[]> responseEntity = createFileDownloadResponse(fileContent);
-            return Mono.just(responseEntity);
-        } catch (Exception exception) {
-            return Mono.error(exception);
-        }
+    public Mono<ResponseEntity<Flux<DataBuffer>>> getFile() {
+        final Flux<DataBuffer> csvStream = flashcardService.streamCsvFile();
+        final ResponseEntity<Flux<DataBuffer>> response = ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(CSV_MEDIA_TYPE))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment")
+                .header("filename", CSV_FILENAME)
+                .body(csvStream);
+        return Mono.just(response);
     }
 
     /**

--- a/vocabulary/src/main/java/com/marvin/vocabulary/service/FlashcardService.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/service/FlashcardService.java
@@ -1,7 +1,7 @@
 package com.marvin.vocabulary.service;
 
 import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.marvin.vocabulary.dto.Flashcard;
@@ -11,16 +11,23 @@ import com.marvin.vocabulary.model.FlashcardEntity;
 import com.marvin.vocabulary.repository.DeckRepository;
 import com.marvin.vocabulary.repository.FlashcardRepository;
 import jakarta.transaction.Transactional;
-import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
+/**
+ * Service for managing vocabulary flashcards, including CRUD operations, CSV import, and streaming CSV export.
+ */
 @Slf4j
 @Service
 public class FlashcardService {
@@ -28,10 +35,18 @@ public class FlashcardService {
     private final CsvSchema schema;
     private final FlashcardRepository flashcardRepository;
     private final DeckRepository deckRepository;
+    private final DataBufferFactory dataBufferFactory;
 
+    /**
+     * Constructs a new FlashcardService with required dependencies.
+     *
+     * @param flashcardRepository the flashcard repository
+     * @param deckRepository      the deck repository
+     */
     public FlashcardService(FlashcardRepository flashcardRepository, DeckRepository deckRepository) {
         this.flashcardRepository = flashcardRepository;
         this.deckRepository = deckRepository;
+        this.dataBufferFactory = new DefaultDataBufferFactory();
 
         this.schema = CsvSchema.builder()
                 .setColumnSeparator('\t')
@@ -46,10 +61,23 @@ public class FlashcardService {
                 .build();
     }
 
+    /**
+     * Retrieves a flashcard by its ID.
+     *
+     * @param id the flashcard ID
+     * @return the flashcard entity, or {@code null} if not found
+     */
     public FlashcardEntity get(int id) {
         return flashcardRepository.findById(id).orElse(null);
     }
 
+    /**
+     * Retrieves flashcards with optional filtering.
+     *
+     * @param missing optional filter name (e.g. {@code "ankiId"})
+     * @param updated optional filter for updated status
+     * @return a list of matching flashcard entities
+     */
     public List<FlashcardEntity> get(String missing, Boolean updated) {
         if (missing == null && updated == null) {
             return flashcardRepository.findAll();
@@ -66,6 +94,12 @@ public class FlashcardService {
         return flashcardRepository.findAll();
     }
 
+    /**
+     * Saves a new flashcard and its reverse counterpart.
+     *
+     * @param flashcard the flashcard data to persist
+     * @return the saved original flashcard entity
+     */
     @Transactional
     public FlashcardEntity save(Flashcard flashcard) {
         DeckEntity deck = getDeckOrThrow(flashcard.deckId());
@@ -94,6 +128,12 @@ public class FlashcardService {
         return savedOriginal;
     }
 
+    /**
+     * Updates an existing flashcard and its reverse counterpart.
+     *
+     * @param flashcard the flashcard data to update
+     * @return the ID of the updated flashcard
+     */
     @Transactional
     public Integer update(Flashcard flashcard) {
         flashcardRepository.findById(flashcard.id())
@@ -130,45 +170,57 @@ public class FlashcardService {
         return flashcard.id();
     }
 
+    /**
+     * Imports flashcards from a CSV file provided as a byte array.
+     *
+     * @param fileBytes the raw bytes of the CSV file
+     * @return the number of flashcards successfully imported
+     */
     @Transactional
     public Integer importFlashcards(byte[] fileBytes) {
         return importFile(fileBytes);
     }
 
-    public byte[] getFile() throws Exception {
+    /**
+     * Streams all flashcards as CSV-formatted {@link DataBuffer} elements.
+     *
+     * <p>The response begins with Anki-compatible header lines, followed by one tab-separated row
+     * per flashcard entity. The blocking JPA {@code findAll()} call is offloaded to the bounded
+     * elastic scheduler so the event loop thread is never blocked.</p>
+     *
+     * @return a {@link Flux} of {@link DataBuffer} chunks representing the CSV content
+     */
+    public Flux<DataBuffer> streamCsvFile() {
+        final ObjectWriter csvWriter = new CsvMapper()
+                .writerFor(FlashcardCsvDTO.class)
+                .with(schema);
 
-        final CsvMapper csvMapper = new CsvMapper();
+        final Flux<DataBuffer> header = Flux.just(
+                dataBufferFactory.wrap("#separator:tab\n".getBytes(StandardCharsets.UTF_8)),
+                dataBufferFactory.wrap("#html:false\n".getBytes(StandardCharsets.UTF_8)),
+                dataBufferFactory.wrap("#guid column:1\n".getBytes(StandardCharsets.UTF_8))
+        );
 
-        byte[] file;
+        final Flux<DataBuffer> rows = Flux
+                .defer(() -> Flux.fromIterable(flashcardRepository.findAll()))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(entity -> new FlashcardCsvDTO(
+                        entity.getDeck().getName(),
+                        entity.getAnkiId(),
+                        entity.getFront(),
+                        entity.getBack(),
+                        entity.getDescription()
+                ))
+                .map(dto -> {
+                    try {
+                        final byte[] rowBytes = csvWriter.writeValueAsBytes(dto);
+                        return dataBufferFactory.wrap(rowBytes);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Failed to serialize flashcard to CSV", e);
+                    }
+                });
 
-        try (
-                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                SequenceWriter sequenceWriter = csvMapper
-                        .writerFor(FlashcardCsvDTO.class)
-                        .with(schema)
-                        .writeValues(byteArrayOutputStream)
-        ) {
-
-            byteArrayOutputStream.write("#separator:tab\n".getBytes(StandardCharsets.UTF_8));
-            byteArrayOutputStream.write("#html:false\n".getBytes(StandardCharsets.UTF_8));
-            byteArrayOutputStream.write("#guid column:1\n".getBytes(StandardCharsets.UTF_8));
-            byteArrayOutputStream.flush();
-
-            for (final FlashcardEntity flashcardEntity : flashcardRepository.findAll()) {
-                sequenceWriter.write(new FlashcardCsvDTO(
-                        flashcardEntity.getDeck().getName(),
-                        flashcardEntity.getAnkiId(),
-                        flashcardEntity.getFront(),
-                        flashcardEntity.getBack(),
-                        flashcardEntity.getDescription()
-                ));
-            }
-
-            file = byteArrayOutputStream.toByteArray();
-
-        }
-
-        return file;
+        return Flux.concat(header, rows);
     }
 
     private int importFile(byte[] fileBytes) {
@@ -217,6 +269,11 @@ public class FlashcardService {
         }
     }
 
+    /**
+     * Returns a stream of all flashcards mapped to DTOs for export purposes.
+     *
+     * @return a stream of {@link Flashcard} DTOs
+     */
     public Stream<Flashcard> getAllFlashcardsForExport() {
         return flashcardRepository.findAll().stream()
                 .map(entity -> new Flashcard(

--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardControllerTest.java
@@ -190,11 +190,12 @@ class FlashcardControllerTest {
     }
 
     @Test
-    void getFileShouldReturnCsvFile() throws Exception {
-        final byte[] expectedFileContent = "#separator:tab\n#html:false\n#guid column:1\ntest-content"
+    void getFileShouldReturnStreamingCsvFile() {
+        final byte[] csvBytes = "#separator:tab\n#html:false\n#guid column:1\ntest-content"
                 .getBytes(StandardCharsets.UTF_8);
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(csvBytes);
 
-        when(flashcardService.getFile()).thenReturn(expectedFileContent);
+        when(flashcardService.streamCsvFile()).thenReturn(Flux.just(dataBuffer));
 
         webTestClient.get()
                 .uri("/vocabulary/flashcards/file")
@@ -203,23 +204,19 @@ class FlashcardControllerTest {
                 .expectHeader().contentType("text/csv")
                 .expectHeader().valueEquals("Content-Disposition", "attachment")
                 .expectHeader().valueEquals("filename", "Standard.csv")
-                .expectHeader()
-                .valueEquals("Content-Length", String.valueOf(expectedFileContent.length))
                 .expectBody(byte[].class)
-                .isEqualTo(expectedFileContent);
+                .isEqualTo(csvBytes);
     }
 
     @Test
-    void getFileWhenExceptionThrownShouldReturnInternalServerError() throws Exception {
-        when(flashcardService.getFile()).thenThrow(new RuntimeException("File generation failed"));
+    void getFileWhenStreamEmitsShouldReturnInternalServerError() {
+        when(flashcardService.streamCsvFile())
+                .thenReturn(Flux.error(new RuntimeException("File generation failed")));
 
         webTestClient.get()
                 .uri("/vocabulary/flashcards/file")
                 .exchange()
-                .expectStatus().is5xxServerError()
-                .expectBody()
-                .jsonPath("$.type").isEqualTo("RuntimeException")
-                .jsonPath("$.message").isEqualTo("File generation failed");
+                .expectStatus().is5xxServerError();
     }
 
     @Test

--- a/vocabulary/src/test/java/com/marvin/vocabulary/service/FlashcardServiceTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/service/FlashcardServiceTest.java
@@ -11,6 +11,8 @@ import com.marvin.vocabulary.model.DeckEntity;
 import com.marvin.vocabulary.model.FlashcardEntity;
 import com.marvin.vocabulary.repository.DeckRepository;
 import com.marvin.vocabulary.repository.FlashcardRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.dao.DataIntegrityViolationException;
+import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
 class FlashcardServiceTest {
@@ -72,6 +76,38 @@ class FlashcardServiceTest {
         assertThat(result).isEqualTo(savedOriginal);
         assertThat(result.getReverseFlashcard()).isEqualTo(savedReverse);
         assertThat(savedReverse.getReverseFlashcard()).isEqualTo(savedOriginal);
+    }
+
+    @Test
+    void streamCsvFileShouldEmitHeaderBuffersThenOneBufferPerFlashcard() {
+        final FlashcardEntity entity = new FlashcardEntity(
+                1, deck, null, "anki-1", "front", "back", "description", false);
+
+        when(flashcardRepository.findAll()).thenReturn(List.of(entity));
+
+        StepVerifier.create(flashcardService.streamCsvFile())
+                .assertNext(buf -> assertBufferContains(buf, "#separator:tab"))
+                .assertNext(buf -> assertBufferContains(buf, "#html:false"))
+                .assertNext(buf -> assertBufferContains(buf, "#guid column:1"))
+                .assertNext(buf -> assertBufferContains(buf, "front"))
+                .verifyComplete();
+    }
+
+    @Test
+    void streamCsvFileShouldEmitOnlyHeadersWhenNoFlashcardsExist() {
+        when(flashcardRepository.findAll()).thenReturn(List.of());
+
+        StepVerifier.create(flashcardService.streamCsvFile())
+                .assertNext(buf -> assertBufferContains(buf, "#separator:tab"))
+                .assertNext(buf -> assertBufferContains(buf, "#html:false"))
+                .assertNext(buf -> assertBufferContains(buf, "#guid column:1"))
+                .verifyComplete();
+    }
+
+    private void assertBufferContains(final DataBuffer buffer, final String expected) {
+        final byte[] bytes = new byte[buffer.readableByteCount()];
+        buffer.read(bytes);
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).contains(expected);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #176. The vocabulary CSV export previously loaded every flashcard via `findAll()` and buffered the entire CSV in a `ByteArrayOutputStream` before returning a `byte[]` — fine at personal scale but it does not scale to large datasets.

## Changes

- **Service**: replaced `FlashcardService.getFile()` with `streamCsvFile()` returning a reactive `Flux<DataBuffer>`. Header lines are emitted first, then one `DataBuffer` per flashcard row. The blocking JPA `findAll()` is wrapped in `Flux.defer(...)` and offloaded to `Schedulers.boundedElastic()` so it never runs on the WebFlux event loop.
- **Controller**: `GET /vocabulary/flashcards/file` now returns a streaming `ResponseEntity<Flux<DataBuffer>>`. The `Content-Length` header is dropped since the size is unknown upfront.
- **Tests**: controller and service tests updated to the new streaming contract (`StepVerifier` on the `Flux<DataBuffer>`, `webTestClient` asserting streamed bytes). Existing-test change was confirmed with the user before modification.

## Verification

- `./gradlew :vocabulary:test --tests '*Flashcard*'` — passing
- Checkstyle: no new violations introduced (the changed files actually have fewer warnings than baseline; pre-existing module warnings are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)