### PR TITLE
Add read-only meal-plan endpoint to nutrition module

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
@@ -1,0 +1,55 @@
+package com.marvin.nutrition.controller;
+
+import com.marvin.nutrition.dto.MealPlanDTO;
+import com.marvin.nutrition.service.MealPlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller serving the static weekly meal-plan reference document.
+ * This is read-only content bundled with the application, not user-editable data.
+ */
+@RestController
+@RequestMapping("/nutrition/meal-plan")
+@Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
+public class MealPlanController {
+
+    private final MealPlanService mealPlanService;
+
+    /**
+     * Creates a new MealPlanController.
+     *
+     * @param mealPlanService the service serving the bundled meal-plan document
+     */
+    public MealPlanController(MealPlanService mealPlanService) {
+        this.mealPlanService = mealPlanService;
+    }
+
+    /**
+     * Returns the static weekly meal-plan reference document.
+     *
+     * @return a Mono emitting the meal-plan DTO
+     */
+    @GetMapping
+    @Operation(
+            summary = "Get the weekly meal plan",
+            description = "Returns the static weekly meal-plan reference document, including the shopping list.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal plan returned",
+                        content = @Content(schema = @Schema(implementation = MealPlanDTO.class))
+                )
+            }
+    )
+    public Mono<MealPlanDTO> getMealPlan() {
+        return mealPlanService.getMealPlan();
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanChangelogEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanChangelogEntryDTO.java
@@ -1,0 +1,24 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a single changelog entry describing a change compared to the previous
+ * plan version.
+ *
+ * @param tag  short label identifying what changed
+ * @param was  the previous value, or {@code null} if this is a newly introduced item
+ * @param text description of the change
+ */
+@Schema(description = "A changelog entry describing a change compared to the previous plan version")
+public record MealPlanChangelogEntryDTO(
+        @Schema(description = "Short label identifying what changed", example = "Whey")
+        String tag,
+
+        @Schema(description = "Previous value, absent if this is a newly introduced item", example = "80 g/Tag (2×40 g)")
+        String was,
+
+        @Schema(description = "Description of the change")
+        String text
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanDTO.java
@@ -1,0 +1,44 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing the static weekly meal-plan reference document.
+ *
+ * @param eyebrow      small label shown above the title
+ * @param title        document title
+ * @param description  short description of the plan's goal and approach
+ * @param stats        headline daily budget statistics
+ * @param changelog    list of changes compared to the previous plan version
+ * @param sections     the plan's daily/weekly meal sections
+ * @param shoppingList the weekly shopping list
+ * @param footer       closing note and data sources
+ */
+@Schema(description = "The static weekly meal-plan reference document")
+public record MealPlanDTO(
+        @Schema(description = "Small label shown above the title", example = "Version 2 — abgeglichen mit Tracking & Lebensmitteldatenbank")
+        String eyebrow,
+
+        @Schema(description = "Document title", example = "Ernährungsplan & Einkaufsliste")
+        String title,
+
+        @Schema(description = "Short description of the plan's goal and approach")
+        String description,
+
+        @Schema(description = "Headline daily budget statistics")
+        List<MealPlanStatDTO> stats,
+
+        @Schema(description = "Changes compared to the previous plan version")
+        List<MealPlanChangelogEntryDTO> changelog,
+
+        @Schema(description = "The plan's daily/weekly meal sections")
+        List<MealPlanSectionDTO> sections,
+
+        @Schema(description = "The weekly shopping list")
+        MealPlanShoppingListDTO shoppingList,
+
+        @Schema(description = "Closing note and data sources")
+        MealPlanFooterDTO footer
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanFooterDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanFooterDTO.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing the meal plan's closing footer.
+ *
+ * @param note    closing note explaining where the nutritional data comes from
+ * @param sources external sources consulted for data not already present in the tracking database
+ */
+@Schema(description = "The meal plan's closing footer")
+public record MealPlanFooterDTO(
+        @Schema(description = "Closing note explaining where the nutritional data comes from")
+        String note,
+
+        @Schema(description = "External sources consulted for data not already present in the tracking database")
+        List<MealPlanSourceDTO> sources
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanRowDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanRowDTO.java
@@ -1,0 +1,31 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a single meal row within a meal plan section.
+ *
+ * @param meal    the meal's name
+ * @param details description of the meal's ingredients
+ * @param qty     quantities of the ingredients as a display string
+ * @param kcal    kilocalories as a display string
+ * @param protein grams of protein as a display string
+ */
+@Schema(description = "A single meal row within a meal plan section")
+public record MealPlanRowDTO(
+        @Schema(description = "Meal name", example = "Frühstück")
+        String meal,
+
+        @Schema(description = "Description of the meal's ingredients")
+        String details,
+
+        @Schema(description = "Quantities of the ingredients as a display string", example = "90g/200ml/20g/100g/50g/10g/1 Stk")
+        String qty,
+
+        @Schema(description = "Kilocalories as a display string", example = "663")
+        String kcal,
+
+        @Schema(description = "Grams of protein as a display string", example = "46,5 g")
+        String protein
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
@@ -1,0 +1,33 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing a single section of the meal plan, e.g. a daily structure or a
+ * group of weekdays sharing the same meals.
+ *
+ * @param title   the section's title
+ * @param note    short note describing the section
+ * @param rows    the meal rows making up this section
+ * @param totals  the section's totals row, or {@code null} if not applicable
+ * @param callout optional explanatory callout text, or {@code null} if none
+ */
+@Schema(description = "A single section of the meal plan")
+public record MealPlanSectionDTO(
+        @Schema(description = "Section title", example = "1 · Tagesstruktur (täglich gleich)")
+        String title,
+
+        @Schema(description = "Short note describing the section", example = "Frühstück & Nachmittag identisch an allen 7 Tagen")
+        String note,
+
+        @Schema(description = "Meal rows making up this section")
+        List<MealPlanRowDTO> rows,
+
+        @Schema(description = "Section totals row, absent if not applicable")
+        MealPlanTotalsDTO totals,
+
+        @Schema(description = "Optional explanatory callout text, absent if none")
+        String callout
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingCategoryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingCategoryDTO.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing a single category on the shopping list, e.g. "Fleisch & Fisch".
+ *
+ * @param title the category's title
+ * @param items the items in this category
+ */
+@Schema(description = "A single category on the shopping list")
+public record MealPlanShoppingCategoryDTO(
+        @Schema(description = "Category title", example = "Fleisch & Fisch")
+        String title,
+
+        @Schema(description = "Items in this category")
+        List<MealPlanShoppingItemDTO> items
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingItemDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingItemDTO.java
@@ -1,0 +1,31 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a single item on the shopping list.
+ *
+ * @param name      the item's name
+ * @param brand     brand or sourcing note, or {@code null} if none
+ * @param badge     badge severity, either {@code "ok"} or {@code "warn"}, or {@code null} if none
+ * @param badgeText text shown alongside the badge, or {@code null} if none
+ * @param qty       quantity to buy as a display string
+ */
+@Schema(description = "A single item on the shopping list")
+public record MealPlanShoppingItemDTO(
+        @Schema(description = "Item name", example = "Hähnchenbrustfilet")
+        String name,
+
+        @Schema(description = "Brand or sourcing note, absent if none", example = "frisch, Kühltheke")
+        String brand,
+
+        @Schema(description = "Badge severity, absent if none", example = "warn", allowableValues = {"ok", "warn"})
+        String badge,
+
+        @Schema(description = "Text shown alongside the badge, absent if none", example = "nur 1.200 g verfügbar")
+        String badgeText,
+
+        @Schema(description = "Quantity to buy as a display string", example = "1.200 g")
+        String qty
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingListDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingListDTO.java
@@ -1,0 +1,28 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing the weekly shopping list.
+ *
+ * @param title      the shopping list's title
+ * @param note       short note describing the shopping list's scope
+ * @param categories the categories making up the shopping list
+ * @param callout    optional explanatory callout text
+ */
+@Schema(description = "The weekly shopping list")
+public record MealPlanShoppingListDTO(
+        @Schema(description = "Shopping list title", example = "4 · Einkaufsliste für Lidl (1 Woche)")
+        String title,
+
+        @Schema(description = "Short note describing the shopping list's scope", example = "4× Kantine Mo–Do · 3× Selbstkochen Fr–So · 40 g Whey/Tag")
+        String note,
+
+        @Schema(description = "Categories making up the shopping list")
+        List<MealPlanShoppingCategoryDTO> categories,
+
+        @Schema(description = "Optional explanatory callout text")
+        String callout
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSourceDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSourceDTO.java
@@ -1,0 +1,19 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a single external data source referenced by the meal plan.
+ *
+ * @param label display label of the source
+ * @param url   link to the source
+ */
+@Schema(description = "A single external data source referenced by the meal plan")
+public record MealPlanSourceDTO(
+        @Schema(description = "Display label of the source", example = "Magerquark (Milbona/Milsani, fatsecret.de)")
+        String label,
+
+        @Schema(description = "Link to the source", example = "https://www.fatsecret.de/Kalorien-Ern%C3%A4hrung/milsani/magerquark/100g")
+        String url
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanStatDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanStatDTO.java
@@ -1,0 +1,19 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a single headline statistic shown in the meal plan's summary bar.
+ *
+ * @param label the statistic's label
+ * @param value the statistic's display value
+ */
+@Schema(description = "A headline statistic shown in the meal plan's summary bar")
+public record MealPlanStatDTO(
+        @Schema(description = "Statistic label", example = "Tagesbudget (Ø)")
+        String label,
+
+        @Schema(description = "Statistic display value", example = "2.416 kcal")
+        String value
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanTotalsDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanTotalsDTO.java
@@ -1,0 +1,23 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing the totals row of a meal plan section.
+ *
+ * @param label   the totals row's label
+ * @param kcal    total kilocalories as a display string
+ * @param protein total grams of protein as a display string
+ */
+@Schema(description = "The totals row of a meal plan section")
+public record MealPlanTotalsDTO(
+        @Schema(description = "Totals row label", example = "Tagesgesamt")
+        String label,
+
+        @Schema(description = "Total kilocalories as a display string", example = "2.407 kcal")
+        String kcal,
+
+        @Schema(description = "Total grams of protein as a display string", example = "182,2 g")
+        String protein
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanService.java
@@ -1,0 +1,49 @@
+package com.marvin.nutrition.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.MealPlanDTO;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * Serves the static weekly meal-plan reference document bundled as a classpath resource.
+ * The document is not user-editable data, so it is parsed once and cached in memory rather than
+ * being persisted in the database.
+ */
+@Service
+public class MealPlanService {
+
+    private static final String MEAL_PLAN_RESOURCE = "nutrition/meal-plan.json";
+
+    private final MealPlanDTO mealPlan;
+
+    /**
+     * Creates a new MealPlanService, eagerly loading and parsing the bundled meal-plan resource.
+     *
+     * @param objectMapper Jackson mapper used to parse the bundled JSON resource
+     */
+    public MealPlanService(ObjectMapper objectMapper) {
+        this.mealPlan = readMealPlan(objectMapper);
+    }
+
+    /**
+     * Returns the weekly meal-plan reference document.
+     *
+     * @return a Mono emitting the cached meal-plan DTO
+     */
+    public Mono<MealPlanDTO> getMealPlan() {
+        return Mono.just(mealPlan);
+    }
+
+    private MealPlanDTO readMealPlan(ObjectMapper objectMapper) {
+        try (InputStream inputStream = new ClassPathResource(MEAL_PLAN_RESOURCE).getInputStream()) {
+            return objectMapper.readValue(inputStream, MealPlanDTO.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load bundled meal-plan resource: " + MEAL_PLAN_RESOURCE, e);
+        }
+    }
+}

--- a/nutrition/src/main/resources/nutrition/meal-plan.json
+++ b/nutrition/src/main/resources/nutrition/meal-plan.json
@@ -1,0 +1,96 @@
+{
+  "eyebrow": "Version 2 — abgeglichen mit Tracking & Lebensmitteldatenbank",
+  "title": "Ernährungsplan & Einkaufsliste",
+  "description": "Fettabbau & Muskelerhalt (Cut) · Whey reduziert, Magerquark als Hauptproteinquelle, Ei kontrolliert statt ad-hoc.",
+  "stats": [
+    {"label": "Tagesbudget (Ø)", "value": "2.416 kcal"},
+    {"label": "Protein", "value": "~184 g"},
+    {"label": "Kohlenhydrate", "value": "~291 g"},
+    {"label": "Fett", "value": "~52 g"}
+  ],
+  "changelog": [
+    {"tag": "Whey", "was": "80 g/Tag (2×40 g)", "text": "→ 40 g/Tag (je 20 g zu Frühstück & Nachmittagssnack) — halbiert, wie gewünscht."},
+    {"tag": "Magerquark", "was": null, "text": "neu: 300 g/Tag (100 g Frühstück + 200 g Nachmittag) übernimmt den Proteinanteil, den der Whey abgibt."},
+    {"tag": "Ei", "was": null, "text": "fest auf 1 Ei/Tag im Frühstück begrenzt, statt wie im Tracking unregelmäßig 1–2 Eier über mehrere Mahlzeiten verteilt."},
+    {"tag": "Korrektur", "was": null, "text": "Abendessen ist an allen 7 Tagen identisch berechnet. Der alte Plan hatte für dieselbe Zutatenliste zwei unterschiedliche Werte (858 vs. 926 kcal) — das war ein Rechenfehler, nicht real erreichbar."},
+    {"tag": "Olivenöl", "was": null, "text": "10 g neu bei Mittag (Wochenende) & Abendessen ausgewiesen, um das Fettziel realistisch zu erreichen, statt es implizit wegzulassen."},
+    {"tag": "Hähnchen-Engpass", "was": null, "text": "nur 1.200 g statt 1.400 g Hähnchenbrust verfügbar → Portion beim Abendessen auf 170 g/Tag reduziert (statt 200 g). Ausgleich über +50 g Magerquark im Nachmittagssnack (150 g → 200 g), das deckt den Protein- & Kalorienverlust fast exakt — Wochenschnitt bleibt praktisch unverändert."}
+  ],
+  "sections": [
+    {
+      "title": "1 · Tagesstruktur (täglich gleich)",
+      "note": "Frühstück & Nachmittag identisch an allen 7 Tagen",
+      "rows": [
+        {"meal": "Frühstück", "details": "Haferflocken, Haferdrink, Whey, Magerquark, TK-Himbeeren, Mandeln, Ei", "qty": "90g/200ml/20g/100g/50g/10g/1 Stk", "kcal": "663", "protein": "46,5 g"},
+        {"meal": "Nachmittag", "details": "Whey, Magerquark, Banane", "qty": "20g/200g/1 Stk", "kcal": "314", "protein": "40,3 g"}
+      ],
+      "totals": null,
+      "callout": "Der Whey-Shake wird jetzt kleiner (20 g statt 40 g) und durch Magerquark ergänzt — pro 100 g liefert Magerquark 12 g Protein bei nur 66 kcal und 0,2 g Fett, macht das Cut-Ziel also nicht teurer. Das Ei ersetzt keine der bisherigen Proteinquellen, sondern deckelt den Konsum bewusst auf eine Portion täglich. Die Nachmittags-Portion Magerquark ist bewusst größer als rechnerisch nötig (200 g statt 150 g) — das federt den Hähnchen-Engpass beim Abendessen ab."
+    },
+    {
+      "title": "2 · Wochentage (Montag – Donnerstag)",
+      "note": "Kantine am Mittag bleibt Richtwert",
+      "rows": [
+        {"meal": "Frühstück", "details": "siehe Tagesstruktur", "qty": "—", "kcal": "663", "protein": "46,5 g"},
+        {"meal": "Mittag (Kantine)", "details": "Mageres Protein, komplexe Carbs, Gemüse (Richtwert)", "qty": "1 Portion", "kcal": "650", "protein": "40,0 g"},
+        {"meal": "Nachmittag", "details": "siehe Tagesstruktur", "qty": "—", "kcal": "314", "protein": "40,3 g"},
+        {"meal": "Abendessen", "details": "Hähnchenbrustfilet, Dinkel-Penne, Kaisergemüse, Olivenöl", "qty": "170g/120g/200g/10g", "kcal": "779", "protein": "55,4 g"}
+      ],
+      "totals": {"label": "Tagesgesamt", "kcal": "2.407 kcal", "protein": "182,2 g"},
+      "callout": null
+    },
+    {
+      "title": "3 · Wochenende (Freitag – Sonntag)",
+      "note": "Mittag wird selbst zubereitet",
+      "rows": [
+        {"meal": "Frühstück", "details": "siehe Tagesstruktur", "qty": "—", "kcal": "663", "protein": "46,5 g"},
+        {"meal": "Mittagessen", "details": "Rinderhüftsteak, Basmatireis, Kaisergemüse, Olivenöl", "qty": "145g/100g/200g/10g", "kcal": "672", "protein": "44,3 g"},
+        {"meal": "Nachmittag", "details": "siehe Tagesstruktur", "qty": "—", "kcal": "314", "protein": "40,3 g"},
+        {"meal": "Abendessen", "details": "Hähnchenbrustfilet, Dinkel-Penne, Kaisergemüse, Olivenöl", "qty": "170g/120g/200g/10g", "kcal": "779", "protein": "55,4 g"}
+      ],
+      "totals": {"label": "Tagesgesamt", "kcal": "2.429 kcal", "protein": "186,4 g"},
+      "callout": "Zielabweichung über die Woche: im Schnitt 2.416 kcal / 184,0 g Protein / 291,0 g Kohlenhydrate / 52,3 g Fett gegen ein Ziel von 2.422 kcal / 188 g / 296 g / 54 g — trotz reduzierter Hähnchenmenge weiterhin unter 2 % Abweichung, dank der Magerquark-Kompensation."
+    }
+  ],
+  "shoppingList": {
+    "title": "4 · Einkaufsliste für Lidl (1 Woche)",
+    "note": "4× Kantine Mo–Do · 3× Selbstkochen Fr–So · 40 g Whey/Tag",
+    "categories": [
+      {"title": "Fleisch & Fisch", "items": [
+        {"name": "Hähnchenbrustfilet", "brand": "frisch, Kühltheke", "badge": "warn", "badgeText": "nur 1.200 g verfügbar", "qty": "1.200 g"},
+        {"name": "Frisches Rinderhüftsteak", "brand": "Lidl", "badge": null, "badgeText": null, "qty": "435 g"}
+      ]},
+      {"title": "Milchprodukte & Eier", "items": [
+        {"name": "Magerquark", "brand": "Milbona (Lidl), 4× 500 g + 1× 250 g Tuben", "badge": null, "badgeText": null, "qty": "2.100 g"},
+        {"name": "Eier", "brand": "10er-Packung", "badge": null, "badgeText": null, "qty": "7 Stk"}
+      ]},
+      {"title": "Proteinpulver", "items": [
+        {"name": "Whey Protein Konzentrat Erdbeere", "brand": "Rühls Bestes", "badge": "warn", "badgeText": "nicht bei Lidl", "qty": "280 g"}
+      ]},
+      {"title": "Gemüse & Obst (TK & frisch)", "items": [
+        {"name": "Kaisergemüse TK", "brand": "Freshona (Lidl)", "badge": null, "badgeText": null, "qty": "2.000 g"},
+        {"name": "TK-Himbeeren", "brand": "Freshona (Lidl)", "badge": null, "badgeText": null, "qty": "350 g"},
+        {"name": "Bananen", "brand": "frisch", "badge": null, "badgeText": null, "qty": "7 Stk"}
+      ]},
+      {"title": "Kohlenhydrate & Getreide", "items": [
+        {"name": "Haferflocken", "brand": "Bio Hafervollkornflocken Kleinblatt, Lidl", "badge": null, "badgeText": null, "qty": "630 g"},
+        {"name": "Dinkel-Penne", "brand": "Bio, Lidl/Bioland", "badge": null, "badgeText": null, "qty": "840 g"},
+        {"name": "Basmatireis", "brand": "Lidl, roh", "badge": null, "badgeText": null, "qty": "300 g"}
+      ]},
+      {"title": "Fette, Nüsse & Drinks", "items": [
+        {"name": "Olivenöl", "brand": "Lidl", "badge": null, "badgeText": null, "qty": "100 ml"},
+        {"name": "Mandeln, blanchiert & gehackt", "brand": "Alesto (Lidl)", "badge": null, "badgeText": null, "qty": "70 g"},
+        {"name": "Bio Haferdrink", "brand": "Lidl, 2 Packungen", "badge": null, "badgeText": null, "qty": "1,4 L"}
+      ]}
+    ],
+    "callout": "Whey Protein wird bei Lidl nicht durchgängig geführt — separat online oder in der Drogerie besorgen. Alle anderen Positionen entsprechen den Produkten, die bereits im Tracking als Lidl-Artikel hinterlegt sind (Freshona, Milbona, Alesto, Bio-Eigenmarken); Basmatireis- und Magerquark-Nährwerte wurden ergänzend recherchiert, da sie bisher nicht im Tracking vorkamen."
+  },
+  "footer": {
+    "note": "Nährwerte für Haferflocken, Haferdrink, Whey, Himbeeren, Hähnchenbrust, Rinderhüftsteak, Dinkel-Penne, Kaisergemüse und Ei stammen aus der bestehenden Lebensmitteldatenbank des Nutrition-Trackings. Magerquark, Basmatireis und Banane waren dort nicht erfasst und wurden recherchiert:",
+    "sources": [
+      {"label": "Magerquark (Milbona/Milsani, fatsecret.de)", "url": "https://www.fatsecret.de/Kalorien-Ern%C3%A4hrung/milsani/magerquark/100g"},
+      {"label": "Basmatireis Lidl, roh (fatsecret.de)", "url": "https://www.fatsecret.de/Kalorien-Ern%C3%A4hrung/lidl/basmati-reis/100g"},
+      {"label": "Banane, frisch (yazio.com)", "url": "https://www.yazio.com/de/kalorientabelle/banane-frisch.html"}
+    ]
+  }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
@@ -1,0 +1,66 @@
+package com.marvin.nutrition.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealPlanDTO;
+import com.marvin.nutrition.dto.MealPlanFooterDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingListDTO;
+import com.marvin.nutrition.service.MealPlanService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealPlanController} covering the read-only meal-plan endpoint. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanController Tests")
+class MealPlanControllerTest {
+
+    @Mock
+    private MealPlanService mealPlanService;
+
+    @InjectMocks
+    private MealPlanController mealPlanController;
+
+    private MealPlanDTO mealPlanDTO;
+
+    /** Sets up shared fixtures for each test. */
+    @BeforeEach
+    void setUp() {
+        final MealPlanShoppingListDTO shoppingList = new MealPlanShoppingListDTO(
+                "4 · Einkaufsliste für Lidl (1 Woche)", "note", List.of(), null
+        );
+        final MealPlanFooterDTO footer = new MealPlanFooterDTO("note", List.of());
+
+        mealPlanDTO = new MealPlanDTO(
+                "Version 2", "Ernährungsplan & Einkaufsliste", "description",
+                List.of(), List.of(), List.of(), shoppingList, footer
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /nutrition/meal-plan
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getMealPlan returns 200 with the meal plan document")
+    void getMealPlan_Returns200WithMealPlan() {
+        when(mealPlanService.getMealPlan()).thenReturn(Mono.just(mealPlanDTO));
+
+        final Mono<MealPlanDTO> result = mealPlanController.getMealPlan();
+
+        StepVerifier.create(result)
+                .assertNext(dto -> assertEquals("Ernährungsplan & Einkaufsliste", dto.title()))
+                .verifyComplete();
+
+        verify(mealPlanService).getMealPlan();
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
@@ -1,0 +1,87 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.MealPlanDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link MealPlanService} covering loading and parsing of the bundled meal-plan resource. */
+@DisplayName("MealPlanService Tests")
+class MealPlanServiceTest {
+
+    private final MealPlanService mealPlanService = new MealPlanService(new ObjectMapper());
+
+    // -----------------------------------------------------------------------
+    // getMealPlan
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getMealPlan loads the bundled meal-plan resource with correct title")
+    void getMealPlan_ReturnsMealPlanWithCorrectTitle() {
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> assertEquals("Ernährungsplan & Einkaufsliste", dto.title()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns four stats with the expected labels and values")
+    void getMealPlan_ReturnsFourStats() {
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> {
+                    assertEquals(4, dto.stats().size());
+                    assertEquals("Tagesbudget (Ø)", dto.stats().get(0).label());
+                    assertEquals("2.416 kcal", dto.stats().get(0).value());
+                    assertEquals("Protein", dto.stats().get(1).label());
+                    assertEquals("~184 g", dto.stats().get(1).value());
+                    assertEquals("Kohlenhydrate", dto.stats().get(2).label());
+                    assertEquals("~291 g", dto.stats().get(2).value());
+                    assertEquals("Fett", dto.stats().get(3).label());
+                    assertEquals("~52 g", dto.stats().get(3).value());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns three sections")
+    void getMealPlan_ReturnsThreeSections() {
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> assertEquals(3, dto.sections().size()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns six shopping list categories")
+    void getMealPlan_ReturnsSixShoppingCategories() {
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> assertEquals(6, dto.shoppingList().categories().size()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns at least one shopping item with a non-null badge")
+    void getMealPlan_ReturnsAtLeastOneItemWithBadge() {
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> {
+                    final boolean hasBadge = dto.shoppingList().categories().stream()
+                            .flatMap(category -> category.items().stream())
+                            .map(MealPlanShoppingItemDTO::badge)
+                            .anyMatch(badge -> badge != null);
+                    assertTrue(hasBadge);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns the same cached DTO instance on repeated calls")
+    void getMealPlan_ReturnsCachedInstanceOnRepeatedCalls() {
+        final MealPlanDTO first = mealPlanService.getMealPlan().block();
+        final MealPlanDTO second = mealPlanService.getMealPlan().block();
+
+        assertEquals(first, second);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `GET /nutrition/meal-plan` endpoint serving a fixed weekly diet-plan reference document (the user's personal meal plan, pasted from an external note).
- Content is bundled as a static classpath JSON resource (`nutrition/src/main/resources/nutrition/meal-plan.json`) rather than modeled as JPA entities/Flyway migrations, since it is not user-editable data.
- New `MealPlanService` loads and parses the resource once (via the existing Jackson `ObjectMapper` bean) and caches the resulting DTO, exposing it as `Mono<MealPlanDTO>`.
- New `MealPlanController` exposes the endpoint following the same controller conventions (Springdoc annotations, `Mono<>` return type) as the module's other controllers.
- New nested record DTOs in `com.marvin.nutrition.dto` (`MealPlanDTO`, `MealPlanStatDTO`, `MealPlanChangelogEntryDTO`, `MealPlanSectionDTO`, `MealPlanRowDTO`, `MealPlanTotalsDTO`, `MealPlanShoppingListDTO`, `MealPlanShoppingCategoryDTO`, `MealPlanShoppingItemDTO`, `MealPlanFooterDTO`, `MealPlanSourceDTO`), all with `@Schema` annotations matching the existing `MealTemplateDTO` style.

## Test plan
- [x] `MealPlanServiceTest` — verifies the bundled resource loads/parses correctly (title, 4 stats, 3 sections, 6 shopping categories, at least one item with a non-null badge) and that the DTO is cached across calls.
- [x] `MealPlanControllerTest` — verifies `GET /nutrition/meal-plan` delegates to the service and returns the expected DTO, following the `MealTemplateControllerTest` Mockito pattern.
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes cleanly.
- [x] `./gradlew :nutrition:test` — new tests pass; the only failures are pre-existing `SportActivityRepositoryTest` / `MealTemplateRepositoryTest` testcontainers failures caused by this sandbox not being able to fetch containers for Docker-based repository tests (reproduced identically on `master`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)