### PR TITLE
feat(nutrition): scale CUT kcal deficit to bodyweight loss rate

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/TargetService.java
@@ -27,7 +27,8 @@ public class TargetService {
     private static final double ACTIVITY_ACTIVE = 1.725;
     private static final double ACTIVITY_VERY_ACTIVE = 1.9;
 
-    private static final int GOAL_CUT_ADJUSTMENT = -500;
+    private static final double CUT_WEEKLY_LOSS_PCT = 0.7;
+    private static final int KCAL_PER_KG_FAT = 7700;
     private static final int GOAL_MAINTAIN_ADJUSTMENT = 0;
     private static final int GOAL_BULK_ADJUSTMENT = 300;
 
@@ -76,7 +77,7 @@ public class TargetService {
         final double weightKg = latestWeight.getWeightKg().doubleValue();
         final int bmr = resolveBmr(profile, weightKg, asOfDate);
         final int maintenanceKcal = computeMaintenance(bmr, profile.getActivityLevel());
-        final int targetKcal = maintenanceKcal + goalAdjustment(profile.getGoal());
+        final int targetKcal = maintenanceKcal + goalAdjustment(profile.getGoal(), weightKg);
 
         final int proteinG = (int) Math.round(profile.getProteinPerKg().doubleValue() * weightKg);
         final int fatG = profile.getFatPct()
@@ -154,14 +155,32 @@ public class TargetService {
     /**
      * Returns the kcal adjustment for the given dietary goal.
      *
-     * @param goal the dietary goal
+     * <p>For {@code CUT}, the deficit is scaled to bodyweight rather than a flat value, following
+     * Garthe et al. 2011, which found that a weekly bodyweight loss rate of about 0.7% best
+     * preserves lean mass during a cut. The weekly deficit is derived from that target loss rate
+     * assuming roughly {@value #KCAL_PER_KG_FAT} kcal per kg of fat mass, then spread evenly
+     * across the week to obtain the daily adjustment.</p>
+     *
+     * @param goal     the dietary goal
+     * @param weightKg current body weight in kilograms, used to scale the CUT deficit
      * @return positive, zero, or negative integer kcal adjustment
      */
-    private int goalAdjustment(Goal goal) {
+    private int goalAdjustment(Goal goal, double weightKg) {
         return switch (goal) {
-            case CUT -> GOAL_CUT_ADJUSTMENT;
+            case CUT -> -cutDailyDeficit(weightKg);
             case MAINTAIN -> GOAL_MAINTAIN_ADJUSTMENT;
             case BULK -> GOAL_BULK_ADJUSTMENT;
         };
+    }
+
+    /**
+     * Computes the daily kcal deficit for a CUT goal, scaled to bodyweight per Garthe et al. 2011.
+     *
+     * @param weightKg current body weight in kilograms
+     * @return the daily kcal deficit, rounded to the nearest whole kcal
+     */
+    private int cutDailyDeficit(double weightKg) {
+        final double weeklyDeficitKcal = weightKg * (CUT_WEEKLY_LOSS_PCT / 100) * KCAL_PER_KG_FAT;
+        return (int) Math.round(weeklyDeficitKcal / 7);
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/TargetServiceTest.java
@@ -93,9 +93,10 @@ class TargetServiceTest {
     /**
      * Female, 25 years, 165 cm, 60 kg → BMR = 10*60 + 6.25*165 - 5*25 - 161 = 600+1031.25-125-161 = 1345.25 → 1345.
      * LIGHT activity: 1345 * 1.375 = 1849.375 → 1849.
-     * CUT goal: 1849 - 500 = 1349.
-     * protein = 2.0 * 60 = 120 g, fat = round(0.30 * 1349 / 9) = round(44.97) = 45 g,
-     * carbs = round((1349 - 120*4 - 45*9) / 4) = round((1349 - 480 - 405) / 4) = round(464 / 4) = round(116) = 116 g.
+     * CUT goal: weeklyDeficitKcal = 60 * (0.7/100) * 7700 = 3234, dailyDeficitKcal = round(3234/7) = 462,
+     * target = 1849 - 462 = 1387.
+     * protein = 2.0 * 60 = 120 g, fat = round(0.30 * 1387 / 9) = round(46.23) = 46 g,
+     * carbs = round((1387 - 120*4 - 46*9) / 4) = round((1387 - 480 - 414) / 4) = round(493 / 4) = round(123.25) = 123 g.
      */
     @Test
     @DisplayName("FEMALE LIGHT CUT uses Mifflin–St Jeor and returns correct macros")
@@ -109,10 +110,10 @@ class TargetServiceTest {
 
         assertEquals(1345, result.bmr());
         assertEquals(1849, result.maintenanceKcal());
-        assertEquals(1349, result.targetKcal());
+        assertEquals(1387, result.targetKcal());
         assertEquals(120, result.proteinG());
-        assertEquals(45, result.fatG());
-        assertEquals(116, result.carbsG());
+        assertEquals(46, result.fatG());
+        assertEquals(123, result.carbsG());
         assertEquals(TargetBasis.MIFFLIN_ST_JEOR.name(), result.basis());
     }
 
@@ -212,8 +213,8 @@ class TargetServiceTest {
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("CUT goal subtracts 500 kcal from maintenance")
-    void compute_CutGoal_Subtracts500() {
+    @DisplayName("CUT goal applies a bodyweight-scaled deficit")
+    void compute_CutGoal_AppliesBodyweightRateDeficit() {
         final LocalDate birthDate = LocalDate.now().minusYears(30);
         final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
                 ActivityLevel.SEDENTARY, Goal.CUT, 2.0, 0.30, 2000);
@@ -221,9 +222,66 @@ class TargetServiceTest {
 
         final TargetsDTO result = targetService.computeTargets(p, w);
 
-        // maintenance = round(2000 * 1.2) = 2400; target = 2400 - 500 = 1900
+        // maintenance = round(2000 * 1.2) = 2400
+        // weeklyDeficitKcal = 80 * (0.7/100) * 7700 = 4312; dailyDeficitKcal = round(4312/7) = round(616.0) = 616
+        // target = 2400 - 616 = 1784
         assertEquals(2400, result.maintenanceKcal());
-        assertEquals(1900, result.targetKcal());
+        assertEquals(1784, result.targetKcal());
+    }
+
+    /**
+     * Garthe et al. 2011: a 0.7%/week bodyweight loss rate preserves lean mass during a cut.
+     * 50 kg → weeklyDeficitKcal = 50 * 0.007 * 7700 = 2695; dailyDeficitKcal = round(2695/7) = 385.
+     * basalKcal = 1500, SEDENTARY → maintenance = round(1500 * 1.2) = 1800; target = 1800 - 385 = 1415.
+     */
+    @Test
+    @DisplayName("CUT goal scales the deficit to bodyweight: 50 kg")
+    void compute_CutGoal_50kg_AppliesBodyweightRateDeficit() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 2.0, 0.30, 1500);
+        final WeightEntryEntity w = weight(50.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(1800, result.maintenanceKcal());
+        assertEquals(1415, result.targetKcal());
+    }
+
+    /**
+     * 70 kg → weeklyDeficitKcal = 70 * 0.007 * 7700 = 3773; dailyDeficitKcal = round(3773/7) = 539.
+     * basalKcal = 1500, SEDENTARY → maintenance = round(1500 * 1.2) = 1800; target = 1800 - 539 = 1261.
+     */
+    @Test
+    @DisplayName("CUT goal scales the deficit to bodyweight: 70 kg")
+    void compute_CutGoal_70kg_AppliesBodyweightRateDeficit() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 2.0, 0.30, 1500);
+        final WeightEntryEntity w = weight(70.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(1800, result.maintenanceKcal());
+        assertEquals(1261, result.targetKcal());
+    }
+
+    /**
+     * 90 kg → weeklyDeficitKcal = 90 * 0.007 * 7700 = 4851; dailyDeficitKcal = round(4851/7) = 693.
+     * basalKcal = 1500, SEDENTARY → maintenance = round(1500 * 1.2) = 1800; target = 1800 - 693 = 1107.
+     */
+    @Test
+    @DisplayName("CUT goal scales the deficit to bodyweight: 90 kg")
+    void compute_CutGoal_90kg_AppliesBodyweightRateDeficit() {
+        final LocalDate birthDate = LocalDate.now().minusYears(30);
+        final ProfileEntity p = profile(Sex.MALE, birthDate, 175.0,
+                ActivityLevel.SEDENTARY, Goal.CUT, 2.0, 0.30, 1500);
+        final WeightEntryEntity w = weight(90.0);
+
+        final TargetsDTO result = targetService.computeTargets(p, w);
+
+        assertEquals(1800, result.maintenanceKcal());
+        assertEquals(1107, result.targetKcal());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace the flat `GOAL_CUT_ADJUSTMENT = -500` constant with a deficit scaled to bodyweight, per Garthe et al. 2011 (0.7%/week bodyweight loss preserves lean mass during a cut).
- `goalAdjustment(Goal, weightKg)` now computes the CUT deficit as `round(weightKg * 0.7% * 7700 / 7)` kcal/day; `MAINTAIN` (0) and `BULK` (+300) are unchanged.
- Updated Javadoc to describe the new rate-based formula.

## Tests
- Added new `TargetServiceTest` cases for CUT at 50kg/70kg/90kg bodyweights.
- Updated two existing tests (`compute_CutGoal_Subtracts500` → `compute_CutGoal_AppliesBodyweightRateDeficit`, and `compute_FemaleLightCut_MifflinFormula`) that hardcoded the old flat -500 math — both were verified arithmetically correct against the new formula and approved by the user since the old behavior is intentionally obsoleted by this issue.
- All other existing tests (BULK, MAINTAIN, Mifflin, macros, error cases, basal_kcal override, asOfDate) are untouched, verified via tdd-test-guardian agent review.

Closes #204

## Test plan
- [x] `./gradlew :nutrition:test --tests TargetServiceTest` passes
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes with zero warnings
- [x] Full `:nutrition:test` run — only pre-existing Docker/Testcontainers-dependent failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)