### PR TITLE
feat(vocabulary): add bean validation on flashcard/deck write endpoints

### DIFF
--- a/vocabulary/build.gradle
+++ b/vocabulary/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'org.hibernate.validator:hibernate-validator'
+    implementation 'org.glassfish.expressly:expressly:5.0.0'
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.38'
     implementation("org.openapitools:jackson-databind-nullable:0.2.7")

--- a/vocabulary/src/main/java/com/marvin/vocabulary/controller/DeckController.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/controller/DeckController.java
@@ -3,9 +3,11 @@ package com.marvin.vocabulary.controller;
 import com.marvin.vocabulary.dto.Deck;
 import com.marvin.vocabulary.model.DeckEntity;
 import com.marvin.vocabulary.service.DeckService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,20 +18,39 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/** REST controller for managing vocabulary decks. */
+@Validated
 @RestController
 @RequestMapping("/vocabulary")
 public class DeckController {
 
     private final DeckService deckService;
 
+    /**
+     * Constructs a new DeckController with the required service.
+     *
+     * @param deckService the deck service
+     */
     public DeckController(DeckService deckService) {
         this.deckService = deckService;
     }
 
+    /**
+     * Converts a DeckEntity to a Deck DTO.
+     *
+     * @param entity the entity to convert
+     * @return the corresponding Deck DTO
+     */
     private static Deck toDto(DeckEntity entity) {
         return new Deck(entity.getId(), entity.getName());
     }
 
+    /**
+     * Retrieves a specific deck by ID.
+     *
+     * @param id the deck ID
+     * @return a Mono containing the deck or 404 if not found
+     */
     @GetMapping("/decks/{id}")
     public Mono<ResponseEntity<Deck>> getDeck(@PathVariable int id) {
         DeckEntity entity = deckService.get(id);
@@ -39,25 +60,40 @@ public class DeckController {
         return Mono.just(ResponseEntity.ok(toDto(entity)));
     }
 
+    /**
+     * Retrieves all decks.
+     *
+     * @return a Flux of all decks
+     */
     @GetMapping("/decks")
     public Flux<Deck> getDecks() {
         List<DeckEntity> decks = deckService.getAll();
         return Flux.fromIterable(decks).map(DeckController::toDto);
     }
 
+    /**
+     * Creates a new deck.
+     *
+     * @param deck the deck to create
+     * @return a Mono with the created deck location response
+     */
     @PostMapping("/decks")
-    public Mono<ResponseEntity<Void>> createDeck(@RequestBody Mono<Deck> deckMono) {
-        return deckMono
-            .map(deckService::create)
-            .map(saved -> ResponseEntity.created(
-                URI.create("/decks/" + saved.getId())
-            ).build());
+    public Mono<ResponseEntity<Void>> createDeck(@RequestBody @Valid Deck deck) {
+        final DeckEntity saved = deckService.create(deck);
+        return Mono.just(ResponseEntity.created(
+            URI.create("/decks/" + saved.getId())
+        ).build());
     }
 
+    /**
+     * Updates an existing deck.
+     *
+     * @param deck the deck to update
+     * @return a Mono with the updated deck
+     */
     @PutMapping("/decks")
-    public Mono<ResponseEntity<Deck>> updateDeck(@RequestBody Mono<Deck> deckMono) {
-        return deckMono
-            .map(deckService::update)
-            .map(deckEntity -> ResponseEntity.ok(toDto(deckEntity)));
+    public Mono<ResponseEntity<Deck>> updateDeck(@RequestBody @Valid Deck deck) {
+        final DeckEntity deckEntity = deckService.update(deck);
+        return Mono.just(ResponseEntity.ok(toDto(deckEntity)));
     }
 }

--- a/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/controller/FlashcardController.java
@@ -16,6 +16,7 @@ import com.marvin.vocabulary.exceptions.RateLimitExceededException;
 import com.marvin.vocabulary.exceptions.WordNotFoundException;
 import com.marvin.vocabulary.model.FlashcardEntity;
 import com.marvin.vocabulary.service.FlashcardService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -44,6 +47,7 @@ import reactor.core.scheduler.Schedulers;
  * services via DeepL API.
  */
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/vocabulary")
 public class FlashcardController {
@@ -149,6 +153,24 @@ public class FlashcardController {
     @ExceptionHandler
     public ResponseEntity<Map<String, String>> handleException(Exception exception) {
         return createErrorResponse(exception, exception.getMessage());
+    }
+
+    /**
+     * Handles request body validation failures.
+     *
+     * @param exception the validation exception
+     * @return a 400 Bad Request error response
+     */
+    @ExceptionHandler
+    public ResponseEntity<Map<String, String>> handleWebExchangeBindException(
+            WebExchangeBindException exception) {
+        log.warn("Validation failed: {}", exception.getMessage());
+        return ResponseEntity.badRequest().body(
+                Map.of(
+                        "type", "VALIDATION_FAILED",
+                        "message", exception.getMessage()
+                )
+        );
     }
 
     /**
@@ -291,13 +313,12 @@ public class FlashcardController {
     /**
      * Creates a new flashcard.
      *
-     * @param flashcardMono a Mono containing the flashcard to create
+     * @param flashcard the flashcard to create
      * @return a Mono with the created flashcard location response
      */
     @PostMapping("/flashcards")
-    public Mono<ResponseEntity<Void>> addFlashcard(@RequestBody Mono<Flashcard> flashcardMono) {
-        return flashcardMono
-                .flatMap(entity -> executeBlocking(() -> flashcardService.save(entity)))
+    public Mono<ResponseEntity<Void>> addFlashcard(@RequestBody @Valid Flashcard flashcard) {
+        return executeBlocking(() -> flashcardService.save(flashcard))
                 .map(savedEntity -> ResponseEntity.created(
                         URI.create("/flashcards/" + savedEntity.getId())
                 ).build());
@@ -306,13 +327,12 @@ public class FlashcardController {
     /**
      * Updates an existing flashcard.
      *
-     * @param flashcardMono a Mono containing the flashcard to update
+     * @param flashcard the flashcard to update
      * @return a Mono with no content response
      */
     @PutMapping("/flashcards")
-    public Mono<ResponseEntity<Void>> updateFlashcard(@RequestBody Mono<Flashcard> flashcardMono) {
-        return flashcardMono
-                .flatMap(entity -> executeBlocking(() -> flashcardService.update(entity)))
+    public Mono<ResponseEntity<Void>> updateFlashcard(@RequestBody @Valid Flashcard flashcard) {
+        return executeBlocking(() -> flashcardService.update(flashcard))
                 .map(updateResult -> ResponseEntity.noContent().build());
     }
 

--- a/vocabulary/src/main/java/com/marvin/vocabulary/dto/Deck.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/dto/Deck.java
@@ -1,7 +1,15 @@
 package com.marvin.vocabulary.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO representing a vocabulary deck.
+ *
+ * @param id the deck ID
+ * @param name the deck name
+ */
 public record Deck(
         Integer id,
-        String name
+        @NotBlank String name
 ) {
 }

--- a/vocabulary/src/main/java/com/marvin/vocabulary/dto/Flashcard.java
+++ b/vocabulary/src/main/java/com/marvin/vocabulary/dto/Flashcard.java
@@ -1,14 +1,28 @@
 package com.marvin.vocabulary.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO representing a vocabulary flashcard.
+ *
+ * @param id the flashcard ID
+ * @param deckId the ID of the deck this flashcard belongs to
+ * @param deck the name of the deck this flashcard belongs to
+ * @param ankiId the corresponding Anki note ID
+ * @param front the front side text
+ * @param back the back side text
+ * @param description an optional description
+ * @param updated whether the flashcard was updated
+ */
 public record Flashcard(
         Integer id,
-        Integer deckId,
+        @NotNull Integer deckId,
         String deck,
         String ankiId,
-        String front,
-        String back,
+        @NotBlank String front,
+        @NotBlank String back,
         String description,
         boolean updated
 ) {
-
 }

--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/DeckValidationTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/DeckValidationTest.java
@@ -1,0 +1,89 @@
+package com.marvin.vocabulary.controller;
+
+import com.marvin.vocabulary.dto.Deck;
+import com.marvin.vocabulary.service.DeckService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ExtendWith(MockitoExtension.class)
+class DeckValidationTest {
+
+    @Mock
+    private DeckService deckService;
+
+    @InjectMocks
+    private DeckController deckController;
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp() {
+        webTestClient = WebTestClient.bindToController(deckController).build();
+    }
+
+    @Test
+    void createDeckWhenNameIsBlankShouldReturnBadRequest() {
+        final Deck invalidDeck = new Deck(null, "");
+
+        webTestClient.post()
+                .uri("/vocabulary/decks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidDeck)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void createDeckWhenNameIsNullShouldReturnBadRequest() {
+        final Deck invalidDeck = new Deck(null, null);
+
+        webTestClient.post()
+                .uri("/vocabulary/decks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidDeck)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void createDeckWhenNameIsWhitespaceShouldReturnBadRequest() {
+        final Deck invalidDeck = new Deck(null, "   ");
+
+        webTestClient.post()
+                .uri("/vocabulary/decks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidDeck)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void updateDeckWhenNameIsBlankShouldReturnBadRequest() {
+        final Deck invalidDeck = new Deck(1, "");
+
+        webTestClient.put()
+                .uri("/vocabulary/decks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidDeck)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void updateDeckWhenNameIsNullShouldReturnBadRequest() {
+        final Deck invalidDeck = new Deck(1, null);
+
+        webTestClient.put()
+                .uri("/vocabulary/decks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidDeck)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}

--- a/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardValidationTest.java
+++ b/vocabulary/src/test/java/com/marvin/vocabulary/controller/FlashcardValidationTest.java
@@ -1,0 +1,205 @@
+package com.marvin.vocabulary.controller;
+
+import com.generated.deepl.api.TranslateTextApi;
+import com.marvin.vocabulary.dictionaryapi.DictionaryClient;
+import com.marvin.vocabulary.dto.Flashcard;
+import com.marvin.vocabulary.service.FlashcardService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ExtendWith(MockitoExtension.class)
+class FlashcardValidationTest {
+
+    @Mock
+    private DictionaryClient dictionaryClient;
+
+    @Mock
+    private FlashcardService flashcardService;
+
+    @Mock
+    private TranslateTextApi translateTextApi;
+
+    @InjectMocks
+    private FlashcardController flashcardController;
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp() {
+        webTestClient = WebTestClient.bindToController(flashcardController).build();
+    }
+
+    @Test
+    void addFlashcardWhenDeckIdIsNullShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                null,
+                null,
+                "test-deck",
+                "anki-123",
+                "front text",
+                "back text",
+                "description",
+                false
+        );
+
+        webTestClient.post()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void addFlashcardWhenFrontIsBlankShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                null,
+                10,
+                "test-deck",
+                "anki-123",
+                "",
+                "back text",
+                "description",
+                false
+        );
+
+        webTestClient.post()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void addFlashcardWhenBackIsBlankShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                null,
+                10,
+                "test-deck",
+                "anki-123",
+                "front text",
+                "",
+                "description",
+                false
+        );
+
+        webTestClient.post()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void addFlashcardWhenFrontIsNullShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                null,
+                10,
+                "test-deck",
+                "anki-123",
+                null,
+                "back text",
+                "description",
+                false
+        );
+
+        webTestClient.post()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void addFlashcardWhenBackIsNullShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                null,
+                10,
+                "test-deck",
+                "anki-123",
+                "front text",
+                null,
+                "description",
+                false
+        );
+
+        webTestClient.post()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void updateFlashcardWhenDeckIdIsNullShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                1,
+                null,
+                "test-deck",
+                "anki-123",
+                "front text",
+                "back text",
+                "description",
+                false
+        );
+
+        webTestClient.put()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void updateFlashcardWhenFrontIsBlankShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                1,
+                10,
+                "test-deck",
+                "anki-123",
+                "   ",
+                "back text",
+                "description",
+                false
+        );
+
+        webTestClient.put()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void updateFlashcardWhenBackIsBlankShouldReturnBadRequest() {
+        final Flashcard invalidFlashcard = new Flashcard(
+                1,
+                10,
+                "test-deck",
+                "anki-123",
+                "front text",
+                "   ",
+                "description",
+                false
+        );
+
+        webTestClient.put()
+                .uri("/vocabulary/flashcards")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidFlashcard)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `jakarta.validation` constraints (`@NotBlank`/`@NotNull`) to `Deck` and `Flashcard` DTOs and validate them via `@Valid` in `DeckController`/`FlashcardController`, so invalid write requests (null `deckId`, blank `front`/`back`/`name`) now fail fast with `400 Bad Request` instead of deep in the service layer.
- Add an EL implementation (`org.glassfish.expressly:expressly`) to the `vocabulary` module so hibernate-validator can actually evaluate the constraints (it was silently failing to initialize without one).
- Map `WebExchangeBindException` to `400` in `FlashcardController` instead of letting it fall through to the generic exception handler, which was returning `500`.

## Test plan
- [x] New `DeckValidationTest` / `FlashcardValidationTest` cover blank/null `name`, `deckId`, `front`, `back` on create and update endpoints
- [x] `./gradlew :vocabulary:test` passes
- [x] Verified checkstyle warning count for touched files matches pre-existing baseline (no new warnings introduced; pre-existing checkstyle debt elsewhere in the module is unrelated to this change)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)