### PR TITLE
feat(nutrition): sport activity domain layer (#199)

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityEntity.java
@@ -1,0 +1,57 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single sport/exercise activity log entry for a given day. */
+@Getter
+@Setter
+@Entity
+@Table(name = "sport_activity", schema = "nutrition")
+public class SportActivityEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "entry_date", nullable = false)
+    private LocalDate entryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_type", nullable = false, length = 20)
+    private SportActivityType activityType;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "kcal_burned", nullable = false, precision = 10, scale = 2)
+    private BigDecimal kcalBurned;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SportActivityEntity that = (SportActivityEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityType.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityType.java
@@ -1,0 +1,17 @@
+package com.marvin.nutrition.entity;
+
+/** The activity category for a {@link SportActivityEntity}. */
+public enum SportActivityType {
+    /** Running or jogging activity. */
+    RUNNING,
+    /** Swimming activity. */
+    SWIMMING,
+    /** Cycling activity. */
+    CYCLING,
+    /** Walking activity. */
+    WALKING,
+    /** Resistance or weight training activity. */
+    STRENGTH_TRAINING,
+    /** Any other activity type not covered above. */
+    OTHER
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/SportActivityRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/SportActivityRepository.java
@@ -1,0 +1,31 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.SportActivityEntity;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link SportActivityEntity}. */
+@Repository
+public interface SportActivityRepository extends JpaRepository<SportActivityEntity, UUID> {
+
+    /**
+     * Returns all sport activities for the given date, ordered by their creation timestamp ascending.
+     *
+     * @param entryDate the date to query
+     * @return list of sport activities for that date in creation order
+     */
+    List<SportActivityEntity> findByEntryDateOrderByCreationDateAsc(LocalDate entryDate);
+
+    /**
+     * Returns all sport activities within the given date range (inclusive), ordered by date and then by
+     * their creation timestamp ascending.
+     *
+     * @param from the first date to include
+     * @param to   the last date to include
+     * @return list of sport activities within the range in date and creation order
+     */
+    List<SportActivityEntity> findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc(LocalDate from, LocalDate to);
+}

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_9__nutrition_sport_activity.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_9__nutrition_sport_activity.sql
@@ -1,0 +1,12 @@
+CREATE TABLE nutrition.sport_activity
+(
+    id            UUID           PRIMARY KEY,
+    entry_date    DATE           NOT NULL,
+    activity_type VARCHAR(20)    NOT NULL,
+    description   VARCHAR(255),
+    kcal_burned   NUMERIC(10, 2) NOT NULL,
+    creation_date TIMESTAMP      NOT NULL,
+    last_modified TIMESTAMP      NOT NULL
+);
+
+CREATE INDEX idx_sport_activity_entry_date ON nutrition.sport_activity(entry_date);

--- a/nutrition/src/test/java/com/marvin/nutrition/repository/SportActivityRepositoryTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/repository/SportActivityRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.marvin.nutrition.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.nutrition.entity.SportActivityEntity;
+import com.marvin.nutrition.entity.SportActivityType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Repository integration test for {@link SportActivityEntity}. */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class SportActivityRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private SportActivityRepository sportActivityRepository;
+
+    /**
+     * Registers dynamic Flyway/datasource properties so migrations run against the Testcontainers database.
+     *
+     * @param registry the dynamic property registry
+     */
+    @DynamicPropertySource
+    static void registerProperties(final DynamicPropertyRegistry registry) {
+        registry.add("spring.flyway.enabled", () -> "false");
+    }
+
+    @Test
+    void findByEntryDateOrderByCreationDateAscReturnsActivitiesInCreationOrder() throws InterruptedException {
+        final LocalDate entryDate = LocalDate.of(2026, 6, 1);
+
+        final SportActivityEntity first = newActivity(entryDate, SportActivityType.RUNNING, "Morning run");
+        sportActivityRepository.save(first);
+        sportActivityRepository.flush();
+        Thread.sleep(10);
+
+        final SportActivityEntity second = newActivity(entryDate, SportActivityType.SWIMMING, "Pool laps");
+        sportActivityRepository.save(second);
+        sportActivityRepository.flush();
+        Thread.sleep(10);
+
+        final SportActivityEntity third = newActivity(entryDate, SportActivityType.CYCLING, "Evening ride");
+        sportActivityRepository.save(third);
+        sportActivityRepository.flush();
+
+        final List<SportActivityEntity> activities = sportActivityRepository.findByEntryDateOrderByCreationDateAsc(entryDate);
+
+        assertThat(activities).extracting(SportActivityEntity::getDescription)
+                .containsExactly("Morning run", "Pool laps", "Evening ride");
+    }
+
+    @Test
+    void findByEntryDateBetweenOrderByEntryDateAscCreationDateAscReturnsOnlyInRangeOrdered() {
+        final LocalDate before = LocalDate.of(2026, 5, 30);
+        final LocalDate from = LocalDate.of(2026, 6, 1);
+        final LocalDate middle = LocalDate.of(2026, 6, 2);
+        final LocalDate to = LocalDate.of(2026, 6, 3);
+        final LocalDate after = LocalDate.of(2026, 6, 5);
+
+        sportActivityRepository.save(newActivity(before, SportActivityType.WALKING, "Outside range before"));
+        sportActivityRepository.save(newActivity(from, SportActivityType.RUNNING, "Day one"));
+        sportActivityRepository.save(newActivity(middle, SportActivityType.STRENGTH_TRAINING, "Day two"));
+        sportActivityRepository.save(newActivity(to, SportActivityType.OTHER, "Day three"));
+        sportActivityRepository.save(newActivity(after, SportActivityType.CYCLING, "Outside range after"));
+
+        final List<SportActivityEntity> activities =
+                sportActivityRepository.findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc(from, to);
+
+        assertThat(activities).extracting(SportActivityEntity::getDescription)
+                .containsExactly("Day one", "Day two", "Day three");
+    }
+
+    private SportActivityEntity newActivity(final LocalDate entryDate, final SportActivityType activityType, final String description) {
+        final SportActivityEntity activity = new SportActivityEntity();
+        activity.setEntryDate(entryDate);
+        activity.setActivityType(activityType);
+        activity.setDescription(description);
+        activity.setKcalBurned(BigDecimal.valueOf(300));
+        return activity;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the domain layer only for tracking sport/exercise activities per day, as the first issue in its milestone (no controller/service/DTO/mapper yet).
- `SportActivityType` enum: `RUNNING`, `SWIMMING`, `CYCLING`, `WALKING`, `STRENGTH_TRAINING`, `OTHER`.
- `SportActivityEntity`: extends `BasicEntity`, fields `id`, `entryDate`, `activityType`, `description`, `kcalBurned`. Mapped to `nutrition.sport_activity`.
- Flyway migration `V1_9__nutrition_sport_activity.sql`: creates `nutrition.sport_activity` table plus `idx_sport_activity_entry_date` index, mirroring the style of `V1_4__nutrition_meal_entry.sql`.
- `SportActivityRepository`: Spring Data JPA repository with `findByEntryDateOrderByCreationDateAsc` and `findByEntryDateBetweenOrderByEntryDateAscCreationDateAsc`, mirroring `MealEntryRepository`.
- `SportActivityRepositoryTest`: `@DataJpaTest` + Testcontainers test (written first, per TDD) covering both finder methods.

## Test plan
- [x] `./gradlew :nutrition:compileJava :nutrition:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — BUILD SUCCESSFUL, zero warnings
- [ ] `./gradlew :nutrition:test` — **not run locally**: this sandbox's Docker daemon has an API version incompatible with the Testcontainers client, so the new Testcontainers-based test could not be executed here. Must be verified in CI where Docker works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)