### PR TITLE
feat(camt): add endpoint to drop uploaded CAMT files into watched import directory

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,4 +17,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/api/src/main/java/com/marvin/api/controller/CamtController.java
+++ b/api/src/main/java/com/marvin/api/controller/CamtController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @RestController
 @Tag(name = "CAMT Processing", description = "API for processing CAMT banking files")
@@ -158,12 +159,12 @@ public class CamtController {
             }
 
             return DataBufferUtils.join(file.content())
-                    .doOnNext(dataBuffer -> {
+                    .flatMap(dataBuffer -> Mono.<Void>fromRunnable(() -> {
                         final byte[] bytes = new byte[dataBuffer.readableByteCount()];
                         dataBuffer.read(bytes);
                         DataBufferUtils.release(dataBuffer);
                         camtImportStorageService.store(filename, bytes);
-                    })
+                    }).subscribeOn(Schedulers.boundedElastic()))
                     .then();
         });
     }

--- a/api/src/main/java/com/marvin/api/controller/CamtController.java
+++ b/api/src/main/java/com/marvin/api/controller/CamtController.java
@@ -1,6 +1,7 @@
 package com.marvin.api.controller;
 
 import com.marvin.costs.importer.DailyCostImportService;
+import com.marvin.costs.service.CamtImportStorageService;
 import com.marvin.camt.model.book_entry.BookingEntryDTO;
 import com.marvin.camt.model.book_entry.BookingsDTO;
 import com.marvin.camt.model.book_entry.CreditDebitCodeDTO;
@@ -22,10 +23,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -36,11 +39,14 @@ public class CamtController {
 
     private final CamtFileParser camtFileParser;
     private final DocumentUnmarshaller documentUnmarshaller;
+    private final CamtImportStorageService camtImportStorageService;
 
     public CamtController(CamtFileParser camtFileParser,
-            DocumentUnmarshaller documentUnmarshaller) {
+            DocumentUnmarshaller documentUnmarshaller,
+            CamtImportStorageService camtImportStorageService) {
         this.camtFileParser = camtFileParser;
         this.documentUnmarshaller = documentUnmarshaller;
+        this.camtImportStorageService = camtImportStorageService;
     }
 
     private static String replaceSpaces(String value) {
@@ -116,6 +122,49 @@ public class CamtController {
                     )
                     .collectList()
                     .map(this::getBookingsDTO);
+        });
+    }
+
+    @Operation(
+        summary = "Import a CAMT booking file",
+        description = "Uploads a zip file containing CAMT.052.001.08 XML files and stores it in the "
+                + "directory watched for asynchronous import. The file is not parsed or previewed here."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "202",
+            description = "File accepted and queued for asynchronous import"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid file format",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+        )
+    })
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @PostMapping(
+            path = "/camt-entries/import",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public Mono<Void> importBookings(
+            @Parameter(description = "Zip file containing CAMT XML files", required = true)
+            @RequestPart("file") Mono<FilePart> fileMono) {
+
+        return fileMono.flatMap(file -> {
+
+            final String filename = Objects.requireNonNull(file.filename());
+            if (!filename.toLowerCase().endsWith(".zip")) {
+                return Mono.error(new IllegalArgumentException("Only zip files are allowed"));
+            }
+
+            return DataBufferUtils.join(file.content())
+                    .doOnNext(dataBuffer -> {
+                        final byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                        dataBuffer.read(bytes);
+                        DataBufferUtils.release(dataBuffer);
+                        camtImportStorageService.store(filename, bytes);
+                    })
+                    .then();
         });
     }
 

--- a/api/src/test/java/com/marvin/api/ApiTestApplication.java
+++ b/api/src/test/java/com/marvin/api/ApiTestApplication.java
@@ -1,0 +1,10 @@
+package com.marvin.api;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application used as context anchor for slice tests.
+ */
+@SpringBootApplication
+class ApiTestApplication {
+}

--- a/api/src/test/java/com/marvin/api/controller/CamtImportControllerTest.java
+++ b/api/src/test/java/com/marvin/api/controller/CamtImportControllerTest.java
@@ -1,0 +1,76 @@
+package com.marvin.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.marvin.camt.parser.CamtFileParser;
+import com.marvin.camt.parser.DocumentUnmarshaller;
+import com.marvin.costs.service.CamtImportStorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+
+@WebFluxTest(
+        controllers = CamtController.class,
+        excludeAutoConfiguration = ReactiveSecurityAutoConfiguration.class
+)
+@DisplayName("CamtController /camt-entries/import Tests")
+class CamtImportControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private CamtFileParser camtFileParser;
+
+    @MockitoBean
+    private DocumentUnmarshaller documentUnmarshaller;
+
+    @MockitoBean
+    private CamtImportStorageService camtImportStorageService;
+
+    @Test
+    @DisplayName("POST /camt-entries/import with a zip file returns 202 and stores the file")
+    void importBookings_ShouldReturn202AndStoreFile_WhenZipUploaded() {
+        final MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("file", "fake-zip-content".getBytes())
+                .filename("statement.zip")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM);
+
+        webTestClient.post()
+                .uri("/camt-entries/import")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
+                .exchange()
+                .expectStatus().isAccepted();
+
+        verify(camtImportStorageService).store(eq("statement.zip"), any(byte[].class));
+    }
+
+    @Test
+    @DisplayName("POST /camt-entries/import with a non-zip filename is rejected without storing")
+    void importBookings_ShouldReject_WhenFileIsNotZip() {
+        final MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("file", "not-a-zip".getBytes())
+                .filename("statement.txt")
+                .contentType(MediaType.TEXT_PLAIN);
+
+        webTestClient.post()
+                .uri("/camt-entries/import")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
+                .exchange()
+                .expectStatus().is5xxServerError();
+
+        verifyNoInteractions(camtImportStorageService);
+    }
+}

