### PR TITLE
refactor(plants): remove Hibernate Envers auditing (#190)

### DIFF
--- a/plants/src/main/java/com/marvin/plants/entity/Plant.java
+++ b/plants/src/main/java/com/marvin/plants/entity/Plant.java
@@ -14,13 +14,10 @@ import java.time.LocalDate;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.envers.Audited;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "plant", schema = "plants")
-@Audited
 public class Plant {
 
     @Id

--- a/plants/src/main/resources/db/migration/plants/V1_8__drop_plant_aud.sql
+++ b/plants/src/main/resources/db/migration/plants/V1_8__drop_plant_aud.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS plants.plant_aud;

--- a/plants/src/main/resources/db/migration/plants/V1_8__drop_plant_aud.sql
+++ b/plants/src/main/resources/db/migration/plants/V1_8__drop_plant_aud.sql
@@ -1,1 +1,3 @@
+-- Issue #190: remove Hibernate Envers auditing from the plants module.
+-- The plant_aud table is no longer written to; safe to drop.
 DROP TABLE IF EXISTS plants.plant_aud;


### PR DESCRIPTION
## Summary
- Removed `@Audited` annotation and its unused `org.hibernate.envers.Audited` import from `Plant.java`
- Added Flyway migration `V1_8__drop_plant_aud.sql` to drop the `plants.plant_aud` audit table
- The shared `public.revinfo` and `public.revinfo_seq` are untouched (still used by it-news and vocabulary modules)

## Test plan
- [ ] `./gradlew :plants:build` passes (compile + tests + checkstyle)
- [ ] No Envers-related imports remain in `Plant.java`
- [ ] Existing migration files (V1_5, V1_7) are unmodified
- [ ] No other modules are affected

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)