### PR TITLE
feat(nutrition): add sport activity CRUD API

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/SportActivityController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/SportActivityController.java
@@ -77,8 +77,7 @@ public class SportActivityController {
                 .map(created -> {
                     final URI location = URI.create(ACTIVITIES_LOCATION_PREFIX + created.id());
                     return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
-                })
-                .onErrorReturn(IllegalArgumentException.class, ResponseEntity.badRequest().build());
+                });
     }
 
     /**
@@ -108,8 +107,7 @@ public class SportActivityController {
             @Valid @RequestBody UpdateSportActivityRequest req) {
         return sportActivityService.updateActivity(id, req)
                 .map(ResponseEntity::ok)
-                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build())
-                .onErrorReturn(IllegalArgumentException.class, ResponseEntity.badRequest().build());
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }
 
     /**

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/SportActivityController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/SportActivityController.java
@@ -1,0 +1,138 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.CreateSportActivityRequest;
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.dto.UpdateSportActivityRequest;
+import com.marvin.nutrition.service.SportActivityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for sport/exercise activity logging.
+ * Provides endpoints to add, update and delete sport activities for a given day.
+ */
+@RestController
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class SportActivityController {
+
+    private static final String ACTIVITIES_LOCATION_PREFIX = "/nutrition/activities/";
+
+    private final SportActivityService sportActivityService;
+
+    /**
+     * Creates a new SportActivityController with the required service.
+     *
+     * @param sportActivityService the service handling sport activity operations
+     */
+    public SportActivityController(SportActivityService sportActivityService) {
+        this.sportActivityService = sportActivityService;
+    }
+
+    /**
+     * Logs a new sport activity for the given date and returns 201 Created with a Location header.
+     *
+     * @param date the date to log the activity for
+     * @param req  the create request body
+     * @return a Mono with 201 Created, Location header, and the created sport activity DTO
+     */
+    @PostMapping("/nutrition/days/{date}/activities")
+    @Operation(
+            summary = "Log a sport activity",
+            description = "Adds a sport activity for the given day. "
+                    + "When activityType is OTHER, a non-blank description is required.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Sport activity created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = SportActivityDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed or missing required description")
+            }
+    )
+    public Mono<ResponseEntity<SportActivityDTO>> addActivity(
+            @PathVariable
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "Date of the sport activity (ISO-8601)", example = "2026-06-07") LocalDate date,
+            @Valid @RequestBody CreateSportActivityRequest req) {
+        return sportActivityService.addActivity(date, req)
+                .map(created -> {
+                    final URI location = URI.create(ACTIVITIES_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                })
+                .onErrorReturn(IllegalArgumentException.class, ResponseEntity.badRequest().build());
+    }
+
+    /**
+     * Updates the sport activity with the given id, or returns 404 if not found.
+     *
+     * @param id  the UUID of the activity to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated DTO, 404 if not found, or 400 if invalid
+     */
+    @PutMapping("/nutrition/activities/{id}")
+    @Operation(
+            summary = "Update a sport activity",
+            description = "Applies partial updates to an existing sport activity. "
+                    + "If the resulting activityType is OTHER, a non-blank description is required.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Sport activity updated",
+                        content = @Content(schema = @Schema(implementation = SportActivityDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed or missing required description"),
+                @ApiResponse(responseCode = "404", description = "Sport activity not found")
+            }
+    )
+    public Mono<ResponseEntity<SportActivityDTO>> updateActivity(
+            @PathVariable @Parameter(description = "UUID of the sport activity to update") UUID id,
+            @Valid @RequestBody UpdateSportActivityRequest req) {
+        return sportActivityService.updateActivity(id, req)
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build())
+                .onErrorReturn(IllegalArgumentException.class, ResponseEntity.badRequest().build());
+    }
+
+    /**
+     * Deletes the sport activity with the given id, or returns 404 if not found.
+     *
+     * @param id the UUID of the activity to delete
+     * @return a Mono with 204 No Content on success, or 404 if not found
+     */
+    @DeleteMapping("/nutrition/activities/{id}")
+    @Operation(
+            summary = "Delete a sport activity",
+            description = "Permanently removes the sport activity.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Sport activity deleted"),
+                @ApiResponse(responseCode = "404", description = "Sport activity not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteActivity(
+            @PathVariable @Parameter(description = "UUID of the sport activity to delete") UUID id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return sportActivityService.deleteActivity(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateSportActivityRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateSportActivityRequest.java
@@ -1,0 +1,34 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.SportActivityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+/**
+ * Request body for logging a new sport/exercise activity.
+ * When {@code activityType} is OTHER, a non-blank {@code description} is required;
+ * this is enforced imperatively by the write service rather than a bean validation constraint.
+ *
+ * @param activityType the activity category (required)
+ * @param description  free-text label (required when {@code activityType} is OTHER)
+ * @param kcalBurned   kilocalories burned during the activity (required)
+ */
+@Schema(description = "Request to log a sport/exercise activity for a given day")
+public record CreateSportActivityRequest(
+        @NotNull
+        @Schema(description = "Activity category", example = "RUNNING")
+        SportActivityType activityType,
+
+        @Size(max = 255)
+        @Schema(description = "Free-text description; required when activityType is OTHER", example = "Climbing")
+        String description,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "Kilocalories burned", example = "300.00")
+        BigDecimal kcalBurned
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/SportActivityDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/SportActivityDTO.java
@@ -1,0 +1,35 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.entity.SportActivityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a logged sport/exercise activity.
+ *
+ * @param id           server-assigned unique identifier
+ * @param entryDate    the date this activity belongs to
+ * @param activityType the activity category (RUNNING, SWIMMING, CYCLING, WALKING, STRENGTH_TRAINING, OTHER)
+ * @param description  free-text label, required when {@code activityType} is OTHER
+ * @param kcalBurned   kilocalories burned during the activity
+ */
+@Schema(description = "A logged sport/exercise activity for a given day")
+public record SportActivityDTO(
+        @Schema(description = "Sport activity identifier")
+        UUID id,
+
+        @Schema(description = "Date of the activity", example = "2026-06-07")
+        LocalDate entryDate,
+
+        @Schema(description = "Activity category", example = "RUNNING")
+        SportActivityType activityType,
+
+        @Schema(description = "Free-text description; required when activityType is OTHER", example = "Climbing")
+        String description,
+
+        @Schema(description = "Kilocalories burned", example = "300.00")
+        BigDecimal kcalBurned
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateSportActivityRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateSportActivityRequest.java
@@ -1,0 +1,34 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import com.marvin.nutrition.entity.SportActivityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+/**
+ * Request body for updating an existing sport/exercise activity.
+ * All fields are optional; only non-null values are applied.
+ * If the resulting activity type is OTHER, a non-blank description is required; this is
+ * enforced imperatively by the write service rather than a bean validation constraint.
+ *
+ * @param activityType updated activity category (nullable)
+ * @param description  updated free-text label (nullable)
+ * @param kcalBurned   updated kilocalories burned (nullable)
+ */
+@Schema(description = "Request to update an existing sport/exercise activity")
+public record UpdateSportActivityRequest(
+        @Schema(description = "Updated activity category (nullable)", example = "CYCLING")
+        SportActivityType activityType,
+
+        @Size(max = 255)
+        @NullOrNotBlank
+        @Schema(description = "Updated free-text description", example = "Climbing")
+        String description,
+
+        @PositiveOrZero
+        @Schema(description = "Updated kilocalories burned", example = "400.00")
+        BigDecimal kcalBurned
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/SportActivityMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/SportActivityMapper.java
@@ -1,0 +1,18 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.entity.SportActivityEntity;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between {@link SportActivityEntity} and {@link SportActivityDTO}. */
+@Mapper(componentModel = "spring")
+public interface SportActivityMapper {
+
+    /**
+     * Maps a sport activity entity to its DTO representation.
+     *
+     * @param entity the sport activity entity to map
+     * @return the corresponding DTO
+     */
+    SportActivityDTO toDTO(SportActivityEntity entity);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/SportActivityService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/SportActivityService.java
@@ -1,0 +1,70 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateSportActivityRequest;
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.dto.UpdateSportActivityRequest;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** Orchestrates sport activity logging operations, delegating writes to {@link SportActivityWriteService}. */
+@Service
+public class SportActivityService {
+
+    private final SportActivityWriteService sportActivityWriteService;
+
+    /**
+     * Creates a new SportActivityService with the required dependencies.
+     *
+     * @param sportActivityWriteService service owning transactional sport activity write operations
+     */
+    public SportActivityService(SportActivityWriteService sportActivityWriteService) {
+        this.sportActivityWriteService = sportActivityWriteService;
+    }
+
+    /**
+     * Logs a new sport activity for the given date.
+     * Emits {@link IllegalArgumentException} if {@code req.activityType()} is OTHER and
+     * {@code req.description()} is null or blank.
+     *
+     * @param date the date to log the activity for
+     * @param req  the create request containing activity details
+     * @return a Mono emitting the created sport activity DTO
+     */
+    public Mono<SportActivityDTO> addActivity(LocalDate date, CreateSportActivityRequest req) {
+        return Mono.fromCallable(() -> sportActivityWriteService.createActivity(date, req))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Updates an existing sport activity.
+     * Emits {@link NoSuchElementException} if no activity with the given id exists.
+     * Emits {@link IllegalArgumentException} if the resulting activity type is OTHER and the
+     * resulting description is null or blank.
+     *
+     * @param id  the UUID of the activity to update
+     * @param req the update request
+     * @return a Mono emitting the updated sport activity DTO
+     */
+    public Mono<SportActivityDTO> updateActivity(UUID id, UpdateSportActivityRequest req) {
+        return Mono.fromCallable(() -> sportActivityWriteService.updateActivity(id, req))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Deletes the sport activity with the given id.
+     * Emits {@link NoSuchElementException} if no activity with that id exists.
+     *
+     * @param id the UUID of the activity to delete
+     * @return an empty Mono on success
+     */
+    public Mono<Void> deleteActivity(UUID id) {
+        return Mono.fromCallable(() -> {
+            sportActivityWriteService.deleteActivity(id);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/SportActivityWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/SportActivityWriteService.java
@@ -1,0 +1,119 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateSportActivityRequest;
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.dto.UpdateSportActivityRequest;
+import com.marvin.nutrition.entity.SportActivityEntity;
+import com.marvin.nutrition.entity.SportActivityType;
+import com.marvin.nutrition.mapper.SportActivityMapper;
+import com.marvin.nutrition.repository.SportActivityRepository;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the transactional write operations for sport activities.
+ *
+ * <p>All methods in this service perform blocking repository access and must only be called from
+ * a thread already running on a blocking-friendly scheduler (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}),
+ * and must be invoked from outside this bean so that Spring's transactional proxy is applied.</p>
+ */
+@Service
+public class SportActivityWriteService {
+
+    private final SportActivityRepository sportActivityRepository;
+    private final SportActivityMapper sportActivityMapper;
+
+    /**
+     * Creates a new SportActivityWriteService with the required dependencies.
+     *
+     * @param sportActivityRepository JPA repository for sport activities
+     * @param sportActivityMapper     MapStruct mapper for entity/DTO conversion
+     */
+    public SportActivityWriteService(
+            SportActivityRepository sportActivityRepository,
+            SportActivityMapper sportActivityMapper) {
+        this.sportActivityRepository = sportActivityRepository;
+        this.sportActivityMapper = sportActivityMapper;
+    }
+
+    /**
+     * Logs a new sport activity for the given date.
+     * Throws {@link IllegalArgumentException} if {@code req.activityType()} is OTHER and
+     * {@code req.description()} is null or blank.
+     *
+     * @param date the date to log the activity for
+     * @param req  the create request containing activity details
+     * @return the created sport activity DTO
+     */
+    @Transactional
+    public SportActivityDTO createActivity(LocalDate date, CreateSportActivityRequest req) {
+        requireDescriptionForOther(req.activityType(), req.description());
+
+        final SportActivityEntity entity = new SportActivityEntity();
+        entity.setEntryDate(date);
+        entity.setActivityType(req.activityType());
+        entity.setDescription(req.description());
+        entity.setKcalBurned(req.kcalBurned());
+
+        return sportActivityMapper.toDTO(sportActivityRepository.save(entity));
+    }
+
+    /**
+     * Updates an existing sport activity.
+     * Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if no activity with the given id exists.
+     * Throws {@link IllegalArgumentException} if the resulting activity type is OTHER and the
+     * resulting description is null or blank.
+     *
+     * @param id  the UUID of the activity to update
+     * @param req the update request
+     * @return the updated sport activity DTO
+     */
+    @Transactional
+    public SportActivityDTO updateActivity(UUID id, UpdateSportActivityRequest req) {
+        final SportActivityEntity entity = sportActivityRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Sport activity not found: " + id));
+
+        if (req.activityType() != null) {
+            entity.setActivityType(req.activityType());
+        }
+        if (req.description() != null) {
+            entity.setDescription(req.description());
+        }
+        if (req.kcalBurned() != null) {
+            entity.setKcalBurned(req.kcalBurned());
+        }
+
+        requireDescriptionForOther(entity.getActivityType(), entity.getDescription());
+
+        return sportActivityMapper.toDTO(sportActivityRepository.save(entity));
+    }
+
+    /**
+     * Deletes the sport activity with the given id.
+     * Throws {@link NoSuchElementException} if no activity with that id exists.
+     *
+     * @param id the UUID of the activity to delete
+     */
+    @Transactional
+    public void deleteActivity(UUID id) {
+        final SportActivityEntity entity = sportActivityRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Sport activity not found: " + id));
+        sportActivityRepository.delete(entity);
+    }
+
+    /**
+     * Validates that a non-blank description is present when the activity type is OTHER.
+     *
+     * @param activityType the activity type to check
+     * @param description  the description to check
+     */
+    private void requireDescriptionForOther(SportActivityType activityType, String description) {
+        if (activityType == SportActivityType.OTHER && (description == null || description.isBlank())) {
+            throw new IllegalArgumentException("description is required for OTHER activity type");
+        }
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/SportActivityControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/SportActivityControllerTest.java
@@ -1,0 +1,204 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateSportActivityRequest;
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.dto.UpdateSportActivityRequest;
+import com.marvin.nutrition.entity.SportActivityType;
+import com.marvin.nutrition.service.SportActivityService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link SportActivityController} covering all endpoints. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SportActivityController Tests")
+class SportActivityControllerTest {
+
+    @Mock
+    private SportActivityService sportActivityService;
+
+    @InjectMocks
+    private SportActivityController sportActivityController;
+
+    private UUID activityId;
+    private LocalDate today;
+    private SportActivityDTO sportActivityDTO;
+    private CreateSportActivityRequest createRequest;
+    private UpdateSportActivityRequest updateRequest;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        activityId = UUID.randomUUID();
+        today = LocalDate.of(2026, 6, 7);
+
+        sportActivityDTO = new SportActivityDTO(
+                activityId, today, SportActivityType.RUNNING, null, new BigDecimal("300.00")
+        );
+
+        createRequest = new CreateSportActivityRequest(
+                SportActivityType.RUNNING, null, new BigDecimal("300.00")
+        );
+
+        updateRequest = new UpdateSportActivityRequest(
+                SportActivityType.CYCLING, null, new BigDecimal("400.00")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/days/{date}/activities
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addActivity returns 201 Created with Location header pointing to new activity")
+    void addActivity_Valid_Returns201WithLocation() {
+        when(sportActivityService.addActivity(eq(today), any(CreateSportActivityRequest.class)))
+                .thenReturn(Mono.just(sportActivityDTO));
+
+        final Mono<ResponseEntity<SportActivityDTO>> result =
+                sportActivityController.addActivity(today, createRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(SportActivityType.RUNNING, response.getBody().activityType());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString()
+                            .contains(activityId.toString()));
+                })
+                .verifyComplete();
+
+        verify(sportActivityService).addActivity(eq(today), any(CreateSportActivityRequest.class));
+    }
+
+    @Test
+    @DisplayName("addActivity returns 400 when service emits IllegalArgumentException")
+    void addActivity_OtherTypeMissingDescription_Returns400() {
+        when(sportActivityService.addActivity(eq(today), any(CreateSportActivityRequest.class)))
+                .thenReturn(Mono.error(new IllegalArgumentException(
+                        "description is required for OTHER activity type")));
+
+        final Mono<ResponseEntity<SportActivityDTO>> result =
+                sportActivityController.addActivity(today, createRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(400, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(sportActivityService).addActivity(eq(today), any(CreateSportActivityRequest.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/activities/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateActivity returns 200 with updated DTO when activity exists")
+    void updateActivity_Found_Returns200WithUpdatedDTO() {
+        final SportActivityDTO updatedDTO = new SportActivityDTO(
+                activityId, today, SportActivityType.CYCLING, null, new BigDecimal("400.00")
+        );
+
+        when(sportActivityService.updateActivity(eq(activityId), any(UpdateSportActivityRequest.class)))
+                .thenReturn(Mono.just(updatedDTO));
+
+        final Mono<ResponseEntity<SportActivityDTO>> result =
+                sportActivityController.updateActivity(activityId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(SportActivityType.CYCLING, response.getBody().activityType());
+                })
+                .verifyComplete();
+
+        verify(sportActivityService).updateActivity(eq(activityId), any(UpdateSportActivityRequest.class));
+    }
+
+    @Test
+    @DisplayName("updateActivity returns 404 when activity not found")
+    void updateActivity_NotFound_Returns404() {
+        when(sportActivityService.updateActivity(eq(activityId), any(UpdateSportActivityRequest.class)))
+                .thenReturn(Mono.error(new NoSuchElementException("Sport activity not found: " + activityId)));
+
+        final Mono<ResponseEntity<SportActivityDTO>> result =
+                sportActivityController.updateActivity(activityId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(sportActivityService).updateActivity(eq(activityId), any(UpdateSportActivityRequest.class));
+    }
+
+    @Test
+    @DisplayName("updateActivity returns 400 when service emits IllegalArgumentException")
+    void updateActivity_OtherTypeMissingDescription_Returns400() {
+        when(sportActivityService.updateActivity(eq(activityId), any(UpdateSportActivityRequest.class)))
+                .thenReturn(Mono.error(new IllegalArgumentException(
+                        "description is required for OTHER activity type")));
+
+        final Mono<ResponseEntity<SportActivityDTO>> result =
+                sportActivityController.updateActivity(activityId, updateRequest);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(400, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(sportActivityService).updateActivity(eq(activityId), any(UpdateSportActivityRequest.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE /nutrition/activities/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteActivity returns 204 No Content when activity exists")
+    void deleteActivity_Exists_Returns204() {
+        when(sportActivityService.deleteActivity(activityId)).thenReturn(Mono.empty());
+
+        final Mono<ResponseEntity<Void>> result = sportActivityController.deleteActivity(activityId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(204, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(sportActivityService).deleteActivity(activityId);
+    }
+
+    @Test
+    @DisplayName("deleteActivity returns 404 when activity not found")
+    void deleteActivity_NotFound_Returns404() {
+        when(sportActivityService.deleteActivity(activityId))
+                .thenReturn(Mono.error(new NoSuchElementException("Sport activity not found: " + activityId)));
+
+        final Mono<ResponseEntity<Void>> result = sportActivityController.deleteActivity(activityId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+
+        verify(sportActivityService).deleteActivity(activityId);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/SportActivityControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/SportActivityControllerTest.java
@@ -92,8 +92,8 @@ class SportActivityControllerTest {
     }
 
     @Test
-    @DisplayName("addActivity returns 400 when service emits IllegalArgumentException")
-    void addActivity_OtherTypeMissingDescription_Returns400() {
+    @DisplayName("addActivity propagates IllegalArgumentException with its message to the global handler")
+    void addActivity_OtherTypeMissingDescription_PropagatesIllegalArgumentException() {
         when(sportActivityService.addActivity(eq(today), any(CreateSportActivityRequest.class)))
                 .thenReturn(Mono.error(new IllegalArgumentException(
                         "description is required for OTHER activity type")));
@@ -102,8 +102,11 @@ class SportActivityControllerTest {
                 sportActivityController.addActivity(today, createRequest);
 
         StepVerifier.create(result)
-                .assertNext(response -> assertEquals(400, response.getStatusCode().value()))
-                .verifyComplete();
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof IllegalArgumentException);
+                    assertEquals("description is required for OTHER activity type", error.getMessage());
+                })
+                .verify();
 
         verify(sportActivityService).addActivity(eq(today), any(CreateSportActivityRequest.class));
     }
@@ -153,8 +156,8 @@ class SportActivityControllerTest {
     }
 
     @Test
-    @DisplayName("updateActivity returns 400 when service emits IllegalArgumentException")
-    void updateActivity_OtherTypeMissingDescription_Returns400() {
+    @DisplayName("updateActivity propagates IllegalArgumentException with its message to the global handler")
+    void updateActivity_OtherTypeMissingDescription_PropagatesIllegalArgumentException() {
         when(sportActivityService.updateActivity(eq(activityId), any(UpdateSportActivityRequest.class)))
                 .thenReturn(Mono.error(new IllegalArgumentException(
                         "description is required for OTHER activity type")));
@@ -163,8 +166,11 @@ class SportActivityControllerTest {
                 sportActivityController.updateActivity(activityId, updateRequest);
 
         StepVerifier.create(result)
-                .assertNext(response -> assertEquals(400, response.getStatusCode().value()))
-                .verifyComplete();
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof IllegalArgumentException);
+                    assertEquals("description is required for OTHER activity type", error.getMessage());
+                })
+                .verify();
 
         verify(sportActivityService).updateActivity(eq(activityId), any(UpdateSportActivityRequest.class));
     }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/SportActivityWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/SportActivityWriteServiceTest.java
@@ -1,0 +1,247 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateSportActivityRequest;
+import com.marvin.nutrition.dto.SportActivityDTO;
+import com.marvin.nutrition.dto.UpdateSportActivityRequest;
+import com.marvin.nutrition.entity.SportActivityEntity;
+import com.marvin.nutrition.entity.SportActivityType;
+import com.marvin.nutrition.mapper.SportActivityMapper;
+import com.marvin.nutrition.repository.SportActivityRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link SportActivityWriteService} covering the transactional write operations. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SportActivityWriteService Tests")
+class SportActivityWriteServiceTest {
+
+    @Mock
+    private SportActivityRepository sportActivityRepository;
+
+    @Mock
+    private SportActivityMapper sportActivityMapper;
+
+    @InjectMocks
+    private SportActivityWriteService sportActivityWriteService;
+
+    private UUID activityId;
+    private SportActivityEntity sportActivityEntity;
+    private SportActivityDTO sportActivityDTO;
+    private LocalDate today;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        activityId = UUID.randomUUID();
+        today = LocalDate.of(2026, 6, 7);
+
+        sportActivityEntity = new SportActivityEntity();
+        sportActivityEntity.setEntryDate(today);
+        sportActivityEntity.setActivityType(SportActivityType.RUNNING);
+        sportActivityEntity.setKcalBurned(new BigDecimal("300.00"));
+
+        sportActivityDTO = new SportActivityDTO(
+                activityId, today, SportActivityType.RUNNING, null, new BigDecimal("300.00")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // createActivity
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createActivity persists a non-OTHER activity without requiring a description")
+    void createActivity_NonOtherType_PersistsWithoutDescription() {
+        final CreateSportActivityRequest req =
+                new CreateSportActivityRequest(SportActivityType.RUNNING, null, new BigDecimal("300.00"));
+
+        when(sportActivityRepository.save(any(SportActivityEntity.class))).thenReturn(sportActivityEntity);
+        when(sportActivityMapper.toDTO(sportActivityEntity)).thenReturn(sportActivityDTO);
+
+        final SportActivityDTO result = sportActivityWriteService.createActivity(today, req);
+
+        assertEquals(sportActivityDTO, result);
+        verify(sportActivityRepository).save(argThat(e ->
+                SportActivityType.RUNNING.equals(e.getActivityType())
+                        && today.equals(e.getEntryDate())
+                        && new BigDecimal("300.00").compareTo(e.getKcalBurned()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("createActivity persists an OTHER activity when description is supplied")
+    void createActivity_OtherTypeWithDescription_Persists() {
+        final CreateSportActivityRequest req =
+                new CreateSportActivityRequest(SportActivityType.OTHER, "Climbing", new BigDecimal("400.00"));
+
+        final SportActivityEntity saved = new SportActivityEntity();
+        saved.setEntryDate(today);
+        saved.setActivityType(SportActivityType.OTHER);
+        saved.setDescription("Climbing");
+        saved.setKcalBurned(new BigDecimal("400.00"));
+
+        final SportActivityDTO dto = new SportActivityDTO(
+                UUID.randomUUID(), today, SportActivityType.OTHER, "Climbing", new BigDecimal("400.00")
+        );
+
+        when(sportActivityRepository.save(any(SportActivityEntity.class))).thenReturn(saved);
+        when(sportActivityMapper.toDTO(saved)).thenReturn(dto);
+
+        final SportActivityDTO result = sportActivityWriteService.createActivity(today, req);
+
+        assertEquals(dto, result);
+        verify(sportActivityRepository).save(argThat(e -> "Climbing".equals(e.getDescription())));
+    }
+
+    @Test
+    @DisplayName("createActivity throws IllegalArgumentException when OTHER type has no description")
+    void createActivity_OtherTypeMissingDescription_ThrowsIllegalArgumentException() {
+        final CreateSportActivityRequest req =
+                new CreateSportActivityRequest(SportActivityType.OTHER, null, new BigDecimal("400.00"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> sportActivityWriteService.createActivity(today, req));
+
+        verify(sportActivityRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createActivity throws IllegalArgumentException when OTHER type has blank description")
+    void createActivity_OtherTypeBlankDescription_ThrowsIllegalArgumentException() {
+        final CreateSportActivityRequest req =
+                new CreateSportActivityRequest(SportActivityType.OTHER, "   ", new BigDecimal("400.00"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> sportActivityWriteService.createActivity(today, req));
+
+        verify(sportActivityRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // updateActivity
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateActivity applies non-null fields and persists the change")
+    void updateActivity_NonNullFields_AppliesAndPersists() {
+        final UpdateSportActivityRequest req =
+                new UpdateSportActivityRequest(SportActivityType.CYCLING, null, new BigDecimal("500.00"));
+
+        final SportActivityEntity updated = new SportActivityEntity();
+        updated.setEntryDate(today);
+        updated.setActivityType(SportActivityType.CYCLING);
+        updated.setKcalBurned(new BigDecimal("500.00"));
+
+        final SportActivityDTO updatedDTO = new SportActivityDTO(
+                activityId, today, SportActivityType.CYCLING, null, new BigDecimal("500.00")
+        );
+
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.of(sportActivityEntity));
+        when(sportActivityRepository.save(any(SportActivityEntity.class))).thenReturn(updated);
+        when(sportActivityMapper.toDTO(updated)).thenReturn(updatedDTO);
+
+        final SportActivityDTO result = sportActivityWriteService.updateActivity(activityId, req);
+
+        assertEquals(updatedDTO, result);
+        verify(sportActivityRepository).save(argThat(e ->
+                SportActivityType.CYCLING.equals(e.getActivityType())
+                        && new BigDecimal("500.00").compareTo(e.getKcalBurned()) == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("updateActivity throws NoSuchElementException when activity not found")
+    void updateActivity_NotFound_ThrowsNoSuchElementException() {
+        final UpdateSportActivityRequest req =
+                new UpdateSportActivityRequest(SportActivityType.CYCLING, null, null);
+
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> sportActivityWriteService.updateActivity(activityId, req));
+
+        verify(sportActivityRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateActivity throws IllegalArgumentException when resulting type is OTHER without description")
+    void updateActivity_ResultingOtherTypeMissingDescription_ThrowsIllegalArgumentException() {
+        final UpdateSportActivityRequest req =
+                new UpdateSportActivityRequest(SportActivityType.OTHER, null, null);
+
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.of(sportActivityEntity));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> sportActivityWriteService.updateActivity(activityId, req));
+
+        verify(sportActivityRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateActivity allows switching to OTHER type when description is supplied in the same request")
+    void updateActivity_ResultingOtherTypeWithDescription_Persists() {
+        final UpdateSportActivityRequest req =
+                new UpdateSportActivityRequest(SportActivityType.OTHER, "Climbing", null);
+
+        final SportActivityEntity updated = new SportActivityEntity();
+        updated.setEntryDate(today);
+        updated.setActivityType(SportActivityType.OTHER);
+        updated.setDescription("Climbing");
+        updated.setKcalBurned(new BigDecimal("300.00"));
+
+        final SportActivityDTO updatedDTO = new SportActivityDTO(
+                activityId, today, SportActivityType.OTHER, "Climbing", new BigDecimal("300.00")
+        );
+
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.of(sportActivityEntity));
+        when(sportActivityRepository.save(any(SportActivityEntity.class))).thenReturn(updated);
+        when(sportActivityMapper.toDTO(updated)).thenReturn(updatedDTO);
+
+        final SportActivityDTO result = sportActivityWriteService.updateActivity(activityId, req);
+
+        assertEquals(updatedDTO, result);
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteActivity
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteActivity throws NoSuchElementException when activity not found")
+    void deleteActivity_NotFound_ThrowsNoSuchElementException() {
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> sportActivityWriteService.deleteActivity(activityId));
+
+        verify(sportActivityRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("deleteActivity deletes when activity exists")
+    void deleteActivity_Exists_Deletes() {
+        when(sportActivityRepository.findById(activityId)).thenReturn(Optional.of(sportActivityEntity));
+
+        sportActivityWriteService.deleteActivity(activityId);
+
+        verify(sportActivityRepository).delete(sportActivityEntity);
+    }
+}


### PR DESCRIPTION
## Summary
- Add CRUD API for sport activities on top of the existing domain model (#199): DTOs, MapStruct mapper, write service, thin orchestration service, and controller.
- `POST /nutrition/days/{date}/activities`, `PUT /nutrition/activities/{id}`, `DELETE /nutrition/activities/{id}`.
- `OTHER` activity type requires a non-blank `description`, validated imperatively in `SportActivityWriteService` (`IllegalArgumentException` -> HTTP 400).
- Does not trigger day-target-snapshot creation (unlike meal-entry CRUD).

Closes #200

## Test plan
- [x] New tests written first: `SportActivityWriteServiceTest`, `SportActivityControllerTest`
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes with zero warnings
- [x] `./gradlew :nutrition:test --tests "*SportActivity*"` passes (excluding pre-existing Testcontainers test, which requires Docker unavailable in this environment)
- [x] No existing test files modified (verified via tdd-test-guardian)