### PR TITLE
feat(nutrition): add CROSS_TRAINER sport activity type

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/SportActivityDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/SportActivityDTO.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  *
  * @param id           server-assigned unique identifier
  * @param entryDate    the date this activity belongs to
- * @param activityType the activity category (RUNNING, SWIMMING, CYCLING, WALKING, STRENGTH_TRAINING, OTHER)
+ * @param activityType the activity category (RUNNING, SWIMMING, CYCLING, WALKING, STRENGTH_TRAINING, CROSS_TRAINER, OTHER)
  * @param description  free-text label, required when {@code activityType} is OTHER
  * @param kcalBurned   kilocalories burned during the activity
  */

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityType.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/SportActivityType.java
@@ -12,6 +12,8 @@ public enum SportActivityType {
     WALKING,
     /** Resistance or weight training activity. */
     STRENGTH_TRAINING,
+    /** Cross trainer (elliptical) activity. */
+    CROSS_TRAINER,
     /** Any other activity type not covered above. */
     OTHER
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/SportActivityWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/SportActivityWriteServiceTest.java
@@ -87,6 +87,34 @@ class SportActivityWriteServiceTest {
     }
 
     @Test
+    @DisplayName("createActivity persists a CROSS_TRAINER activity without requiring a description")
+    void createActivity_CrossTrainerType_PersistsWithoutDescription() {
+        final CreateSportActivityRequest req =
+                new CreateSportActivityRequest(SportActivityType.CROSS_TRAINER, null, new BigDecimal("250.00"));
+
+        final SportActivityEntity saved = new SportActivityEntity();
+        saved.setEntryDate(today);
+        saved.setActivityType(SportActivityType.CROSS_TRAINER);
+        saved.setKcalBurned(new BigDecimal("250.00"));
+
+        final SportActivityDTO dto = new SportActivityDTO(
+                activityId, today, SportActivityType.CROSS_TRAINER, null, new BigDecimal("250.00")
+        );
+
+        when(sportActivityRepository.save(any(SportActivityEntity.class))).thenReturn(saved);
+        when(sportActivityMapper.toDTO(saved)).thenReturn(dto);
+
+        final SportActivityDTO result = sportActivityWriteService.createActivity(today, req);
+
+        assertEquals(dto, result);
+        verify(sportActivityRepository).save(argThat(e ->
+                SportActivityType.CROSS_TRAINER.equals(e.getActivityType())
+                        && today.equals(e.getEntryDate())
+                        && new BigDecimal("250.00").compareTo(e.getKcalBurned()) == 0
+        ));
+    }
+
+    @Test
     @DisplayName("createActivity persists an OTHER activity when description is supplied")
     void createActivity_OtherTypeWithDescription_Persists() {
         final CreateSportActivityRequest req =


### PR DESCRIPTION
## Summary
- The frontend added a "Crosstrainer" activity option, but the backend's `SportActivityType` enum was missing it, which would reject any such activity at validation/deserialization.
- Added `CROSS_TRAINER` to the enum (persisted as `EnumType.STRING`, so purely additive — no migration needed).

## Test plan
- [x] Added a failing-first unit test (`createActivity_CrossTrainerType_PersistsWithoutDescription`) exercising the new type, confirmed it failed before the enum change and passes after
- [x] `./gradlew :nutrition:test` — 262/262 runnable tests pass (2 unrelated Testcontainers tests fail locally due to no Docker access in this sandbox)
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — clean