--- a/costs/src/main/java/com/marvin/costs/service/CamtImportStorageService.java
+++ b/costs/src/main/java/com/marvin/costs/service/CamtImportStorageService.java
@@ -32,9 +32,10 @@ public class CamtImportStorageService {
      *
      * @param fileName the name of the file to write
      * @param content  the raw bytes of the file
+     * @throws IllegalArgumentException if the resolved target path escapes the watched import directory
      */
     public void store(String fileName, byte[] content) {
-        final Path target = directoryIn.resolve(fileName);
+        final Path target = resolveWithinImportDirectory(fileName);
         try {
             Files.write(target, content);
             LOGGER.info("Stored uploaded CAMT file {} for import.", fileName);
@@ -42,6 +43,15 @@ public class CamtImportStorageService {
             LOGGER.error("Could not store uploaded CAMT file {}!", fileName, e);
             throw new UncheckedIOException(e);
         }
+    }
+
+    private Path resolveWithinImportDirectory(String fileName) {
+        final Path normalizedImportDirectory = directoryIn.toAbsolutePath().normalize();
+        final Path target = normalizedImportDirectory.resolve(fileName).normalize();
+        if (!target.startsWith(normalizedImportDirectory)) {
+            throw new IllegalArgumentException("File name escapes the import directory: " + fileName);
+        }
+        return target;
     }
 
     private void ensureDirectory() {

--- a/costs/src/main/java/com/marvin/costs/service/CamtImportStorageService.java
+++ b/costs/src/main/java/com/marvin/costs/service/CamtImportStorageService.java
@@ -1,0 +1,57 @@
+package com.marvin.costs.service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Persists uploaded CAMT files into the directory watched by {@link DirectoryWatcher}. */
+@Service
+public class CamtImportStorageService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CamtImportStorageService.class);
+
+    private final Path directoryIn;
+
+    /**
+     * Constructs a new {@code CamtImportStorageService}.
+     *
+     * @param directoryIn the directory that {@link DirectoryWatcher} watches for new CAMT files
+     */
+    public CamtImportStorageService(@Value("${camt.import.file.in}") String directoryIn) {
+        this.directoryIn = Path.of(directoryIn);
+        ensureDirectory();
+    }
+
+    /**
+     * Writes the given file bytes into the watched import directory.
+     *
+     * @param fileName the name of the file to write
+     * @param content  the raw bytes of the file
+     */
+    public void store(String fileName, byte[] content) {
+        final Path target = directoryIn.resolve(fileName);
+        try {
+            Files.write(target, content);
+            LOGGER.info("Stored uploaded CAMT file {} for import.", fileName);
+        } catch (IOException e) {
+            LOGGER.error("Could not store uploaded CAMT file {}!", fileName, e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void ensureDirectory() {
+        try {
+            if (!Files.exists(directoryIn)) {
+                Files.createDirectories(directoryIn);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Could not create CAMT import directory!", e);
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/costs/src/test/java/com/marvin/costs/service/CamtImportStorageServiceTest.java
+++ b/costs/src/test/java/com/marvin/costs/service/CamtImportStorageServiceTest.java
@@ -1,6 +1,7 @@
 package com.marvin.costs.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -56,5 +57,18 @@ class CamtImportStorageServiceTest {
 
         final Path storedFile = importDir.resolve("statement.zip");
         assertThat(Files.readString(storedFile)).isEqualTo("new-content");
+    }
+
+    @Test
+    void shouldRejectFileNameThatEscapesImportDirectoryViaPathTraversal() {
+        final Path importDir = tempDir.resolve("camt-in");
+        final CamtImportStorageService service = new CamtImportStorageService(importDir.toString());
+        final String traversalFileName = "../../../etc/passwd-traversal.zip";
+
+        assertThatThrownBy(() -> service.store(traversalFileName, "malicious-content".getBytes()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final Path escapedTarget = importDir.resolve(traversalFileName).normalize();
+        assertThat(escapedTarget).doesNotExist();
     }
 }

--- a/costs/src/test/java/com/marvin/costs/service/CamtImportStorageServiceTest.java
+++ b/costs/src/test/java/com/marvin/costs/service/CamtImportStorageServiceTest.java
@@ -1,0 +1,60 @@
+package com.marvin.costs.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CamtImportStorageServiceTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void shouldCreateImportDirectoryIfMissing() {
+        final Path importDir = tempDir.resolve("camt-in");
+        assertThat(importDir).doesNotExist();
+
+        new CamtImportStorageService(importDir.toString());
+
+        assertThat(importDir).exists().isDirectory();
+    }
+
+    @Test
+    void shouldNotFailWhenImportDirectoryAlreadyExists() throws IOException {
+        final Path importDir = tempDir.resolve("camt-in");
+        Files.createDirectories(importDir);
+
+        new CamtImportStorageService(importDir.toString());
+
+        assertThat(importDir).exists().isDirectory();
+    }
+
+    @Test
+    void shouldWriteFileBytesIntoImportDirectory() throws IOException {
+        final Path importDir = tempDir.resolve("camt-in");
+        final CamtImportStorageService service = new CamtImportStorageService(importDir.toString());
+        final byte[] content = "fake-camt-zip-content".getBytes();
+
+        service.store("statement.zip", content);
+
+        final Path storedFile = importDir.resolve("statement.zip");
+        assertThat(storedFile).exists();
+        assertThat(Files.readAllBytes(storedFile)).isEqualTo(content);
+    }
+
+    @Test
+    void shouldOverwriteExistingFileWithSameName() throws IOException {
+        final Path importDir = tempDir.resolve("camt-in");
+        final CamtImportStorageService service = new CamtImportStorageService(importDir.toString());
+        service.store("statement.zip", "old-content".getBytes());
+
+        service.store("statement.zip", "new-content".getBytes());
+
+        final Path storedFile = importDir.resolve("statement.zip");
+        assertThat(Files.readString(storedFile)).isEqualTo("new-content");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `POST /camt-entries/import` to `CamtController` (api module): accepts a multipart `.zip` file, validates the filename the same way the existing `/camt-entries` endpoint does, persists the raw bytes via the new storage service, and returns `202 Accepted`. No parsing/preview logic — processing remains async via the existing `DirectoryWatcher` -> `Delegator` flow.
- Add `CamtImportStorageService` (costs module): writes uploaded file bytes into the directory already watched by `DirectoryWatcher` (`camt.import.file.in` / `CAMT_DIRECTORY_IN`), creating the directory first if missing. Modeled on `BackupUploadHandler`'s directory-creation/write pattern.

## Test plan
- [x] New unit test `CamtImportStorageServiceTest` (costs) using `@TempDir` against a real filesystem — covers directory creation, writing bytes, and overwrite behavior.
- [x] New `@WebFluxTest` controller test `CamtImportControllerTest` (api) using `WebTestClient` — covers a valid `.zip` upload returning 202 and invoking the storage service, and a non-`.zip` filename being rejected the same way (500, matching the existing endpoint's unhandled `IllegalArgumentException` behavior, since there's no `@ControllerAdvice` in this module).
- [x] `./gradlew :costs:test :api:test` passes.
- [x] `./gradlew :costs:checkstyleMain :costs:checkstyleTest :api:checkstyleMain :api:checkstyleTest` passes with zero warnings.
- [x] `./gradlew :boot:compileJava` confirms the aggregated boot module still compiles.
- [x] No existing test files were modified (verified via tdd-test-guardian agent).

Closes #197