### PR TITLE
Move nutrition meal-plan content from classpath JSON into DB

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanChangelogEntryEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanChangelogEntryEntity.java
@@ -1,0 +1,55 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single changelog entry describing a change compared to the previous plan version. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_changelog_entry", schema = "nutrition")
+public class MealPlanChangelogEntryEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_id", nullable = false)
+    private Long mealPlanId;
+
+    @Column(name = "tag", nullable = false, length = 255)
+    private String tag;
+
+    @Column(name = "was", length = 500)
+    private String was;
+
+    @Column(name = "entry_text", nullable = false)
+    private String text;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanChangelogEntryEntity that = (MealPlanChangelogEntryEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanEntity.java
@@ -1,0 +1,60 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing the singleton header row of the weekly meal-plan reference document. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan", schema = "nutrition")
+public class MealPlanEntity extends BasicEntity {
+
+    /** Fixed identifier of the single meal-plan row, enforced by a DB-level CHECK constraint. */
+    public static final long SINGLETON_ID = 1L;
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "eyebrow", nullable = false, length = 500)
+    private String eyebrow;
+
+    @Column(name = "title", nullable = false, length = 500)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "shopping_list_title", nullable = false, length = 500)
+    private String shoppingListTitle;
+
+    @Column(name = "shopping_list_note", nullable = false, length = 500)
+    private String shoppingListNote;
+
+    @Column(name = "shopping_list_callout")
+    private String shoppingListCallout;
+
+    @Column(name = "footer_note", nullable = false)
+    private String footerNote;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanEntity that = (MealPlanEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanRowEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanRowEntity.java
@@ -1,0 +1,61 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single meal row within a {@link MealPlanSectionEntity}. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_row", schema = "nutrition")
+public class MealPlanRowEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_section_id", nullable = false)
+    private UUID mealPlanSectionId;
+
+    @Column(name = "meal", nullable = false, length = 255)
+    private String meal;
+
+    @Column(name = "details", nullable = false)
+    private String details;
+
+    @Column(name = "qty", nullable = false, length = 255)
+    private String qty;
+
+    @Column(name = "kcal", nullable = false, length = 255)
+    private String kcal;
+
+    @Column(name = "protein", nullable = false, length = 255)
+    private String protein;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanRowEntity that = (MealPlanRowEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSectionEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSectionEntity.java
@@ -1,0 +1,64 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single section of the meal plan, e.g. a daily structure or a group of weekdays. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_section", schema = "nutrition")
+public class MealPlanSectionEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_id", nullable = false)
+    private Long mealPlanId;
+
+    @Column(name = "title", nullable = false, length = 500)
+    private String title;
+
+    @Column(name = "note", nullable = false, length = 500)
+    private String note;
+
+    @Column(name = "totals_label", length = 255)
+    private String totalsLabel;
+
+    @Column(name = "totals_kcal", length = 255)
+    private String totalsKcal;
+
+    @Column(name = "totals_protein", length = 255)
+    private String totalsProtein;
+
+    @Column(name = "callout")
+    private String callout;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanSectionEntity that = (MealPlanSectionEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanShoppingCategoryEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanShoppingCategoryEntity.java
@@ -1,0 +1,49 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single category on the shopping list, e.g. "Fleisch & Fisch". */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_shopping_category", schema = "nutrition")
+public class MealPlanShoppingCategoryEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_id", nullable = false)
+    private Long mealPlanId;
+
+    @Column(name = "title", nullable = false, length = 500)
+    private String title;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanShoppingCategoryEntity that = (MealPlanShoppingCategoryEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanShoppingItemEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanShoppingItemEntity.java
@@ -1,0 +1,61 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single item on the shopping list within a {@link MealPlanShoppingCategoryEntity}. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_shopping_item", schema = "nutrition")
+public class MealPlanShoppingItemEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_shopping_category_id", nullable = false)
+    private UUID mealPlanShoppingCategoryId;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "brand", length = 500)
+    private String brand;
+
+    @Column(name = "badge", length = 10)
+    private String badge;
+
+    @Column(name = "badge_text", length = 500)
+    private String badgeText;
+
+    @Column(name = "qty", nullable = false, length = 255)
+    private String qty;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanShoppingItemEntity that = (MealPlanShoppingItemEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSourceEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSourceEntity.java
@@ -1,0 +1,52 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single external data source referenced by the meal plan's footer. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_source", schema = "nutrition")
+public class MealPlanSourceEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_id", nullable = false)
+    private Long mealPlanId;
+
+    @Column(name = "label", nullable = false, length = 500)
+    private String label;
+
+    @Column(name = "url", nullable = false, length = 1000)
+    private String url;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanSourceEntity that = (MealPlanSourceEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanStatEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanStatEntity.java
@@ -1,0 +1,52 @@
+package com.marvin.nutrition.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a single headline statistic shown in the meal plan's summary bar. */
+@Getter
+@Setter
+@Entity
+@Table(name = "meal_plan_stat", schema = "nutrition")
+public class MealPlanStatEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "meal_plan_id", nullable = false)
+    private Long mealPlanId;
+
+    @Column(name = "label", nullable = false, length = 255)
+    private String label;
+
+    @Column(name = "value", nullable = false, length = 255)
+    private String value;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MealPlanStatEntity that = (MealPlanStatEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/mapper/MealPlanMapper.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/mapper/MealPlanMapper.java
@@ -1,0 +1,141 @@
+package com.marvin.nutrition.mapper;
+
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.dto.MealPlanTotalsDTO;
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/** MapStruct mapper converting meal-plan entities into their corresponding DTOs. */
+@Mapper(componentModel = "spring")
+public interface MealPlanMapper {
+
+    /**
+     * Maps a single headline statistic entity to its DTO representation.
+     *
+     * @param entity the stat entity to map
+     * @return the corresponding DTO
+     */
+    MealPlanStatDTO toStatDTO(MealPlanStatEntity entity);
+
+    /**
+     * Maps a list of headline statistic entities to their DTO representations.
+     *
+     * @param entities the stat entities to map
+     * @return the corresponding DTOs
+     */
+    List<MealPlanStatDTO> toStatDTOs(List<MealPlanStatEntity> entities);
+
+    /**
+     * Maps a single changelog entry entity to its DTO representation.
+     *
+     * @param entity the changelog entry entity to map
+     * @return the corresponding DTO
+     */
+    MealPlanChangelogEntryDTO toChangelogEntryDTO(MealPlanChangelogEntryEntity entity);
+
+    /**
+     * Maps a list of changelog entry entities to their DTO representations.
+     *
+     * @param entities the changelog entry entities to map
+     * @return the corresponding DTOs
+     */
+    List<MealPlanChangelogEntryDTO> toChangelogEntryDTOs(List<MealPlanChangelogEntryEntity> entities);
+
+    /**
+     * Maps a single meal row entity to its DTO representation.
+     *
+     * @param entity the row entity to map
+     * @return the corresponding DTO
+     */
+    MealPlanRowDTO toRowDTO(MealPlanRowEntity entity);
+
+    /**
+     * Maps a list of meal row entities to their DTO representations.
+     *
+     * @param entities the row entities to map
+     * @return the corresponding DTOs
+     */
+    List<MealPlanRowDTO> toRowDTOs(List<MealPlanRowEntity> entities);
+
+    /**
+     * Maps a single shopping item entity to its DTO representation.
+     *
+     * @param entity the shopping item entity to map
+     * @return the corresponding DTO
+     */
+    MealPlanShoppingItemDTO toShoppingItemDTO(MealPlanShoppingItemEntity entity);
+
+    /**
+     * Maps a list of shopping item entities to their DTO representations.
+     *
+     * @param entities the shopping item entities to map
+     * @return the corresponding DTOs
+     */
+    List<MealPlanShoppingItemDTO> toShoppingItemDTOs(List<MealPlanShoppingItemEntity> entities);
+
+    /**
+     * Maps a single footer source entity to its DTO representation.
+     *
+     * @param entity the source entity to map
+     * @return the corresponding DTO
+     */
+    MealPlanSourceDTO toSourceDTO(MealPlanSourceEntity entity);
+
+    /**
+     * Maps a list of footer source entities to their DTO representations.
+     *
+     * @param entities the source entities to map
+     * @return the corresponding DTOs
+     */
+    List<MealPlanSourceDTO> toSourceDTOs(List<MealPlanSourceEntity> entities);
+
+    /**
+     * Maps a section entity and its already-mapped rows to a section DTO, folding the entity's
+     * nullable totals columns into a nested {@link MealPlanTotalsDTO}.
+     *
+     * @param entity the section entity to map
+     * @param rows   the already-mapped rows belonging to this section
+     * @return the corresponding DTO
+     */
+    @Mapping(target = "rows", source = "rows")
+    @Mapping(target = "totals", expression = "java(toTotals(entity))")
+    MealPlanSectionDTO toSectionDTO(MealPlanSectionEntity entity, List<MealPlanRowDTO> rows);
+
+    /**
+     * Maps a shopping category entity and its already-mapped items to a shopping category DTO.
+     *
+     * @param entity the shopping category entity to map
+     * @param items  the already-mapped items belonging to this category
+     * @return the corresponding DTO
+     */
+    @Mapping(target = "items", source = "items")
+    MealPlanShoppingCategoryDTO toShoppingCategoryDTO(MealPlanShoppingCategoryEntity entity, List<MealPlanShoppingItemDTO> items);
+
+    /**
+     * Builds the section's nested totals DTO from its scalar totals columns, or {@code null} if the
+     * section has no totals row.
+     *
+     * @param entity the section entity
+     * @return the totals DTO, or {@code null} if {@code totalsLabel} is {@code null}
+     */
+    default MealPlanTotalsDTO toTotals(MealPlanSectionEntity entity) {
+        if (entity.getTotalsLabel() == null) {
+            return null;
+        }
+        return new MealPlanTotalsDTO(entity.getTotalsLabel(), entity.getTotalsKcal(), entity.getTotalsProtein());
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanChangelogEntryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanChangelogEntryRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanChangelogEntryEntity}. */
+@Repository
+public interface MealPlanChangelogEntryRepository extends JpaRepository<MealPlanChangelogEntryEntity, UUID> {
+
+    /**
+     * Returns all changelog entries belonging to the given meal plan, ordered by their display position.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return list of changelog entries ordered by sort order ascending
+     */
+    List<MealPlanChangelogEntryEntity> findAllByMealPlanIdOrderBySortOrderAsc(Long mealPlanId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanRepository.java
@@ -1,0 +1,10 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for the single-row meal-plan header. */
+@Repository
+public interface MealPlanRepository extends JpaRepository<MealPlanEntity, Long> {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanRowRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanRowRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanRowEntity}. */
+@Repository
+public interface MealPlanRowRepository extends JpaRepository<MealPlanRowEntity, UUID> {
+
+    /**
+     * Returns all rows belonging to the given meal plan section, ordered by their display position.
+     *
+     * @param mealPlanSectionId the id of the meal plan section
+     * @return list of rows ordered by sort order ascending
+     */
+    List<MealPlanRowEntity> findAllByMealPlanSectionIdOrderBySortOrderAsc(UUID mealPlanSectionId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanSectionRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanSectionRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanSectionEntity}. */
+@Repository
+public interface MealPlanSectionRepository extends JpaRepository<MealPlanSectionEntity, UUID> {
+
+    /**
+     * Returns all sections belonging to the given meal plan, ordered by their display position.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return list of sections ordered by sort order ascending
+     */
+    List<MealPlanSectionEntity> findAllByMealPlanIdOrderBySortOrderAsc(Long mealPlanId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanShoppingCategoryRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanShoppingCategoryRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanShoppingCategoryEntity}. */
+@Repository
+public interface MealPlanShoppingCategoryRepository extends JpaRepository<MealPlanShoppingCategoryEntity, UUID> {
+
+    /**
+     * Returns all shopping categories belonging to the given meal plan, ordered by their display position.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return list of shopping categories ordered by sort order ascending
+     */
+    List<MealPlanShoppingCategoryEntity> findAllByMealPlanIdOrderBySortOrderAsc(Long mealPlanId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanShoppingItemRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanShoppingItemRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanShoppingItemEntity}. */
+@Repository
+public interface MealPlanShoppingItemRepository extends JpaRepository<MealPlanShoppingItemEntity, UUID> {
+
+    /**
+     * Returns all items belonging to the given shopping category, ordered by their display position.
+     *
+     * @param mealPlanShoppingCategoryId the id of the shopping category
+     * @return list of items ordered by sort order ascending
+     */
+    List<MealPlanShoppingItemEntity> findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(UUID mealPlanShoppingCategoryId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanSourceRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanSourceRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanSourceEntity}. */
+@Repository
+public interface MealPlanSourceRepository extends JpaRepository<MealPlanSourceEntity, UUID> {
+
+    /**
+     * Returns all footer sources belonging to the given meal plan, ordered by their display position.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return list of sources ordered by sort order ascending
+     */
+    List<MealPlanSourceEntity> findAllByMealPlanIdOrderBySortOrderAsc(Long mealPlanId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanStatRepository.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/repository/MealPlanStatRepository.java
@@ -1,0 +1,20 @@
+package com.marvin.nutrition.repository;
+
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link MealPlanStatEntity}. */
+@Repository
+public interface MealPlanStatRepository extends JpaRepository<MealPlanStatEntity, UUID> {
+
+    /**
+     * Returns all stats belonging to the given meal plan, ordered by their display position.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return list of stats ordered by sort order ascending
+     */
+    List<MealPlanStatEntity> findAllByMealPlanIdOrderBySortOrderAsc(Long mealPlanId);
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionAssembler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionAssembler.java
@@ -1,0 +1,64 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanRowRepository;
+import com.marvin.nutrition.repository.MealPlanSectionRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/** Assembles the meal plan's ordered list of sections together with each section's ordered rows. */
+@Component
+public class MealPlanSectionAssembler {
+
+    private final MealPlanSectionRepository mealPlanSectionRepository;
+    private final MealPlanRowRepository mealPlanRowRepository;
+    private final MealPlanMapper mealPlanMapper;
+
+    /**
+     * Creates a new MealPlanSectionAssembler.
+     *
+     * @param mealPlanSectionRepository JPA repository for meal plan sections
+     * @param mealPlanRowRepository    JPA repository for meal plan rows
+     * @param mealPlanMapper           mapper for converting entities into DTOs
+     */
+    public MealPlanSectionAssembler(
+            MealPlanSectionRepository mealPlanSectionRepository,
+            MealPlanRowRepository mealPlanRowRepository,
+            MealPlanMapper mealPlanMapper) {
+        this.mealPlanSectionRepository = mealPlanSectionRepository;
+        this.mealPlanRowRepository = mealPlanRowRepository;
+        this.mealPlanMapper = mealPlanMapper;
+    }
+
+    /**
+     * Loads and assembles all sections of the given meal plan, each with its ordered rows.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return the ordered list of section DTOs
+     */
+    public List<MealPlanSectionDTO> assemble(Long mealPlanId) {
+        final List<MealPlanSectionEntity> sections =
+                mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId);
+        return sections.stream()
+                .map(this::toSectionDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads a section's rows and maps the section together with them to a DTO.
+     *
+     * @param section the section entity
+     * @return the assembled section DTO
+     */
+    private MealPlanSectionDTO toSectionDTO(MealPlanSectionEntity section) {
+        final List<MealPlanRowEntity> rowEntities =
+                mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(section.getId());
+        final List<MealPlanRowDTO> rows = mealPlanMapper.toRowDTOs(rowEntities);
+        return mealPlanMapper.toSectionDTO(section, rows);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanService.java
@@ -1,49 +1,108 @@
 package com.marvin.nutrition.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
 import com.marvin.nutrition.dto.MealPlanDTO;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import org.springframework.core.io.ClassPathResource;
+import com.marvin.nutrition.dto.MealPlanFooterDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingListDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.entity.MealPlanEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanChangelogEntryRepository;
+import com.marvin.nutrition.repository.MealPlanRepository;
+import com.marvin.nutrition.repository.MealPlanSourceRepository;
+import com.marvin.nutrition.repository.MealPlanStatRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
- * Serves the static weekly meal-plan reference document bundled as a classpath resource.
- * The document is not user-editable data, so it is parsed once and cached in memory rather than
- * being persisted in the database.
+ * Serves the weekly meal-plan reference document ("Ernährungsplan &amp; Einkaufsliste"), assembled
+ * from its normalized database tables. The content is read-only from this service's perspective;
+ * it is edited via database migrations, not through this API.
  */
 @Service
 public class MealPlanService {
 
-    private static final String MEAL_PLAN_RESOURCE = "nutrition/meal-plan.json";
-
-    private final MealPlanDTO mealPlan;
+    private final MealPlanRepository mealPlanRepository;
+    private final MealPlanStatRepository mealPlanStatRepository;
+    private final MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository;
+    private final MealPlanSourceRepository mealPlanSourceRepository;
+    private final MealPlanSectionAssembler mealPlanSectionAssembler;
+    private final MealPlanShoppingListAssembler mealPlanShoppingListAssembler;
+    private final MealPlanMapper mealPlanMapper;
 
     /**
-     * Creates a new MealPlanService, eagerly loading and parsing the bundled meal-plan resource.
+     * Creates a new MealPlanService with the required dependencies.
      *
-     * @param objectMapper Jackson mapper used to parse the bundled JSON resource
+     * @param mealPlanRepository               JPA repository for the meal-plan header
+     * @param mealPlanStatRepository            JPA repository for headline stats
+     * @param mealPlanChangelogEntryRepository  JPA repository for changelog entries
+     * @param mealPlanSourceRepository          JPA repository for footer sources
+     * @param mealPlanSectionAssembler          assembles sections together with their rows
+     * @param mealPlanShoppingListAssembler     assembles shopping categories together with their items
+     * @param mealPlanMapper                    MapStruct mapper for entity/DTO conversion
      */
-    public MealPlanService(ObjectMapper objectMapper) {
-        this.mealPlan = readMealPlan(objectMapper);
+    public MealPlanService(
+            MealPlanRepository mealPlanRepository,
+            MealPlanStatRepository mealPlanStatRepository,
+            MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository,
+            MealPlanSourceRepository mealPlanSourceRepository,
+            MealPlanSectionAssembler mealPlanSectionAssembler,
+            MealPlanShoppingListAssembler mealPlanShoppingListAssembler,
+            MealPlanMapper mealPlanMapper) {
+        this.mealPlanRepository = mealPlanRepository;
+        this.mealPlanStatRepository = mealPlanStatRepository;
+        this.mealPlanChangelogEntryRepository = mealPlanChangelogEntryRepository;
+        this.mealPlanSourceRepository = mealPlanSourceRepository;
+        this.mealPlanSectionAssembler = mealPlanSectionAssembler;
+        this.mealPlanShoppingListAssembler = mealPlanShoppingListAssembler;
+        this.mealPlanMapper = mealPlanMapper;
     }
 
     /**
-     * Returns the weekly meal-plan reference document.
+     * Returns the weekly meal-plan reference document, assembled from its database tables.
+     * Emits {@link NoSuchElementException} if the singleton meal-plan row is missing.
      *
-     * @return a Mono emitting the cached meal-plan DTO
+     * @return a Mono emitting the assembled meal-plan DTO
      */
     public Mono<MealPlanDTO> getMealPlan() {
-        return Mono.just(mealPlan);
+        return Mono.fromCallable(() -> {
+            final MealPlanEntity mealPlan = mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)
+                    .orElseThrow(() -> new NoSuchElementException("Meal plan not found"));
+            return toMealPlanDTO(mealPlan);
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
-    private MealPlanDTO readMealPlan(ObjectMapper objectMapper) {
-        try (InputStream inputStream = new ClassPathResource(MEAL_PLAN_RESOURCE).getInputStream()) {
-            return objectMapper.readValue(inputStream, MealPlanDTO.class);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to load bundled meal-plan resource: " + MEAL_PLAN_RESOURCE, e);
-        }
+    /**
+     * Assembles the full meal-plan DTO from the header entity and its related child tables.
+     *
+     * @param mealPlan the meal-plan header entity
+     * @return the assembled meal-plan DTO
+     */
+    private MealPlanDTO toMealPlanDTO(MealPlanEntity mealPlan) {
+        final Long id = mealPlan.getId();
+
+        final List<MealPlanStatDTO> stats = mealPlanMapper.toStatDTOs(
+                mealPlanStatRepository.findAllByMealPlanIdOrderBySortOrderAsc(id));
+        final List<MealPlanChangelogEntryDTO> changelog = mealPlanMapper.toChangelogEntryDTOs(
+                mealPlanChangelogEntryRepository.findAllByMealPlanIdOrderBySortOrderAsc(id));
+        final List<MealPlanSourceDTO> sources = mealPlanMapper.toSourceDTOs(
+                mealPlanSourceRepository.findAllByMealPlanIdOrderBySortOrderAsc(id));
+
+        final List<MealPlanSectionDTO> sections = mealPlanSectionAssembler.assemble(id);
+        final List<MealPlanShoppingCategoryDTO> categories = mealPlanShoppingListAssembler.assemble(id);
+
+        final MealPlanShoppingListDTO shoppingList = new MealPlanShoppingListDTO(
+                mealPlan.getShoppingListTitle(), mealPlan.getShoppingListNote(), categories,
+                mealPlan.getShoppingListCallout());
+        final MealPlanFooterDTO footer = new MealPlanFooterDTO(mealPlan.getFooterNote(), sources);
+
+        return new MealPlanDTO(mealPlan.getEyebrow(), mealPlan.getTitle(), mealPlan.getDescription(),
+                stats, changelog, sections, shoppingList, footer);
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanShoppingListAssembler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanShoppingListAssembler.java
@@ -1,0 +1,64 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanShoppingCategoryRepository;
+import com.marvin.nutrition.repository.MealPlanShoppingItemRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/** Assembles the meal plan's ordered list of shopping categories together with each category's ordered items. */
+@Component
+public class MealPlanShoppingListAssembler {
+
+    private final MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository;
+    private final MealPlanShoppingItemRepository mealPlanShoppingItemRepository;
+    private final MealPlanMapper mealPlanMapper;
+
+    /**
+     * Creates a new MealPlanShoppingListAssembler.
+     *
+     * @param mealPlanShoppingCategoryRepository JPA repository for shopping categories
+     * @param mealPlanShoppingItemRepository     JPA repository for shopping items
+     * @param mealPlanMapper                     mapper for converting entities into DTOs
+     */
+    public MealPlanShoppingListAssembler(
+            MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository,
+            MealPlanShoppingItemRepository mealPlanShoppingItemRepository,
+            MealPlanMapper mealPlanMapper) {
+        this.mealPlanShoppingCategoryRepository = mealPlanShoppingCategoryRepository;
+        this.mealPlanShoppingItemRepository = mealPlanShoppingItemRepository;
+        this.mealPlanMapper = mealPlanMapper;
+    }
+
+    /**
+     * Loads and assembles all shopping categories of the given meal plan, each with its ordered items.
+     *
+     * @param mealPlanId the id of the meal plan
+     * @return the ordered list of shopping category DTOs
+     */
+    public List<MealPlanShoppingCategoryDTO> assemble(Long mealPlanId) {
+        final List<MealPlanShoppingCategoryEntity> categories =
+                mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId);
+        return categories.stream()
+                .map(this::toShoppingCategoryDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads a category's items and maps the category together with them to a DTO.
+     *
+     * @param category the shopping category entity
+     * @return the assembled shopping category DTO
+     */
+    private MealPlanShoppingCategoryDTO toShoppingCategoryDTO(MealPlanShoppingCategoryEntity category) {
+        final List<MealPlanShoppingItemEntity> itemEntities =
+                mealPlanShoppingItemRepository.findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(category.getId());
+        final List<MealPlanShoppingItemDTO> items = mealPlanMapper.toShoppingItemDTOs(itemEntities);
+        return mealPlanMapper.toShoppingCategoryDTO(category, items);
+    }
+}

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_10__nutrition_meal_plan.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_10__nutrition_meal_plan.sql
@@ -1,0 +1,263 @@
+-- Move the "Ernährungsplan & Einkaufsliste" meal-plan/shopping-list content from a static
+-- classpath JSON resource into fully normalized relational tables, seeded with the current
+-- content of nutrition/src/main/resources/nutrition/meal-plan.json.
+
+CREATE TABLE nutrition.meal_plan
+(
+    id                     BIGINT        PRIMARY KEY CHECK (id = 1),
+    eyebrow                VARCHAR(500)  NOT NULL,
+    title                  VARCHAR(500)  NOT NULL,
+    description            TEXT          NOT NULL,
+    shopping_list_title    VARCHAR(500)  NOT NULL,
+    shopping_list_note     VARCHAR(500)  NOT NULL,
+    shopping_list_callout  TEXT,
+    footer_note            TEXT          NOT NULL,
+    creation_date          TIMESTAMP     NOT NULL,
+    last_modified          TIMESTAMP     NOT NULL
+);
+
+CREATE TABLE nutrition.meal_plan_stat
+(
+    id            UUID          PRIMARY KEY,
+    meal_plan_id  BIGINT        NOT NULL REFERENCES nutrition.meal_plan(id) ON DELETE CASCADE,
+    label         VARCHAR(255)  NOT NULL,
+    value         VARCHAR(255)  NOT NULL,
+    sort_order    INTEGER       NOT NULL,
+    creation_date TIMESTAMP     NOT NULL,
+    last_modified TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_stat_meal_plan_id ON nutrition.meal_plan_stat(meal_plan_id);
+
+CREATE TABLE nutrition.meal_plan_changelog_entry
+(
+    id            UUID          PRIMARY KEY,
+    meal_plan_id  BIGINT        NOT NULL REFERENCES nutrition.meal_plan(id) ON DELETE CASCADE,
+    tag           VARCHAR(255)  NOT NULL,
+    was           VARCHAR(500),
+    entry_text    TEXT          NOT NULL,
+    sort_order    INTEGER       NOT NULL,
+    creation_date TIMESTAMP     NOT NULL,
+    last_modified TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_changelog_entry_meal_plan_id ON nutrition.meal_plan_changelog_entry(meal_plan_id);
+
+CREATE TABLE nutrition.meal_plan_section
+(
+    id              UUID          PRIMARY KEY,
+    meal_plan_id    BIGINT        NOT NULL REFERENCES nutrition.meal_plan(id) ON DELETE CASCADE,
+    title           VARCHAR(500)  NOT NULL,
+    note            VARCHAR(500)  NOT NULL,
+    totals_label    VARCHAR(255),
+    totals_kcal     VARCHAR(255),
+    totals_protein  VARCHAR(255),
+    callout         TEXT,
+    sort_order      INTEGER       NOT NULL,
+    creation_date   TIMESTAMP     NOT NULL,
+    last_modified   TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_section_meal_plan_id ON nutrition.meal_plan_section(meal_plan_id);
+
+CREATE TABLE nutrition.meal_plan_row
+(
+    id                    UUID          PRIMARY KEY,
+    meal_plan_section_id  UUID          NOT NULL REFERENCES nutrition.meal_plan_section(id) ON DELETE CASCADE,
+    meal                  VARCHAR(255)  NOT NULL,
+    details               TEXT          NOT NULL,
+    qty                   VARCHAR(255)  NOT NULL,
+    kcal                  VARCHAR(255)  NOT NULL,
+    protein               VARCHAR(255)  NOT NULL,
+    sort_order            INTEGER       NOT NULL,
+    creation_date         TIMESTAMP     NOT NULL,
+    last_modified         TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_row_meal_plan_section_id ON nutrition.meal_plan_row(meal_plan_section_id);
+
+CREATE TABLE nutrition.meal_plan_shopping_category
+(
+    id            UUID          PRIMARY KEY,
+    meal_plan_id  BIGINT        NOT NULL REFERENCES nutrition.meal_plan(id) ON DELETE CASCADE,
+    title         VARCHAR(500)  NOT NULL,
+    sort_order    INTEGER       NOT NULL,
+    creation_date TIMESTAMP     NOT NULL,
+    last_modified TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_shopping_category_meal_plan_id ON nutrition.meal_plan_shopping_category(meal_plan_id);
+
+CREATE TABLE nutrition.meal_plan_shopping_item
+(
+    id                              UUID          PRIMARY KEY,
+    meal_plan_shopping_category_id UUID          NOT NULL REFERENCES nutrition.meal_plan_shopping_category(id) ON DELETE CASCADE,
+    name                            VARCHAR(255)  NOT NULL,
+    brand                           VARCHAR(500),
+    badge                           VARCHAR(10)   CHECK (badge IN ('ok', 'warn') OR badge IS NULL),
+    badge_text                      VARCHAR(500),
+    qty                             VARCHAR(255)  NOT NULL,
+    sort_order                      INTEGER       NOT NULL,
+    creation_date                   TIMESTAMP     NOT NULL,
+    last_modified                   TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_shopping_item_category_id ON nutrition.meal_plan_shopping_item(meal_plan_shopping_category_id);
+
+CREATE TABLE nutrition.meal_plan_source
+(
+    id            UUID          PRIMARY KEY,
+    meal_plan_id  BIGINT        NOT NULL REFERENCES nutrition.meal_plan(id) ON DELETE CASCADE,
+    label         VARCHAR(500)  NOT NULL,
+    url           VARCHAR(1000) NOT NULL,
+    sort_order    INTEGER       NOT NULL,
+    creation_date TIMESTAMP     NOT NULL,
+    last_modified TIMESTAMP     NOT NULL
+);
+
+CREATE INDEX idx_meal_plan_source_meal_plan_id ON nutrition.meal_plan_source(meal_plan_id);
+
+-- Seed data: header row (singleton, id = 1)
+INSERT INTO nutrition.meal_plan
+    (id, eyebrow, title, description, shopping_list_title, shopping_list_note, shopping_list_callout, footer_note,
+     creation_date, last_modified)
+VALUES
+    (1,
+     'Version 3 — Ei & Magerquark aus dem Frühstück ins Abendessen verschoben',
+     'Ernährungsplan & Einkaufsliste',
+     'Fettabbau & Muskelerhalt (Cut) · Whey reduziert, Magerquark als Hauptproteinquelle, Ei kontrolliert statt ad-hoc.',
+     '4 · Einkaufsliste für Lidl (1 Woche)',
+     '4× Kantine Mo–Do · 3× Selbstkochen Fr–So · 40 g Whey/Tag',
+     'Whey Protein wird bei Lidl nicht durchgängig geführt — separat online oder in der Drogerie besorgen. Alle anderen Positionen entsprechen den Produkten, die bereits im Tracking als Lidl-Artikel hinterlegt sind (Freshona, Milbona, Alesto, Bio-Eigenmarken); Basmatireis- und Magerquark-Nährwerte wurden ergänzend recherchiert, da sie bisher nicht im Tracking vorkamen.',
+     'Nährwerte für Haferflocken, Haferdrink, Whey, Himbeeren, Hähnchenbrust, Rinderhüftsteak, Dinkel-Penne, Kaisergemüse und Ei stammen aus der bestehenden Lebensmitteldatenbank des Nutrition-Trackings. Magerquark, Basmatireis und Banane waren dort nicht erfasst und wurden recherchiert:',
+     now(), now());
+
+-- Seed data: stats (4)
+INSERT INTO nutrition.meal_plan_stat (id, meal_plan_id, label, value, sort_order, creation_date, last_modified)
+VALUES
+    ('d74eba94-2b41-4fd9-8fa4-2d642c8e3f2d', 1, 'Tagesbudget (Ø)', '2.416 kcal', 0, now(), now()),
+    ('4fb904f4-d0d7-44b0-8274-6446fcf52661', 1, 'Protein', '~184 g', 1, now(), now()),
+    ('ef84bcbb-9e4b-4540-bc3b-3622b8bd6c70', 1, 'Kohlenhydrate', '~291 g', 2, now(), now()),
+    ('499070e8-df59-417f-a225-109e0dc75d96', 1, 'Fett', '~52 g', 3, now(), now());
+
+-- Seed data: changelog entries (9)
+INSERT INTO nutrition.meal_plan_changelog_entry (id, meal_plan_id, tag, was, entry_text, sort_order, creation_date, last_modified)
+VALUES
+    ('0f4fe0df-5aeb-4104-a196-43d1ea498e3c', 1, 'Whey', '80 g/Tag (2×40 g)',
+     '→ 40 g/Tag (je 20 g zu Frühstück & Nachmittagssnack) — halbiert, wie gewünscht.', 0, now(), now()),
+    ('66fe1cf6-d562-4239-9ffd-c97a58d33b0f', 1, 'Magerquark', NULL,
+     'neu: 300 g/Tag (100 g Frühstück + 200 g Nachmittag) übernimmt den Proteinanteil, den der Whey abgibt.', 1, now(), now()),
+    ('897ea972-8e0f-42d9-bbaa-012ad7e0a631', 1, 'Ei', NULL,
+     'fest auf 1 Ei/Tag im Frühstück begrenzt, statt wie im Tracking unregelmäßig 1–2 Eier über mehrere Mahlzeiten verteilt.', 2, now(), now()),
+    ('5a703cc6-bbcd-4d4a-9e57-3b217e8c9cf3', 1, 'Korrektur', NULL,
+     'Abendessen ist an allen 7 Tagen identisch berechnet. Der alte Plan hatte für dieselbe Zutatenliste zwei unterschiedliche Werte (858 vs. 926 kcal) — das war ein Rechenfehler, nicht real erreichbar.', 3, now(), now()),
+    ('b1a9b6e1-276a-4c96-adfb-608375471d60', 1, 'Olivenöl', NULL,
+     '10 g neu bei Mittag (Wochenende) & Abendessen ausgewiesen, um das Fettziel realistisch zu erreichen, statt es implizit wegzulassen.', 4, now(), now()),
+    ('21fd6402-7495-4ee6-ae1d-5935dec49f80', 1, 'Hähnchen-Engpass', NULL,
+     'nur 1.200 g statt 1.400 g Hähnchenbrust verfügbar → Portion beim Abendessen auf 170 g/Tag reduziert (statt 200 g). Ausgleich über +50 g Magerquark im Nachmittagssnack (150 g → 200 g), das deckt den Protein- & Kalorienverlust fast exakt — Wochenschnitt bleibt praktisch unverändert.', 5, now(), now()),
+    ('91005971-02da-4bb8-9603-7fe7b0654f4d', 1, 'Frühstück', '+ 100 g Magerquark, 1 Ei',
+     'Magerquark und Ei aus dem Frühstück entfernt — Frühstück besteht jetzt nur noch aus Haferflocken, Haferdrink, Whey, TK-Himbeeren und Mandeln.', 6, now(), now()),
+    ('78e798cb-a8c6-43cd-87df-050587c0f57a', 1, 'Ei', '1 Ei/Tag im Frühstück',
+     '→ 1 Ei/Tag im Abendessen (alle 7 Tage) — Ei wird nur noch zu Mittag/Abendbrot am Wochenende bzw. zum Abendbrot an Wochentagen gegessen, nicht mehr morgens.', 7, now(), now()),
+    ('9c92c50b-a83b-4e84-9efc-e52a349e748a', 1, 'Magerquark', '100 g Frühstück + 200 g Nachmittag',
+     '→ 200 g Nachmittag + 100 g Abendessen — nicht mehr im Frühstück, sondern auf Nachmittag & Abendessen verteilt. Tagesmenge bleibt bei 300 g.', 8, now(), now());
+
+-- Seed data: sections (3)
+INSERT INTO nutrition.meal_plan_section
+    (id, meal_plan_id, title, note, totals_label, totals_kcal, totals_protein, callout, sort_order, creation_date, last_modified)
+VALUES
+    ('5b21f5d0-5dd3-4653-8941-8920f7231447', 1, '1 · Tagesstruktur (täglich gleich)',
+     'Frühstück & Nachmittag identisch an allen 7 Tagen', NULL, NULL, NULL,
+     'Der Whey-Shake wird jetzt kleiner (20 g statt 40 g) und durch Magerquark ergänzt — pro 100 g liefert Magerquark 12 g Protein bei nur 66 kcal und 0,2 g Fett, macht das Cut-Ziel also nicht teurer. Ei und ein Teil des Magerquarks (100 g) sind aus dem Frühstück verschwunden und wandern ins Abendessen: das Frühstück besteht dadurch nur noch aus Haferflocken, Haferdrink, Whey, TK-Himbeeren und Mandeln. Magerquark ist damit auf Nachmittag (200 g) und Abendessen (100 g) verteilt, das Ei gibt es nur noch zu Mittag/Abendbrot am Wochenende bzw. zum Abendbrot an Wochentagen. Die Nachmittags-Portion Magerquark ist weiterhin bewusst größer als rechnerisch nötig (200 g statt 150 g) — das federt den Hähnchen-Engpass beim Abendessen ab.',
+     0, now(), now()),
+    ('41de111d-8e9e-4067-98ed-6d6ccba19c07', 1, '2 · Wochentage (Montag – Donnerstag)',
+     'Kantine am Mittag bleibt Richtwert', 'Tagesgesamt', '2.407 kcal', '182,2 g', NULL,
+     1, now(), now()),
+    ('edc7ee00-af02-4c76-850c-38315022f2b7', 1, '3 · Wochenende (Freitag – Sonntag)',
+     'Mittag wird selbst zubereitet', 'Tagesgesamt', '2.428 kcal', '186,5 g',
+     'Zielabweichung über die Woche: im Schnitt 2.416 kcal / 184,0 g Protein / 291,0 g Kohlenhydrate / 52,3 g Fett gegen ein Ziel von 2.422 kcal / 188 g / 296 g / 54 g — trotz reduzierter Hähnchenmenge weiterhin unter 2 % Abweichung, dank der Magerquark-Kompensation.',
+     2, now(), now());
+
+-- Seed data: rows (10) — section 1 has 2, section 2 has 4, section 3 has 4
+INSERT INTO nutrition.meal_plan_row (id, meal_plan_section_id, meal, details, qty, kcal, protein, sort_order, creation_date, last_modified)
+VALUES
+    ('b3818af7-c8f5-4f8b-9c13-e6e1a9d7e9a1', '5b21f5d0-5dd3-4653-8941-8920f7231447', 'Frühstück',
+     'Haferflocken, Haferdrink, Whey, TK-Himbeeren, Mandeln', '90g/200ml/20g/50g/10g', '519', '28,0 g', 0, now(), now()),
+    ('b9420d05-8454-4f21-8e33-3d3dfbbbef01', '5b21f5d0-5dd3-4653-8941-8920f7231447', 'Nachmittag',
+     'Whey, Magerquark, Banane', '20g/200g/1 Stk', '314', '40,3 g', 1, now(), now()),
+
+    ('fdf766c6-9571-4aa8-a8d1-9f0f7c5a80c4', '41de111d-8e9e-4067-98ed-6d6ccba19c07', 'Frühstück',
+     'siehe Tagesstruktur', '—', '519', '28,0 g', 0, now(), now()),
+    ('b321d7fb-5d46-4d9d-8f52-158e14ea958c', '41de111d-8e9e-4067-98ed-6d6ccba19c07', 'Mittag (Kantine)',
+     'Mageres Protein, komplexe Carbs, Gemüse (Richtwert)', '1 Portion', '650', '40,0 g', 1, now(), now()),
+    ('632eac1a-476f-4ea4-a68f-2c842e62236c', '41de111d-8e9e-4067-98ed-6d6ccba19c07', 'Nachmittag',
+     'siehe Tagesstruktur', '—', '314', '40,3 g', 2, now(), now()),
+    ('83d82b3a-a2ab-41a7-94e9-fb022ebdc54a', '41de111d-8e9e-4067-98ed-6d6ccba19c07', 'Abendessen',
+     'Hähnchenbrustfilet, Dinkel-Penne, Kaisergemüse, Olivenöl, Magerquark, Ei', '170g/120g/200g/10g/100g/1 Stk', '923', '73,9 g', 3, now(), now()),
+
+    ('3faffc1d-51db-47b5-91ab-aafa9c63caae', 'edc7ee00-af02-4c76-850c-38315022f2b7', 'Frühstück',
+     'siehe Tagesstruktur', '—', '519', '28,0 g', 0, now(), now()),
+    ('cda168ce-aeec-4f84-ad78-ca5e168a6b86', 'edc7ee00-af02-4c76-850c-38315022f2b7', 'Mittagessen',
+     'Rinderhüftsteak, Basmatireis, Kaisergemüse, Olivenöl', '145g/100g/200g/10g', '672', '44,3 g', 1, now(), now()),
+    ('db5bd1f0-af65-4cd4-81b1-f33e263f2d26', 'edc7ee00-af02-4c76-850c-38315022f2b7', 'Nachmittag',
+     'siehe Tagesstruktur', '—', '314', '40,3 g', 2, now(), now()),
+    ('1a26687c-cdda-4083-9a1c-3fa4381e15d5', 'edc7ee00-af02-4c76-850c-38315022f2b7', 'Abendessen',
+     'Hähnchenbrustfilet, Dinkel-Penne, Kaisergemüse, Olivenöl, Magerquark, Ei', '170g/120g/200g/10g/100g/1 Stk', '923', '73,9 g', 3, now(), now());
+
+-- Seed data: shopping categories (6)
+INSERT INTO nutrition.meal_plan_shopping_category (id, meal_plan_id, title, sort_order, creation_date, last_modified)
+VALUES
+    ('10682dcd-1f76-4db0-8044-ea3a17c7354a', 1, 'Fleisch & Fisch', 0, now(), now()),
+    ('6ee27873-bf8b-4cff-a67e-365ce2bad325', 1, 'Milchprodukte & Eier', 1, now(), now()),
+    ('bcba0a32-0a0d-4384-a4e0-bde9466ee0df', 1, 'Proteinpulver', 2, now(), now()),
+    ('2d23c32b-e833-4ea0-b9a7-b0b8d21d699e', 1, 'Gemüse & Obst (TK & frisch)', 3, now(), now()),
+    ('22ca2d83-8380-4ede-acd3-80468f5e47d0', 1, 'Kohlenhydrate & Getreide', 4, now(), now()),
+    ('f7d4100f-bd31-4347-8bd0-8efb90599126', 1, 'Fette, Nüsse & Drinks', 5, now(), now());
+
+-- Seed data: shopping items (14) — 2 + 2 + 1 + 3 + 3 + 3
+INSERT INTO nutrition.meal_plan_shopping_item
+    (id, meal_plan_shopping_category_id, name, brand, badge, badge_text, qty, sort_order, creation_date, last_modified)
+VALUES
+    ('4b076c0c-fc17-4b28-8679-d3dcaf7945b7', '10682dcd-1f76-4db0-8044-ea3a17c7354a', 'Hähnchenbrustfilet',
+     'frisch, Kühltheke', 'warn', 'nur 1.200 g verfügbar', '1.200 g', 0, now(), now()),
+    ('ee9037fa-7e11-4690-9176-e5e22fc8d503', '10682dcd-1f76-4db0-8044-ea3a17c7354a', 'Frisches Rinderhüftsteak',
+     'Lidl', NULL, NULL, '435 g', 1, now(), now()),
+
+    ('2ca3cb46-7881-49d8-a66a-53ee5c6aff04', '6ee27873-bf8b-4cff-a67e-365ce2bad325', 'Magerquark',
+     'Milbona (Lidl), 4× 500 g + 1× 250 g Tuben', NULL, NULL, '2.100 g', 0, now(), now()),
+    ('544eb690-80c3-42a3-a52b-14e3ef43e2bc', '6ee27873-bf8b-4cff-a67e-365ce2bad325', 'Eier',
+     '10er-Packung', NULL, NULL, '7 Stk', 1, now(), now()),
+
+    ('df29412b-e700-4c3f-ae5f-5651f2838e06', 'bcba0a32-0a0d-4384-a4e0-bde9466ee0df', 'Whey Protein Konzentrat Erdbeere',
+     'Rühls Bestes', 'warn', 'nicht bei Lidl', '280 g', 0, now(), now()),
+
+    ('a374534f-6632-4403-8c27-72cfb5bf8e0f', '2d23c32b-e833-4ea0-b9a7-b0b8d21d699e', 'Kaisergemüse TK',
+     'Freshona (Lidl)', NULL, NULL, '2.000 g', 0, now(), now()),
+    ('979e8e8b-9fd1-4625-b766-c27e98a37461', '2d23c32b-e833-4ea0-b9a7-b0b8d21d699e', 'TK-Himbeeren',
+     'Freshona (Lidl)', NULL, NULL, '350 g', 1, now(), now()),
+    ('effb7f70-7259-4015-9aba-775d97f9a9b2', '2d23c32b-e833-4ea0-b9a7-b0b8d21d699e', 'Bananen',
+     'frisch', NULL, NULL, '7 Stk', 2, now(), now()),
+
+    ('32953ae9-2980-494e-8b85-bb4b894e3ba6', '22ca2d83-8380-4ede-acd3-80468f5e47d0', 'Haferflocken',
+     'Bio Hafervollkornflocken Kleinblatt, Lidl', NULL, NULL, '630 g', 0, now(), now()),
+    ('1b0a8d11-56ef-4585-84b5-f1b2ae09a616', '22ca2d83-8380-4ede-acd3-80468f5e47d0', 'Dinkel-Penne',
+     'Bio, Lidl/Bioland', NULL, NULL, '840 g', 1, now(), now()),
+    ('ae4cb5b4-0069-4aa5-95d8-defbd35a6c72', '22ca2d83-8380-4ede-acd3-80468f5e47d0', 'Basmatireis',
+     'Lidl, roh', NULL, NULL, '300 g', 2, now(), now()),
+
+    ('4a74e7ee-447b-4d37-999d-59eb8ee16dff', 'f7d4100f-bd31-4347-8bd0-8efb90599126', 'Olivenöl',
+     'Lidl', NULL, NULL, '100 ml', 0, now(), now()),
+    ('26e8a7df-5fe7-4cb1-9425-198ea98120b8', 'f7d4100f-bd31-4347-8bd0-8efb90599126', 'Mandeln, blanchiert & gehackt',
+     'Alesto (Lidl)', NULL, NULL, '70 g', 1, now(), now()),
+    ('0b552292-396f-4fd0-bafd-4a34d4ce7c50', 'f7d4100f-bd31-4347-8bd0-8efb90599126', 'Bio Haferdrink',
+     'Lidl, 2 Packungen', NULL, NULL, '1,4 L', 2, now(), now());
+
+-- Seed data: footer sources (3)
+INSERT INTO nutrition.meal_plan_source (id, meal_plan_id, label, url, sort_order, creation_date, last_modified)
+VALUES
+    ('df31c398-b885-4689-bdcd-d1ff2291a7a6', 1, 'Magerquark (Milbona/Milsani, fatsecret.de)',
+     'https://www.fatsecret.de/Kalorien-Ern%C3%A4hrung/milsani/magerquark/100g', 0, now(), now()),
+    ('df4bf910-7545-4aab-ac31-f1a10d4958ff', 1, 'Basmatireis Lidl, roh (fatsecret.de)',
+     'https://www.fatsecret.de/Kalorien-Ern%C3%A4hrung/lidl/basmati-reis/100g', 1, now(), now()),
+    ('8763cd1a-4096-4115-8ff5-b3476a0821e5', 1, 'Banane, frisch (yazio.com)',
+     'https://www.yazio.com/de/kalorientabelle/banane-frisch.html', 2, now(), now());

--- a/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
@@ -1,0 +1,51 @@
+package com.marvin.nutrition.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link MealPlanMapper}, focused on the nullable {@code totals} branch of {@code toSectionDTO}. */
+@DisplayName("MealPlanMapper Tests")
+class MealPlanMapperTest {
+
+    private final MealPlanMapper mealPlanMapper = new MealPlanMapperImpl();
+
+    @Test
+    @DisplayName("toSectionDTO returns null totals when the section has no totals label")
+    void toSectionDTO_NoTotalsLabel_ReturnsNullTotals() {
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setTitle("1 · Tagesstruktur (täglich gleich)");
+        section.setNote("note");
+        section.setCallout("callout");
+
+        final MealPlanSectionDTO dto = mealPlanMapper.toSectionDTO(section, List.of());
+
+        assertEquals("1 · Tagesstruktur (täglich gleich)", dto.title());
+        assertNull(dto.totals());
+    }
+
+    @Test
+    @DisplayName("toSectionDTO builds totals when the section has a totals label")
+    void toSectionDTO_WithTotalsLabel_ReturnsTotals() {
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setTitle("2 · Wochentage (Montag – Donnerstag)");
+        section.setNote("note");
+        section.setTotalsLabel("Tagesgesamt");
+        section.setTotalsKcal("2.407 kcal");
+        section.setTotalsProtein("182,2 g");
+
+        final MealPlanRowDTO row = new MealPlanRowDTO("Frühstück", "details", "qty", "519", "28,0 g");
+        final MealPlanSectionDTO dto = mealPlanMapper.toSectionDTO(section, List.of(row));
+
+        assertEquals(List.of(row), dto.rows());
+        assertEquals("Tagesgesamt", dto.totals().label());
+        assertEquals("2.407 kcal", dto.totals().kcal());
+        assertEquals("182,2 g", dto.totals().protein());
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/repository/MealPlanRepositoryTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/repository/MealPlanRepositoryTest.java
@@ -1,0 +1,271 @@
+package com.marvin.nutrition.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import com.marvin.nutrition.entity.MealPlanEntity;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Repository integration test covering all eight meal-plan tables: ordering and cascade delete. */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class MealPlanRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private MealPlanRepository mealPlanRepository;
+
+    @Autowired
+    private MealPlanStatRepository mealPlanStatRepository;
+
+    @Autowired
+    private MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository;
+
+    @Autowired
+    private MealPlanSourceRepository mealPlanSourceRepository;
+
+    @Autowired
+    private MealPlanSectionRepository mealPlanSectionRepository;
+
+    @Autowired
+    private MealPlanRowRepository mealPlanRowRepository;
+
+    @Autowired
+    private MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository;
+
+    @Autowired
+    private MealPlanShoppingItemRepository mealPlanShoppingItemRepository;
+
+    private MealPlanEntity mealPlan;
+
+    /**
+     * Registers dynamic Flyway/datasource properties so migrations run against the Testcontainers database.
+     *
+     * @param registry the dynamic property registry
+     */
+    @DynamicPropertySource
+    static void registerProperties(final DynamicPropertyRegistry registry) {
+        registry.add("spring.flyway.enabled", () -> "false");
+    }
+
+    /**
+     * Creates the singleton meal-plan header row used as the foreign-key target for this test's children.
+     */
+    @BeforeEach
+    void setUp() {
+        final MealPlanEntity newMealPlan = new MealPlanEntity();
+        newMealPlan.setId(MealPlanEntity.SINGLETON_ID);
+        newMealPlan.setEyebrow("Version 3");
+        newMealPlan.setTitle("Ernährungsplan & Einkaufsliste");
+        newMealPlan.setDescription("description");
+        newMealPlan.setShoppingListTitle("shopping list title");
+        newMealPlan.setShoppingListNote("shopping list note");
+        newMealPlan.setShoppingListCallout(null);
+        newMealPlan.setFooterNote("footer note");
+        mealPlan = mealPlanRepository.save(newMealPlan);
+    }
+
+    /**
+     * Removes the meal-plan row created for this test, cascading to any remaining children.
+     */
+    @AfterEach
+    void tearDown() {
+        mealPlanRepository.deleteById(mealPlan.getId());
+    }
+
+    @Test
+    void savesAndFindsStatsOrderedBySortOrder() {
+        saveStat("Protein", "~184 g", 1);
+        saveStat("Tagesbudget (Ø)", "2.416 kcal", 0);
+
+        final List<MealPlanStatEntity> stats =
+                mealPlanStatRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId());
+
+        assertThat(stats).extracting(MealPlanStatEntity::getLabel)
+                .containsExactly("Tagesbudget (Ø)", "Protein");
+    }
+
+    @Test
+    void savesAndFindsChangelogEntriesOrderedBySortOrder() {
+        saveChangelogEntry("Magerquark", null, "neu: 300 g/Tag", 1);
+        saveChangelogEntry("Whey", "80 g/Tag", "→ 40 g/Tag", 0);
+
+        final List<MealPlanChangelogEntryEntity> entries =
+                mealPlanChangelogEntryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId());
+
+        assertThat(entries).extracting(MealPlanChangelogEntryEntity::getTag)
+                .containsExactly("Whey", "Magerquark");
+        assertThat(entries.get(0).getWas()).isEqualTo("80 g/Tag");
+        assertThat(entries.get(1).getWas()).isNull();
+    }
+
+    @Test
+    void savesAndFindsSourcesOrderedBySortOrder() {
+        saveSource("Basmatireis", "https://example.org/basmatireis", 1);
+        saveSource("Magerquark", "https://example.org/magerquark", 0);
+
+        final List<MealPlanSourceEntity> sources =
+                mealPlanSourceRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId());
+
+        assertThat(sources).extracting(MealPlanSourceEntity::getLabel)
+                .containsExactly("Magerquark", "Basmatireis");
+    }
+
+    @Test
+    void savesAndFindsSectionsWithRowsOrderedBySortOrder() {
+        final MealPlanSectionEntity section = saveSection("2 · Wochentage", "note", "Tagesgesamt", "2.407 kcal", "182,2 g", 0);
+
+        saveRow(section.getId(), "Abendessen", "details", "qty", "923", "73,9 g", 1);
+        saveRow(section.getId(), "Frühstück", "details", "qty", "519", "28,0 g", 0);
+
+        final List<MealPlanSectionEntity> sections =
+                mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId());
+        assertThat(sections).hasSize(1);
+        assertThat(sections.getFirst().getTotalsLabel()).isEqualTo("Tagesgesamt");
+
+        final List<MealPlanRowEntity> rows =
+                mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(section.getId());
+        assertThat(rows).extracting(MealPlanRowEntity::getMeal)
+                .containsExactly("Frühstück", "Abendessen");
+    }
+
+    @Test
+    void savesAndFindsShoppingCategoriesWithItemsOrderedBySortOrder() {
+        final MealPlanShoppingCategoryEntity category = saveShoppingCategory("Fleisch & Fisch", 0);
+
+        saveShoppingItem(category.getId(), "Rinderhüftsteak", "Lidl", null, null, "435 g", 1);
+        saveShoppingItem(category.getId(), "Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g", 0);
+
+        final List<MealPlanShoppingCategoryEntity> categories =
+                mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId());
+        assertThat(categories).hasSize(1);
+
+        final List<MealPlanShoppingItemEntity> items = mealPlanShoppingItemRepository
+                .findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(category.getId());
+        assertThat(items).extracting(MealPlanShoppingItemEntity::getName)
+                .containsExactly("Hähnchenbrustfilet", "Rinderhüftsteak");
+        assertThat(items.getFirst().getBadge()).isEqualTo("warn");
+        assertThat(items.get(1).getBadge()).isNull();
+    }
+
+    @Test
+    void deletingMealPlanCascadesToAllChildTables() {
+        saveStat("Protein", "~184 g", 0);
+        saveChangelogEntry("Whey", null, "text", 0);
+        saveSource("Magerquark", "https://example.org/magerquark", 0);
+        final MealPlanSectionEntity section = saveSection("Section", "note", null, null, null, 0);
+        saveRow(section.getId(), "Frühstück", "details", "qty", "519", "28,0 g", 0);
+        final MealPlanShoppingCategoryEntity category = saveShoppingCategory("Fleisch & Fisch", 0);
+        saveShoppingItem(category.getId(), "Hähnchenbrustfilet", null, null, null, "1.200 g", 0);
+
+        mealPlanRepository.deleteById(mealPlan.getId());
+        mealPlanRepository.flush();
+
+        assertThat(mealPlanStatRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId())).isEmpty();
+        assertThat(mealPlanChangelogEntryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId())).isEmpty();
+        assertThat(mealPlanSourceRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId())).isEmpty();
+        assertThat(mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId())).isEmpty();
+        assertThat(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(section.getId())).isEmpty();
+        assertThat(mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlan.getId())).isEmpty();
+        assertThat(mealPlanShoppingItemRepository
+                .findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(category.getId())).isEmpty();
+    }
+
+    private MealPlanStatEntity saveStat(String label, String value, int sortOrder) {
+        final MealPlanStatEntity stat = new MealPlanStatEntity();
+        stat.setMealPlanId(mealPlan.getId());
+        stat.setLabel(label);
+        stat.setValue(value);
+        stat.setSortOrder(sortOrder);
+        return mealPlanStatRepository.save(stat);
+    }
+
+    private MealPlanChangelogEntryEntity saveChangelogEntry(String tag, String was, String text, int sortOrder) {
+        final MealPlanChangelogEntryEntity entry = new MealPlanChangelogEntryEntity();
+        entry.setMealPlanId(mealPlan.getId());
+        entry.setTag(tag);
+        entry.setWas(was);
+        entry.setText(text);
+        entry.setSortOrder(sortOrder);
+        return mealPlanChangelogEntryRepository.save(entry);
+    }
+
+    private MealPlanSourceEntity saveSource(String label, String url, int sortOrder) {
+        final MealPlanSourceEntity source = new MealPlanSourceEntity();
+        source.setMealPlanId(mealPlan.getId());
+        source.setLabel(label);
+        source.setUrl(url);
+        source.setSortOrder(sortOrder);
+        return mealPlanSourceRepository.save(source);
+    }
+
+    private MealPlanSectionEntity saveSection(
+            String title, String note, String totalsLabel, String totalsKcal, String totalsProtein, int sortOrder) {
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setMealPlanId(mealPlan.getId());
+        section.setTitle(title);
+        section.setNote(note);
+        section.setTotalsLabel(totalsLabel);
+        section.setTotalsKcal(totalsKcal);
+        section.setTotalsProtein(totalsProtein);
+        section.setSortOrder(sortOrder);
+        return mealPlanSectionRepository.save(section);
+    }
+
+    private MealPlanRowEntity saveRow(
+            UUID sectionId, String meal, String details, String qty, String kcal, String protein, int sortOrder) {
+        final MealPlanRowEntity row = new MealPlanRowEntity();
+        row.setMealPlanSectionId(sectionId);
+        row.setMeal(meal);
+        row.setDetails(details);
+        row.setQty(qty);
+        row.setKcal(kcal);
+        row.setProtein(protein);
+        row.setSortOrder(sortOrder);
+        return mealPlanRowRepository.save(row);
+    }
+
+    private MealPlanShoppingCategoryEntity saveShoppingCategory(String title, int sortOrder) {
+        final MealPlanShoppingCategoryEntity category = new MealPlanShoppingCategoryEntity();
+        category.setMealPlanId(mealPlan.getId());
+        category.setTitle(title);
+        category.setSortOrder(sortOrder);
+        return mealPlanShoppingCategoryRepository.save(category);
+    }
+
+    private MealPlanShoppingItemEntity saveShoppingItem(
+            UUID categoryId, String name, String brand, String badge, String badgeText, String qty, int sortOrder) {
+        final MealPlanShoppingItemEntity item = new MealPlanShoppingItemEntity();
+        item.setMealPlanShoppingCategoryId(categoryId);
+        item.setName(name);
+        item.setBrand(brand);
+        item.setBadge(badge);
+        item.setBadgeText(badgeText);
+        item.setQty(qty);
+        item.setSortOrder(sortOrder);
+        return mealPlanShoppingItemRepository.save(item);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionAssemblerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionAssemblerTest.java
@@ -1,0 +1,95 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanRowRepository;
+import com.marvin.nutrition.repository.MealPlanSectionRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link MealPlanSectionAssembler} covering multi-section row assembly. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanSectionAssembler Tests")
+class MealPlanSectionAssemblerTest {
+
+    @Mock
+    private MealPlanSectionRepository mealPlanSectionRepository;
+
+    @Mock
+    private MealPlanRowRepository mealPlanRowRepository;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @InjectMocks
+    private MealPlanSectionAssembler mealPlanSectionAssembler;
+
+    @Test
+    @DisplayName("assemble loads each section's own rows and maps them via the mapper")
+    void assemble_LoadsRowsPerSectionAndMaps() {
+        final Long mealPlanId = 1L;
+        final UUID sectionOneId = UUID.randomUUID();
+        final UUID sectionTwoId = UUID.randomUUID();
+
+        final MealPlanSectionEntity sectionOne = new MealPlanSectionEntity();
+        sectionOne.setId(sectionOneId);
+        sectionOne.setTitle("1 · Tagesstruktur");
+
+        final MealPlanSectionEntity sectionTwo = new MealPlanSectionEntity();
+        sectionTwo.setId(sectionTwoId);
+        sectionTwo.setTitle("2 · Wochentage");
+
+        final MealPlanRowEntity rowOneEntity = new MealPlanRowEntity();
+        rowOneEntity.setId(UUID.randomUUID());
+        rowOneEntity.setMeal("Frühstück");
+        final MealPlanRowEntity rowTwoEntity = new MealPlanRowEntity();
+        rowTwoEntity.setId(UUID.randomUUID());
+        rowTwoEntity.setMeal("Abendessen");
+
+        final MealPlanRowDTO rowOneDTO = new MealPlanRowDTO("Frühstück", "details", "qty", "519", "28,0 g");
+        final MealPlanRowDTO rowTwoDTO = new MealPlanRowDTO("Abendessen", "details", "qty", "923", "73,9 g");
+
+        final MealPlanSectionDTO sectionOneDTO =
+                new MealPlanSectionDTO("1 · Tagesstruktur", "note", List.of(rowOneDTO), null, null);
+        final MealPlanSectionDTO sectionTwoDTO =
+                new MealPlanSectionDTO("2 · Wochentage", "note", List.of(rowTwoDTO), null, null);
+
+        when(mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId))
+                .thenReturn(List.of(sectionOne, sectionTwo));
+        when(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(sectionOneId))
+                .thenReturn(List.of(rowOneEntity));
+        when(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(sectionTwoId))
+                .thenReturn(List.of(rowTwoEntity));
+        when(mealPlanMapper.toRowDTOs(List.of(rowOneEntity))).thenReturn(List.of(rowOneDTO));
+        when(mealPlanMapper.toRowDTOs(List.of(rowTwoEntity))).thenReturn(List.of(rowTwoDTO));
+        when(mealPlanMapper.toSectionDTO(sectionOne, List.of(rowOneDTO))).thenReturn(sectionOneDTO);
+        when(mealPlanMapper.toSectionDTO(sectionTwo, List.of(rowTwoDTO))).thenReturn(sectionTwoDTO);
+
+        final List<MealPlanSectionDTO> result = mealPlanSectionAssembler.assemble(mealPlanId);
+
+        assertEquals(List.of(sectionOneDTO, sectionTwoDTO), result);
+    }
+
+    @Test
+    @DisplayName("assemble returns an empty list when the meal plan has no sections")
+    void assemble_NoSections_ReturnsEmptyList() {
+        final Long mealPlanId = 1L;
+        when(mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId)).thenReturn(List.of());
+
+        final List<MealPlanSectionDTO> result = mealPlanSectionAssembler.assemble(mealPlanId);
+
+        assertEquals(List.of(), result);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
@@ -2,71 +2,208 @@ package com.marvin.nutrition.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marvin.nutrition.dto.MealPlanDTO;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
 import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import com.marvin.nutrition.entity.MealPlanEntity;
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanChangelogEntryRepository;
+import com.marvin.nutrition.repository.MealPlanRepository;
+import com.marvin.nutrition.repository.MealPlanSourceRepository;
+import com.marvin.nutrition.repository.MealPlanStatRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.test.StepVerifier;
 
-/** Unit tests for {@link MealPlanService} covering loading and parsing of the bundled meal-plan resource. */
+/**
+ * Unit tests for {@link MealPlanService} covering assembly of the meal-plan DTO from its
+ * repositories and assemblers now that the content is database-backed rather than a cached
+ * classpath resource.
+ *
+ * <p>This test class is a deliberate, pre-approved rewrite (not an incremental edit) of the
+ * previous version, which asserted classpath-loading and "same cached instance forever" behavior
+ * that no longer applies once reads go through repositories on every call.</p>
+ */
+@ExtendWith(MockitoExtension.class)
 @DisplayName("MealPlanService Tests")
 class MealPlanServiceTest {
 
-    private final MealPlanService mealPlanService = new MealPlanService(new ObjectMapper());
+    @Mock
+    private MealPlanRepository mealPlanRepository;
+
+    @Mock
+    private MealPlanStatRepository mealPlanStatRepository;
+
+    @Mock
+    private MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository;
+
+    @Mock
+    private MealPlanSourceRepository mealPlanSourceRepository;
+
+    @Mock
+    private MealPlanSectionAssembler mealPlanSectionAssembler;
+
+    @Mock
+    private MealPlanShoppingListAssembler mealPlanShoppingListAssembler;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @InjectMocks
+    private MealPlanService mealPlanService;
+
+    private MealPlanEntity mealPlanEntity;
+    private List<MealPlanStatEntity> statEntities;
+    private List<MealPlanStatDTO> statDTOs;
+    private List<MealPlanChangelogEntryEntity> changelogEntities;
+    private List<MealPlanChangelogEntryDTO> changelogDTOs;
+    private List<MealPlanSourceEntity> sourceEntities;
+    private List<MealPlanSourceDTO> sourceDTOs;
+    private List<MealPlanSectionDTO> sectionDTOs;
+    private List<MealPlanShoppingCategoryDTO> categoryDTOs;
+
+    /** Sets up shared fixtures for each test, mirroring the shape of the real seeded content. */
+    @BeforeEach
+    void setUp() {
+        mealPlanEntity = new MealPlanEntity();
+        mealPlanEntity.setId(MealPlanEntity.SINGLETON_ID);
+        mealPlanEntity.setEyebrow("Version 3");
+        mealPlanEntity.setTitle("Ernährungsplan & Einkaufsliste");
+        mealPlanEntity.setDescription("Fettabbau & Muskelerhalt (Cut)");
+        mealPlanEntity.setShoppingListTitle("4 · Einkaufsliste für Lidl (1 Woche)");
+        mealPlanEntity.setShoppingListNote("4× Kantine Mo–Do · 3× Selbstkochen Fr–So");
+        mealPlanEntity.setShoppingListCallout("Whey Protein wird bei Lidl nicht durchgängig geführt.");
+        mealPlanEntity.setFooterNote("Nährwerte stammen aus der bestehenden Lebensmitteldatenbank.");
+
+        statEntities = List.of(
+                new MealPlanStatEntity(), new MealPlanStatEntity(),
+                new MealPlanStatEntity(), new MealPlanStatEntity());
+        statDTOs = List.of(
+                new MealPlanStatDTO("Tagesbudget (Ø)", "2.416 kcal"),
+                new MealPlanStatDTO("Protein", "~184 g"),
+                new MealPlanStatDTO("Kohlenhydrate", "~291 g"),
+                new MealPlanStatDTO("Fett", "~52 g"));
+
+        changelogEntities = List.of(new MealPlanChangelogEntryEntity(), new MealPlanChangelogEntryEntity());
+        changelogDTOs = List.of(
+                new MealPlanChangelogEntryDTO("Whey", "80 g/Tag (2×40 g)", "→ 40 g/Tag"),
+                new MealPlanChangelogEntryDTO("Magerquark", null, "neu: 300 g/Tag"));
+
+        sourceEntities = List.of(new MealPlanSourceEntity(), new MealPlanSourceEntity());
+        sourceDTOs = List.of(
+                new MealPlanSourceDTO("Magerquark (fatsecret.de)", "https://www.fatsecret.de/magerquark"),
+                new MealPlanSourceDTO("Basmatireis (fatsecret.de)", "https://www.fatsecret.de/basmatireis"));
+
+        final MealPlanRowDTO row = new MealPlanRowDTO("Frühstück", "Haferflocken, Whey", "90g/20g", "519", "28,0 g");
+        sectionDTOs = List.of(
+                new MealPlanSectionDTO("1 · Tagesstruktur", "note", List.of(row), null, "callout"),
+                new MealPlanSectionDTO("2 · Wochentage", "note", List.of(row), null, null),
+                new MealPlanSectionDTO("3 · Wochenende", "note", List.of(row), null, "callout"));
+
+        final MealPlanShoppingItemDTO plainItem =
+                new MealPlanShoppingItemDTO("Rinderhüftsteak", "Lidl", null, null, "435 g");
+        final MealPlanShoppingItemDTO badgedItem = new MealPlanShoppingItemDTO(
+                "Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
+        categoryDTOs = List.of(
+                new MealPlanShoppingCategoryDTO("Fleisch & Fisch", List.of(badgedItem, plainItem)),
+                new MealPlanShoppingCategoryDTO("Milchprodukte & Eier", List.of(plainItem)));
+    }
+
+    /** Stubs every repository/assembler/mapper call needed for a full, successful {@code getMealPlan()} read. */
+    private void stubHappyPath() {
+        when(mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)).thenReturn(Optional.of(mealPlanEntity));
+        when(mealPlanStatRepository.findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID))
+                .thenReturn(statEntities);
+        when(mealPlanMapper.toStatDTOs(statEntities)).thenReturn(statDTOs);
+        when(mealPlanChangelogEntryRepository.findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID))
+                .thenReturn(changelogEntities);
+        when(mealPlanMapper.toChangelogEntryDTOs(changelogEntities)).thenReturn(changelogDTOs);
+        when(mealPlanSourceRepository.findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID))
+                .thenReturn(sourceEntities);
+        when(mealPlanMapper.toSourceDTOs(sourceEntities)).thenReturn(sourceDTOs);
+        when(mealPlanSectionAssembler.assemble(MealPlanEntity.SINGLETON_ID)).thenReturn(sectionDTOs);
+        when(mealPlanShoppingListAssembler.assemble(MealPlanEntity.SINGLETON_ID)).thenReturn(categoryDTOs);
+    }
 
     // -----------------------------------------------------------------------
     // getMealPlan
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("getMealPlan loads the bundled meal-plan resource with correct title")
+    @DisplayName("getMealPlan returns the meal plan with the header's title")
     void getMealPlan_ReturnsMealPlanWithCorrectTitle() {
+        stubHappyPath();
+
         StepVerifier.create(mealPlanService.getMealPlan())
                 .assertNext(dto -> assertEquals("Ernährungsplan & Einkaufsliste", dto.title()))
                 .verifyComplete();
     }
 
     @Test
-    @DisplayName("getMealPlan returns four stats with the expected labels and values")
-    void getMealPlan_ReturnsFourStats() {
+    @DisplayName("getMealPlan returns the stats mapped from the stat repository")
+    void getMealPlan_ReturnsStatsFromRepository() {
+        stubHappyPath();
+
         StepVerifier.create(mealPlanService.getMealPlan())
                 .assertNext(dto -> {
                     assertEquals(4, dto.stats().size());
-                    assertEquals("Tagesbudget (Ø)", dto.stats().get(0).label());
-                    assertEquals("2.416 kcal", dto.stats().get(0).value());
-                    assertEquals("Protein", dto.stats().get(1).label());
-                    assertEquals("~184 g", dto.stats().get(1).value());
-                    assertEquals("Kohlenhydrate", dto.stats().get(2).label());
-                    assertEquals("~291 g", dto.stats().get(2).value());
-                    assertEquals("Fett", dto.stats().get(3).label());
-                    assertEquals("~52 g", dto.stats().get(3).value());
+                    assertEquals(statDTOs, dto.stats());
                 })
                 .verifyComplete();
     }
 
     @Test
-    @DisplayName("getMealPlan returns three sections")
-    void getMealPlan_ReturnsThreeSections() {
+    @DisplayName("getMealPlan returns the changelog entries mapped from the changelog repository")
+    void getMealPlan_ReturnsChangelogFromRepository() {
+        stubHappyPath();
+
         StepVerifier.create(mealPlanService.getMealPlan())
-                .assertNext(dto -> assertEquals(3, dto.sections().size()))
+                .assertNext(dto -> assertEquals(changelogDTOs, dto.changelog()))
                 .verifyComplete();
     }
 
     @Test
-    @DisplayName("getMealPlan returns six shopping list categories")
-    void getMealPlan_ReturnsSixShoppingCategories() {
-        StepVerifier.create(mealPlanService.getMealPlan())
-                .assertNext(dto -> assertEquals(6, dto.shoppingList().categories().size()))
-                .verifyComplete();
-    }
+    @DisplayName("getMealPlan returns the sections assembled by the section assembler")
+    void getMealPlan_ReturnsSectionsFromAssembler() {
+        stubHappyPath();
 
-    @Test
-    @DisplayName("getMealPlan returns at least one shopping item with a non-null badge")
-    void getMealPlan_ReturnsAtLeastOneItemWithBadge() {
         StepVerifier.create(mealPlanService.getMealPlan())
                 .assertNext(dto -> {
+                    assertEquals(3, dto.sections().size());
+                    assertEquals(sectionDTOs, dto.sections());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan returns a shopping list with title, note, callout and categories with a badged item")
+    void getMealPlan_ReturnsShoppingListFromAssembler() {
+        stubHappyPath();
+
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> {
+                    assertEquals(mealPlanEntity.getShoppingListTitle(), dto.shoppingList().title());
+                    assertEquals(mealPlanEntity.getShoppingListNote(), dto.shoppingList().note());
+                    assertEquals(mealPlanEntity.getShoppingListCallout(), dto.shoppingList().callout());
+                    assertEquals(2, dto.shoppingList().categories().size());
                     final boolean hasBadge = dto.shoppingList().categories().stream()
                             .flatMap(category -> category.items().stream())
                             .map(MealPlanShoppingItemDTO::badge)
@@ -77,11 +214,42 @@ class MealPlanServiceTest {
     }
 
     @Test
-    @DisplayName("getMealPlan returns the same cached DTO instance on repeated calls")
-    void getMealPlan_ReturnsCachedInstanceOnRepeatedCalls() {
-        final MealPlanDTO first = mealPlanService.getMealPlan().block();
-        final MealPlanDTO second = mealPlanService.getMealPlan().block();
+    @DisplayName("getMealPlan returns a footer with the closing note and mapped sources")
+    void getMealPlan_ReturnsFooterFromRepository() {
+        stubHappyPath();
 
-        assertEquals(first, second);
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> {
+                    assertEquals(mealPlanEntity.getFooterNote(), dto.footer().note());
+                    assertEquals(sourceDTOs, dto.footer().sources());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getMealPlan reads every table exactly once per call, replacing the former in-memory cache")
+    void getMealPlan_CallsEachRepositoryAndAssemblerOnce() {
+        stubHappyPath();
+
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .assertNext(dto -> assertEquals("Ernährungsplan & Einkaufsliste", dto.title()))
+                .verifyComplete();
+
+        verify(mealPlanRepository).findById(MealPlanEntity.SINGLETON_ID);
+        verify(mealPlanStatRepository).findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID);
+        verify(mealPlanChangelogEntryRepository).findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID);
+        verify(mealPlanSourceRepository).findAllByMealPlanIdOrderBySortOrderAsc(MealPlanEntity.SINGLETON_ID);
+        verify(mealPlanSectionAssembler).assemble(MealPlanEntity.SINGLETON_ID);
+        verify(mealPlanShoppingListAssembler).assemble(MealPlanEntity.SINGLETON_ID);
+    }
+
+    @Test
+    @DisplayName("getMealPlan emits NoSuchElementException when the singleton meal-plan row is missing")
+    void getMealPlan_MealPlanNotFound_EmitsNoSuchElementException() {
+        when(mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(mealPlanService.getMealPlan())
+                .expectError(NoSuchElementException.class)
+                .verify();
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListAssemblerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListAssemblerTest.java
@@ -1,0 +1,97 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanShoppingCategoryRepository;
+import com.marvin.nutrition.repository.MealPlanShoppingItemRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link MealPlanShoppingListAssembler} covering multi-category item assembly. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanShoppingListAssembler Tests")
+class MealPlanShoppingListAssemblerTest {
+
+    @Mock
+    private MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository;
+
+    @Mock
+    private MealPlanShoppingItemRepository mealPlanShoppingItemRepository;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @InjectMocks
+    private MealPlanShoppingListAssembler mealPlanShoppingListAssembler;
+
+    @Test
+    @DisplayName("assemble loads each category's own items and maps them via the mapper")
+    void assemble_LoadsItemsPerCategoryAndMaps() {
+        final Long mealPlanId = 1L;
+        final UUID categoryOneId = UUID.randomUUID();
+        final UUID categoryTwoId = UUID.randomUUID();
+
+        final MealPlanShoppingCategoryEntity categoryOne = new MealPlanShoppingCategoryEntity();
+        categoryOne.setId(categoryOneId);
+        categoryOne.setTitle("Fleisch & Fisch");
+
+        final MealPlanShoppingCategoryEntity categoryTwo = new MealPlanShoppingCategoryEntity();
+        categoryTwo.setId(categoryTwoId);
+        categoryTwo.setTitle("Milchprodukte & Eier");
+
+        final MealPlanShoppingItemEntity itemOneEntity = new MealPlanShoppingItemEntity();
+        itemOneEntity.setId(UUID.randomUUID());
+        itemOneEntity.setName("Hähnchenbrustfilet");
+        final MealPlanShoppingItemEntity itemTwoEntity = new MealPlanShoppingItemEntity();
+        itemTwoEntity.setId(UUID.randomUUID());
+        itemTwoEntity.setName("Magerquark");
+
+        final MealPlanShoppingItemDTO itemOneDTO =
+                new MealPlanShoppingItemDTO("Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
+        final MealPlanShoppingItemDTO itemTwoDTO =
+                new MealPlanShoppingItemDTO("Magerquark", "Milbona", null, null, "2.100 g");
+
+        final MealPlanShoppingCategoryDTO categoryOneDTO =
+                new MealPlanShoppingCategoryDTO("Fleisch & Fisch", List.of(itemOneDTO));
+        final MealPlanShoppingCategoryDTO categoryTwoDTO =
+                new MealPlanShoppingCategoryDTO("Milchprodukte & Eier", List.of(itemTwoDTO));
+
+        when(mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId))
+                .thenReturn(List.of(categoryOne, categoryTwo));
+        when(mealPlanShoppingItemRepository.findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(categoryOneId))
+                .thenReturn(List.of(itemOneEntity));
+        when(mealPlanShoppingItemRepository.findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(categoryTwoId))
+                .thenReturn(List.of(itemTwoEntity));
+        when(mealPlanMapper.toShoppingItemDTOs(List.of(itemOneEntity))).thenReturn(List.of(itemOneDTO));
+        when(mealPlanMapper.toShoppingItemDTOs(List.of(itemTwoEntity))).thenReturn(List.of(itemTwoDTO));
+        when(mealPlanMapper.toShoppingCategoryDTO(categoryOne, List.of(itemOneDTO))).thenReturn(categoryOneDTO);
+        when(mealPlanMapper.toShoppingCategoryDTO(categoryTwo, List.of(itemTwoDTO))).thenReturn(categoryTwoDTO);
+
+        final List<MealPlanShoppingCategoryDTO> result = mealPlanShoppingListAssembler.assemble(mealPlanId);
+
+        assertEquals(List.of(categoryOneDTO, categoryTwoDTO), result);
+    }
+
+    @Test
+    @DisplayName("assemble returns an empty list when the meal plan has no shopping categories")
+    void assemble_NoCategories_ReturnsEmptyList() {
+        final Long mealPlanId = 1L;
+        when(mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId)).thenReturn(List.of());
+
+        final List<MealPlanShoppingCategoryDTO> result = mealPlanShoppingListAssembler.assemble(mealPlanId);
+
+        assertEquals(List.of(), result);
+    }
+}


### PR DESCRIPTION
## Summary
- Moves the nutrition module's "Ernährungsplan & Einkaufsliste" meal-plan/shopping-list content from a static classpath JSON resource (`nutrition/meal-plan.json`) into 8 fully normalized `nutrition.meal_plan_*` tables, seeded via `V1_10__nutrition_meal_plan.sql` with the exact current content (4 stats, 9 changelog entries, 3 sections/10 rows, 6 shopping categories/14 items, 3 footer sources).
- Adds one entity + one repository per table, a composite `MealPlanMapper`, and two `@Component` assembler helpers (`MealPlanSectionAssembler`, `MealPlanShoppingListAssembler`) so `MealPlanService`'s constructor stays within Checkstyle's 7-parameter limit.
- Rewrites `MealPlanService.getMealPlan()` to assemble the DTO from repositories inside `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())` per call, instead of parsing+caching the JSON resource once at startup. `GET /nutrition/meal-plan`, `MealPlanController`, and all DTOs are unchanged.
- `MealPlanServiceTest` is rewritten (pre-approved exception — old test asserted classpath-loading/"cached forever" behavior that no longer applies); new `MealPlanRepositoryTest`, `MealPlanMapperTest`, `MealPlanSectionAssemblerTest`, `MealPlanShoppingListAssemblerTest` added. `MealPlanControllerTest` is untouched.
- `nutrition/src/main/resources/nutrition/meal-plan.json` is intentionally **kept** for now — see Test plan below.

## Test plan
- [x] `./gradlew :nutrition:compileJava :nutrition:compileTestJava` — compiles.
- [x] `./gradlew :nutrition:test` (all non-Testcontainers tests: service/mapper/assembler/controller/dto) — pass.
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — zero warnings.
- [x] Migration content verified programmatically: every string field from `meal-plan.json` diffed against the migration's SQL literals (full match), and row counts per table checked (1 header, 4 stats, 9 changelog, 3 sections, 10 rows, 6 categories, 14 items, 3 sources).
- [ ] `MealPlanRepositoryTest` (Testcontainers/`@DataJpaTest`) — compiles and passes checkstyle but was **not executed locally** (Docker is not available/permitted in this sandbox); should run in CI, same as the pre-existing `MealTemplateRepositoryTest` it mirrors.
- [ ] End-to-end check (`docker compose -f docker-compose-local.yaml up -d`, start app, `curl http://localhost:<port>/nutrition/meal-plan | jq .`, diff against `meal-plan.json`) — **not performed** for the same Docker-sandbox reason. `meal-plan.json` is deliberately left in place until this is done; please run it (or let CI's Testcontainers run confirm the migration applies) before deleting the JSON file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)