### PR TITLE
Add REST write endpoints for meal-plan content corrections

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
@@ -1,46 +1,82 @@
 package com.marvin.nutrition.controller;
 
+import com.marvin.nutrition.dto.CreateMealPlanChangelogEntryRequest;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
 import com.marvin.nutrition.dto.MealPlanDTO;
+import com.marvin.nutrition.dto.MealPlanHeaderDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSourceRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanStatRequest;
 import com.marvin.nutrition.service.MealPlanService;
+import com.marvin.nutrition.service.MealPlanWriteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
- * REST controller serving the static weekly meal-plan reference document.
- * This is read-only content bundled with the application, not user-editable data.
+ * REST controller serving the weekly meal-plan reference document and its content-write endpoints.
+ * The document is assembled from normalized database tables; its content (section text, row
+ * details/macros, headline stats, shopping list, changelog, header text) can be corrected through
+ * this API instead of hand-written SQL or new Flyway migrations.
  */
 @RestController
 @RequestMapping("/nutrition/meal-plan")
 @Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
 public class MealPlanController {
 
+    private static final String CHANGELOG_LOCATION_PREFIX = "/nutrition/meal-plan/changelog/";
+
     private final MealPlanService mealPlanService;
+    private final MealPlanWriteService mealPlanWriteService;
 
     /**
      * Creates a new MealPlanController.
      *
-     * @param mealPlanService the service serving the bundled meal-plan document
+     * @param mealPlanService      the service serving the assembled meal-plan document
+     * @param mealPlanWriteService the service owning the meal-plan's transactional write operations
      */
-    public MealPlanController(MealPlanService mealPlanService) {
+    public MealPlanController(MealPlanService mealPlanService, MealPlanWriteService mealPlanWriteService) {
         this.mealPlanService = mealPlanService;
+        this.mealPlanWriteService = mealPlanWriteService;
     }
 
     /**
-     * Returns the static weekly meal-plan reference document.
+     * Returns the weekly meal-plan reference document.
      *
      * @return a Mono emitting the meal-plan DTO
      */
     @GetMapping
     @Operation(
             summary = "Get the weekly meal plan",
-            description = "Returns the static weekly meal-plan reference document, including the shopping list.",
+            description = "Returns the weekly meal-plan reference document, including the shopping list.",
             responses = {
                 @ApiResponse(
                         responseCode = "200",
@@ -51,5 +87,245 @@ public class MealPlanController {
     )
     public Mono<MealPlanDTO> getMealPlan() {
         return mealPlanService.getMealPlan();
+    }
+
+    /**
+     * Updates the meal plan's header content, or returns 404 if the singleton row is missing.
+     *
+     * @param req the update request body
+     * @return a Mono with 200 and the updated header DTO, or 404 if not found
+     */
+    @PutMapping
+    @Operation(
+            summary = "Update the meal plan's header content",
+            description = "Applies partial updates to the meal plan's header (eyebrow, title, description, "
+                    + "shopping-list title/note/callout, footer note).",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Meal plan header updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanHeaderDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Meal plan not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanHeaderDTO>> updateMealPlan(@Valid @RequestBody UpdateMealPlanRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateMealPlan(req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan section, or returns 404 if not found.
+     *
+     * @param id  the UUID of the section to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated section DTO, or 404 if not found
+     */
+    @PutMapping("/sections/{id}")
+    @Operation(
+            summary = "Update a meal-plan section",
+            description = "Applies partial updates to an existing meal-plan section's title, note and/or callout.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Section updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanSectionDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Section not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanSectionDTO>> updateSection(
+            @PathVariable @Parameter(description = "UUID of the section to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanSectionRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateSection(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan row, or returns 404 if not found.
+     *
+     * @param id  the UUID of the row to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated row DTO, or 404 if not found
+     */
+    @PutMapping("/rows/{id}")
+    @Operation(
+            summary = "Update a meal-plan row",
+            description = "Applies partial updates to an existing meal-plan row's meal, details, quantity, "
+                    + "kcal and/or protein.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Row updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanRowDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Row not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanRowDTO>> updateRow(
+            @PathVariable @Parameter(description = "UUID of the row to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanRowRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateRow(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan headline statistic, or returns 404 if not found.
+     *
+     * @param id  the UUID of the stat to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated stat DTO, or 404 if not found
+     */
+    @PutMapping("/stats/{id}")
+    @Operation(
+            summary = "Update a meal-plan headline statistic",
+            description = "Applies partial updates to an existing headline statistic's label and/or value.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Stat updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanStatDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Stat not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanStatDTO>> updateStat(
+            @PathVariable @Parameter(description = "UUID of the stat to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanStatRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateStat(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan shopping-list category, or returns 404 if not found.
+     *
+     * @param id  the UUID of the category to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated category DTO, or 404 if not found
+     */
+    @PutMapping("/shopping-categories/{id}")
+    @Operation(
+            summary = "Update a meal-plan shopping-list category",
+            description = "Applies partial updates to an existing shopping-list category's title.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Shopping category updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanShoppingCategoryDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Shopping category not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanShoppingCategoryDTO>> updateShoppingCategory(
+            @PathVariable @Parameter(description = "UUID of the shopping category to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanShoppingCategoryRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateShoppingCategory(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan shopping-list item, or returns 404 if not found.
+     *
+     * @param id  the UUID of the item to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated item DTO, or 404 if not found
+     */
+    @PutMapping("/shopping-items/{id}")
+    @Operation(
+            summary = "Update a meal-plan shopping-list item",
+            description = "Applies partial updates to an existing shopping-list item's name, brand, badge, "
+                    + "badge text and/or quantity.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Shopping item updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanShoppingItemDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Shopping item not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanShoppingItemDTO>> updateShoppingItem(
+            @PathVariable @Parameter(description = "UUID of the shopping item to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanShoppingItemRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateShoppingItem(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Updates a meal-plan footer source, or returns 404 if not found.
+     *
+     * @param id  the UUID of the source to update
+     * @param req the update request body
+     * @return a Mono with 200 and the updated source DTO, or 404 if not found
+     */
+    @PutMapping("/sources/{id}")
+    @Operation(
+            summary = "Update a meal-plan footer source",
+            description = "Applies partial updates to an existing footer source's label and/or URL.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Source updated",
+                        content = @Content(schema = @Schema(implementation = MealPlanSourceDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed"),
+                @ApiResponse(responseCode = "404", description = "Source not found")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanSourceDTO>> updateSource(
+            @PathVariable @Parameter(description = "UUID of the source to update") UUID id,
+            @Valid @RequestBody UpdateMealPlanSourceRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.updateSource(id, req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Appends a new entry to the meal plan's changelog and returns 201 Created with a Location header.
+     *
+     * @param req the create request body
+     * @return a Mono with 201 Created, Location header, and the created changelog entry DTO
+     */
+    @PostMapping("/changelog")
+    @Operation(
+            summary = "Append a meal-plan changelog entry",
+            description = "Appends a new entry to the meal plan's changelog. The changelog is an append-only "
+                    + "historical log; there is no update or delete operation for existing entries.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Changelog entry created; Location header contains the URI",
+                        content = @Content(schema = @Schema(implementation = MealPlanChangelogEntryDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Validation failed or missing required fields")
+            }
+    )
+    public Mono<ResponseEntity<MealPlanChangelogEntryDTO>> addChangelogEntry(
+            @Valid @RequestBody CreateMealPlanChangelogEntryRequest req) {
+        return Mono.fromCallable(() -> mealPlanWriteService.addChangelogEntry(req))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(created -> {
+                    final URI location = URI.create(CHANGELOG_LOCATION_PREFIX + created.id());
+                    return ResponseEntity.status(HttpStatus.CREATED).location(location).body(created);
+                });
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealPlanChangelogEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealPlanChangelogEntryRequest.java
@@ -1,0 +1,36 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request body for appending a new entry to the meal plan's changelog.
+ * The changelog is an append-only historical log, so {@code tag}, {@code text} and {@code sortOrder}
+ * are required; only {@code was} is optional since newly introduced items have no previous value.
+ *
+ * @param tag       short label identifying what changed (required)
+ * @param was       the previous value, or {@code null} if this is a newly introduced item
+ * @param text      description of the change (required)
+ * @param sortOrder display position of the entry (required)
+ */
+@Schema(description = "Request to append a new entry to the meal plan's changelog")
+public record CreateMealPlanChangelogEntryRequest(
+        @NotBlank
+        @Schema(description = "Short label identifying what changed", example = "Whey")
+        String tag,
+
+        @NullOrNotBlank
+        @Schema(description = "Previous value, absent if this is a newly introduced item", example = "80 g/Tag (2×40 g)")
+        String was,
+
+        @NotBlank
+        @Schema(description = "Description of the change", example = "→ 40 g/Tag")
+        String text,
+
+        @NotNull
+        @Schema(description = "Display position of the entry", example = "0")
+        Integer sortOrder
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanChangelogEntryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanChangelogEntryDTO.java
@@ -1,17 +1,22 @@
 package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single changelog entry describing a change compared to the previous
  * plan version.
  *
+ * @param id   the changelog entry's unique identifier
  * @param tag  short label identifying what changed
  * @param was  the previous value, or {@code null} if this is a newly introduced item
  * @param text description of the change
  */
 @Schema(description = "A changelog entry describing a change compared to the previous plan version")
 public record MealPlanChangelogEntryDTO(
+        @Schema(description = "Changelog entry unique identifier")
+        UUID id,
+
         @Schema(description = "Short label identifying what changed", example = "Whey")
         String tag,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanHeaderDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanHeaderDTO.java
@@ -1,0 +1,39 @@
+package com.marvin.nutrition.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing the meal plan's header content, returned after updating it.
+ *
+ * @param eyebrow             small label shown above the title
+ * @param title               document title
+ * @param description         short description of the plan's goal and approach
+ * @param shoppingListTitle   the shopping list's title
+ * @param shoppingListNote    short note describing the shopping list's scope
+ * @param shoppingListCallout optional explanatory callout text for the shopping list, or {@code null} if none
+ * @param footerNote          closing note explaining where the nutritional data comes from
+ */
+@Schema(description = "The meal plan's header content")
+public record MealPlanHeaderDTO(
+        @Schema(description = "Small label shown above the title", example = "Version 2 — abgeglichen mit Tracking & Lebensmitteldatenbank")
+        String eyebrow,
+
+        @Schema(description = "Document title", example = "Ernährungsplan & Einkaufsliste")
+        String title,
+
+        @Schema(description = "Short description of the plan's goal and approach")
+        String description,
+
+        @Schema(description = "Shopping list title", example = "4 · Einkaufsliste für Lidl (1 Woche)")
+        String shoppingListTitle,
+
+        @Schema(description = "Short note describing the shopping list's scope")
+        String shoppingListNote,
+
+        @Schema(description = "Optional explanatory callout text for the shopping list, absent if none")
+        String shoppingListCallout,
+
+        @Schema(description = "Closing note explaining where the nutritional data comes from")
+        String footerNote
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanRowDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanRowDTO.java
@@ -1,10 +1,12 @@
 package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single meal row within a meal plan section.
  *
+ * @param id      the row's unique identifier
  * @param meal    the meal's name
  * @param details description of the meal's ingredients
  * @param qty     quantities of the ingredients as a display string
@@ -13,6 +15,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @Schema(description = "A single meal row within a meal plan section")
 public record MealPlanRowDTO(
+        @Schema(description = "Row unique identifier")
+        UUID id,
+
         @Schema(description = "Meal name", example = "Frühstück")
         String meal,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
@@ -2,11 +2,13 @@ package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single section of the meal plan, e.g. a daily structure or a
  * group of weekdays sharing the same meals.
  *
+ * @param id      the section's unique identifier
  * @param title   the section's title
  * @param note    short note describing the section
  * @param rows    the meal rows making up this section
@@ -15,6 +17,9 @@ import java.util.List;
  */
 @Schema(description = "A single section of the meal plan")
 public record MealPlanSectionDTO(
+        @Schema(description = "Section unique identifier")
+        UUID id,
+
         @Schema(description = "Section title", example = "1 · Tagesstruktur (täglich gleich)")
         String title,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingCategoryDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingCategoryDTO.java
@@ -2,15 +2,20 @@ package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single category on the shopping list, e.g. "Fleisch & Fisch".
  *
+ * @param id    the category's unique identifier
  * @param title the category's title
  * @param items the items in this category
  */
 @Schema(description = "A single category on the shopping list")
 public record MealPlanShoppingCategoryDTO(
+        @Schema(description = "Category unique identifier")
+        UUID id,
+
         @Schema(description = "Category title", example = "Fleisch & Fisch")
         String title,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingItemDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanShoppingItemDTO.java
@@ -1,10 +1,12 @@
 package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single item on the shopping list.
  *
+ * @param id        the item's unique identifier
  * @param name      the item's name
  * @param brand     brand or sourcing note, or {@code null} if none
  * @param badge     badge severity, either {@code "ok"} or {@code "warn"}, or {@code null} if none
@@ -13,6 +15,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @Schema(description = "A single item on the shopping list")
 public record MealPlanShoppingItemDTO(
+        @Schema(description = "Item unique identifier")
+        UUID id,
+
         @Schema(description = "Item name", example = "Hähnchenbrustfilet")
         String name,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSourceDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSourceDTO.java
@@ -1,15 +1,20 @@
 package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single external data source referenced by the meal plan.
  *
+ * @param id    the source's unique identifier
  * @param label display label of the source
  * @param url   link to the source
  */
 @Schema(description = "A single external data source referenced by the meal plan")
 public record MealPlanSourceDTO(
+        @Schema(description = "Source unique identifier")
+        UUID id,
+
         @Schema(description = "Display label of the source", example = "Magerquark (Milbona/Milsani, fatsecret.de)")
         String label,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanStatDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanStatDTO.java
@@ -1,15 +1,20 @@
 package com.marvin.nutrition.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 /**
  * Data Transfer Object representing a single headline statistic shown in the meal plan's summary bar.
  *
+ * @param id    the statistic's unique identifier
  * @param label the statistic's label
  * @param value the statistic's display value
  */
 @Schema(description = "A headline statistic shown in the meal plan's summary bar")
 public record MealPlanStatDTO(
+        @Schema(description = "Statistic unique identifier")
+        UUID id,
+
         @Schema(description = "Statistic label", example = "Tagesbudget (Ø)")
         String label,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRequest.java
@@ -1,0 +1,48 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating the meal plan's header content.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param eyebrow              updated small label shown above the title (nullable)
+ * @param title                updated document title (nullable)
+ * @param description          updated short description of the plan's goal and approach (nullable)
+ * @param shoppingListTitle    updated shopping list title (nullable)
+ * @param shoppingListNote     updated shopping list note (nullable)
+ * @param shoppingListCallout  updated shopping list callout text (nullable)
+ * @param footerNote           updated closing note (nullable)
+ */
+@Schema(description = "Request to update the meal plan's header content")
+public record UpdateMealPlanRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated small label shown above the title", example = "Version 3 — abgeglichen mit Tracking")
+        String eyebrow,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated document title", example = "Ernährungsplan & Einkaufsliste")
+        String title,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated short description of the plan's goal and approach")
+        String description,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated shopping list title", example = "4 · Einkaufsliste für Lidl (1 Woche)")
+        String shoppingListTitle,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated shopping list note", example = "4× Kantine Mo–Do · 3× Selbstkochen Fr–So")
+        String shoppingListNote,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated shopping list callout text")
+        String shoppingListCallout,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated closing note explaining where the nutritional data comes from")
+        String footerNote
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRowRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRowRequest.java
@@ -1,0 +1,38 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan row.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param meal    updated meal name (nullable)
+ * @param details updated description of the meal's ingredients (nullable)
+ * @param qty     updated quantities of the ingredients as a display string (nullable)
+ * @param kcal    updated kilocalories as a display string (nullable)
+ * @param protein updated grams of protein as a display string (nullable)
+ */
+@Schema(description = "Request to update a meal-plan row")
+public record UpdateMealPlanRowRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated meal name", example = "Frühstück")
+        String meal,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated description of the meal's ingredients")
+        String details,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated quantities of the ingredients as a display string", example = "90g/200ml/20g/100g/50g/10g/1 Stk")
+        String qty,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated kilocalories as a display string", example = "663")
+        String kcal,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated grams of protein as a display string", example = "46,5 g")
+        String protein
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
@@ -1,0 +1,28 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan section.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param title   updated section title (nullable)
+ * @param note    updated short note describing the section (nullable)
+ * @param callout updated explanatory callout text (nullable)
+ */
+@Schema(description = "Request to update a meal-plan section")
+public record UpdateMealPlanSectionRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated section title", example = "1 · Tagesstruktur (täglich gleich)")
+        String title,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated short note describing the section")
+        String note,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated explanatory callout text")
+        String callout
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingCategoryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingCategoryRequest.java
@@ -1,0 +1,18 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan shopping-list category.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param title updated category title (nullable)
+ */
+@Schema(description = "Request to update a meal-plan shopping-list category")
+public record UpdateMealPlanShoppingCategoryRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated category title", example = "Fleisch & Fisch")
+        String title
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingItemRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingItemRequest.java
@@ -1,0 +1,38 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan shopping-list item.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param name      updated item name (nullable)
+ * @param brand     updated brand or sourcing note (nullable)
+ * @param badge     updated badge severity, either {@code "ok"} or {@code "warn"} (nullable)
+ * @param badgeText updated text shown alongside the badge (nullable)
+ * @param qty       updated quantity to buy as a display string (nullable)
+ */
+@Schema(description = "Request to update a meal-plan shopping-list item")
+public record UpdateMealPlanShoppingItemRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated item name", example = "Hähnchenbrustfilet")
+        String name,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated brand or sourcing note", example = "frisch, Kühltheke")
+        String brand,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated badge severity", example = "warn", allowableValues = {"ok", "warn"})
+        String badge,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated text shown alongside the badge", example = "nur 1.200 g verfügbar")
+        String badgeText,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated quantity to buy as a display string", example = "1.200 g")
+        String qty
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSourceRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSourceRequest.java
@@ -1,0 +1,23 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan footer source.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param label updated display label of the source (nullable)
+ * @param url   updated link to the source (nullable)
+ */
+@Schema(description = "Request to update a meal-plan footer source")
+public record UpdateMealPlanSourceRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated display label of the source", example = "Magerquark (Milbona/Milsani, fatsecret.de)")
+        String label,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated link to the source", example = "https://www.fatsecret.de/magerquark")
+        String url
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanStatRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanStatRequest.java
@@ -1,0 +1,23 @@
+package com.marvin.nutrition.dto;
+
+import com.marvin.nutrition.dto.validation.NullOrNotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for updating a meal-plan headline statistic.
+ * All fields are optional; only non-null values are applied.
+ *
+ * @param label updated statistic label (nullable)
+ * @param value updated statistic display value (nullable)
+ */
+@Schema(description = "Request to update a meal-plan headline statistic")
+public record UpdateMealPlanStatRequest(
+        @NullOrNotBlank
+        @Schema(description = "Updated statistic label", example = "Tagesbudget (Ø)")
+        String label,
+
+        @NullOrNotBlank
+        @Schema(description = "Updated statistic display value", example = "2.416 kcal")
+        String value
+) {
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionWriteService.java
@@ -1,0 +1,113 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanRowRepository;
+import com.marvin.nutrition.repository.MealPlanSectionRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the transactional write operations for meal-plan sections and rows.
+ *
+ * <p>All methods in this service perform blocking repository access and must only be called from
+ * a thread already running on a blocking-friendly scheduler (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}),
+ * and must be invoked from outside this bean so that Spring's transactional proxy is applied.</p>
+ */
+@Service
+public class MealPlanSectionWriteService {
+
+    private final MealPlanSectionRepository mealPlanSectionRepository;
+    private final MealPlanRowRepository mealPlanRowRepository;
+    private final MealPlanMapper mealPlanMapper;
+
+    /**
+     * Creates a new MealPlanSectionWriteService with the required dependencies.
+     *
+     * @param mealPlanSectionRepository JPA repository for meal-plan sections
+     * @param mealPlanRowRepository     JPA repository for meal-plan rows
+     * @param mealPlanMapper            MapStruct mapper for entity/DTO conversion
+     */
+    public MealPlanSectionWriteService(
+            MealPlanSectionRepository mealPlanSectionRepository,
+            MealPlanRowRepository mealPlanRowRepository,
+            MealPlanMapper mealPlanMapper) {
+        this.mealPlanSectionRepository = mealPlanSectionRepository;
+        this.mealPlanRowRepository = mealPlanRowRepository;
+        this.mealPlanMapper = mealPlanMapper;
+    }
+
+    /**
+     * Updates an existing meal-plan section's title, note and/or callout.
+     * Only non-null fields from the request are applied. The returned DTO includes the section's
+     * current (unmodified) rows.
+     * Throws {@link NoSuchElementException} if no section with the given id exists.
+     *
+     * @param id  the UUID of the section to update
+     * @param req the update request
+     * @return the updated section DTO, including its rows
+     */
+    @Transactional
+    public MealPlanSectionDTO updateSection(UUID id, UpdateMealPlanSectionRequest req) {
+        final MealPlanSectionEntity section = mealPlanSectionRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan section not found: " + id));
+
+        if (req.title() != null) {
+            section.setTitle(req.title());
+        }
+        if (req.note() != null) {
+            section.setNote(req.note());
+        }
+        if (req.callout() != null) {
+            section.setCallout(req.callout());
+        }
+
+        final MealPlanSectionEntity saved = mealPlanSectionRepository.save(section);
+        final List<MealPlanRowEntity> rowEntities =
+                mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(saved.getId());
+        final List<MealPlanRowDTO> rows = mealPlanMapper.toRowDTOs(rowEntities);
+        return mealPlanMapper.toSectionDTO(saved, rows);
+    }
+
+    /**
+     * Updates an existing meal-plan row's meal, details, quantity, kcal and/or protein.
+     * Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if no row with the given id exists.
+     *
+     * @param id  the UUID of the row to update
+     * @param req the update request
+     * @return the updated row DTO
+     */
+    @Transactional
+    public MealPlanRowDTO updateRow(UUID id, UpdateMealPlanRowRequest req) {
+        final MealPlanRowEntity row = mealPlanRowRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan row not found: " + id));
+
+        if (req.meal() != null) {
+            row.setMeal(req.meal());
+        }
+        if (req.details() != null) {
+            row.setDetails(req.details());
+        }
+        if (req.qty() != null) {
+            row.setQty(req.qty());
+        }
+        if (req.kcal() != null) {
+            row.setKcal(req.kcal());
+        }
+        if (req.protein() != null) {
+            row.setProtein(req.protein());
+        }
+
+        final MealPlanRowEntity saved = mealPlanRowRepository.save(row);
+        return mealPlanMapper.toRowDTO(saved);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanShoppingListWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanShoppingListWriteService.java
@@ -1,0 +1,107 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanShoppingCategoryRepository;
+import com.marvin.nutrition.repository.MealPlanShoppingItemRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the transactional write operations for meal-plan shopping-list categories and items.
+ *
+ * <p>All methods in this service perform blocking repository access and must only be called from
+ * a thread already running on a blocking-friendly scheduler (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}),
+ * and must be invoked from outside this bean so that Spring's transactional proxy is applied.</p>
+ */
+@Service
+public class MealPlanShoppingListWriteService {
+
+    private final MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository;
+    private final MealPlanShoppingItemRepository mealPlanShoppingItemRepository;
+    private final MealPlanMapper mealPlanMapper;
+
+    /**
+     * Creates a new MealPlanShoppingListWriteService with the required dependencies.
+     *
+     * @param mealPlanShoppingCategoryRepository JPA repository for shopping categories
+     * @param mealPlanShoppingItemRepository     JPA repository for shopping items
+     * @param mealPlanMapper                     MapStruct mapper for entity/DTO conversion
+     */
+    public MealPlanShoppingListWriteService(
+            MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository,
+            MealPlanShoppingItemRepository mealPlanShoppingItemRepository,
+            MealPlanMapper mealPlanMapper) {
+        this.mealPlanShoppingCategoryRepository = mealPlanShoppingCategoryRepository;
+        this.mealPlanShoppingItemRepository = mealPlanShoppingItemRepository;
+        this.mealPlanMapper = mealPlanMapper;
+    }
+
+    /**
+     * Updates an existing shopping category's title.
+     * Only non-null fields from the request are applied. The returned DTO includes the category's
+     * current (unmodified) items.
+     * Throws {@link NoSuchElementException} if no category with the given id exists.
+     *
+     * @param id  the UUID of the category to update
+     * @param req the update request
+     * @return the updated category DTO, including its items
+     */
+    @Transactional
+    public MealPlanShoppingCategoryDTO updateShoppingCategory(UUID id, UpdateMealPlanShoppingCategoryRequest req) {
+        final MealPlanShoppingCategoryEntity category = mealPlanShoppingCategoryRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan shopping category not found: " + id));
+
+        if (req.title() != null) {
+            category.setTitle(req.title());
+        }
+
+        final MealPlanShoppingCategoryEntity saved = mealPlanShoppingCategoryRepository.save(category);
+        final List<MealPlanShoppingItemEntity> itemEntities = mealPlanShoppingItemRepository
+                .findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(saved.getId());
+        final List<MealPlanShoppingItemDTO> items = mealPlanMapper.toShoppingItemDTOs(itemEntities);
+        return mealPlanMapper.toShoppingCategoryDTO(saved, items);
+    }
+
+    /**
+     * Updates an existing shopping item's name, brand, badge, badge text and/or quantity.
+     * Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if no item with the given id exists.
+     *
+     * @param id  the UUID of the item to update
+     * @param req the update request
+     * @return the updated item DTO
+     */
+    @Transactional
+    public MealPlanShoppingItemDTO updateShoppingItem(UUID id, UpdateMealPlanShoppingItemRequest req) {
+        final MealPlanShoppingItemEntity item = mealPlanShoppingItemRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan shopping item not found: " + id));
+
+        if (req.name() != null) {
+            item.setName(req.name());
+        }
+        if (req.brand() != null) {
+            item.setBrand(req.brand());
+        }
+        if (req.badge() != null) {
+            item.setBadge(req.badge());
+        }
+        if (req.badgeText() != null) {
+            item.setBadgeText(req.badgeText());
+        }
+        if (req.qty() != null) {
+            item.setQty(req.qty());
+        }
+
+        final MealPlanShoppingItemEntity saved = mealPlanShoppingItemRepository.save(item);
+        return mealPlanMapper.toShoppingItemDTO(saved);
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanWriteService.java
@@ -1,0 +1,250 @@
+package com.marvin.nutrition.service;
+
+import com.marvin.nutrition.dto.CreateMealPlanChangelogEntryRequest;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
+import com.marvin.nutrition.dto.MealPlanHeaderDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSourceRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanStatRequest;
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import com.marvin.nutrition.entity.MealPlanEntity;
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanChangelogEntryRepository;
+import com.marvin.nutrition.repository.MealPlanRepository;
+import com.marvin.nutrition.repository.MealPlanSourceRepository;
+import com.marvin.nutrition.repository.MealPlanStatRepository;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the transactional write operations for the weekly meal-plan reference document, so that
+ * content corrections can be made through the REST API instead of hand-written SQL or new Flyway
+ * migrations.
+ *
+ * <p>Header, headline-stat, footer-source and changelog updates are handled directly by this
+ * service. Section/row and shopping-category/item updates are delegated to
+ * {@link MealPlanSectionWriteService} and {@link MealPlanShoppingListWriteService} respectively, to
+ * keep this facade's constructor within the project's parameter-count limit while still exposing a
+ * single write-service entry point per the module's read-side {@code MealPlanService} counterpart.</p>
+ *
+ * <p>All methods in this service perform blocking repository access (directly or via the delegate
+ * services) and must only be called from a thread already running on a blocking-friendly scheduler
+ * (e.g. {@link reactor.core.scheduler.Schedulers#boundedElastic()}), and must be invoked from
+ * outside this bean so that Spring's transactional proxy is applied.</p>
+ */
+@Service
+public class MealPlanWriteService {
+
+    private final MealPlanRepository mealPlanRepository;
+    private final MealPlanStatRepository mealPlanStatRepository;
+    private final MealPlanSourceRepository mealPlanSourceRepository;
+    private final MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository;
+    private final MealPlanMapper mealPlanMapper;
+    private final MealPlanSectionWriteService mealPlanSectionWriteService;
+    private final MealPlanShoppingListWriteService mealPlanShoppingListWriteService;
+
+    /**
+     * Creates a new MealPlanWriteService with the required dependencies.
+     *
+     * @param mealPlanRepository                JPA repository for the meal-plan header
+     * @param mealPlanStatRepository            JPA repository for headline stats
+     * @param mealPlanSourceRepository          JPA repository for footer sources
+     * @param mealPlanChangelogEntryRepository  JPA repository for changelog entries
+     * @param mealPlanMapper                    MapStruct mapper for entity/DTO conversion
+     * @param mealPlanSectionWriteService       delegate owning section/row write operations
+     * @param mealPlanShoppingListWriteService  delegate owning shopping category/item write operations
+     */
+    public MealPlanWriteService(
+            MealPlanRepository mealPlanRepository,
+            MealPlanStatRepository mealPlanStatRepository,
+            MealPlanSourceRepository mealPlanSourceRepository,
+            MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository,
+            MealPlanMapper mealPlanMapper,
+            MealPlanSectionWriteService mealPlanSectionWriteService,
+            MealPlanShoppingListWriteService mealPlanShoppingListWriteService) {
+        this.mealPlanRepository = mealPlanRepository;
+        this.mealPlanStatRepository = mealPlanStatRepository;
+        this.mealPlanSourceRepository = mealPlanSourceRepository;
+        this.mealPlanChangelogEntryRepository = mealPlanChangelogEntryRepository;
+        this.mealPlanMapper = mealPlanMapper;
+        this.mealPlanSectionWriteService = mealPlanSectionWriteService;
+        this.mealPlanShoppingListWriteService = mealPlanShoppingListWriteService;
+    }
+
+    /**
+     * Updates the meal plan's header content (eyebrow, title, description, shopping-list title/note/callout,
+     * footer note). Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if the singleton meal-plan row is missing (should not happen
+     * once the seeding migration has run).
+     *
+     * @param req the update request
+     * @return the updated header DTO
+     */
+    @Transactional
+    public MealPlanHeaderDTO updateMealPlan(UpdateMealPlanRequest req) {
+        final MealPlanEntity entity = mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan not found"));
+
+        if (req.eyebrow() != null) {
+            entity.setEyebrow(req.eyebrow());
+        }
+        if (req.title() != null) {
+            entity.setTitle(req.title());
+        }
+        if (req.description() != null) {
+            entity.setDescription(req.description());
+        }
+        if (req.shoppingListTitle() != null) {
+            entity.setShoppingListTitle(req.shoppingListTitle());
+        }
+        if (req.shoppingListNote() != null) {
+            entity.setShoppingListNote(req.shoppingListNote());
+        }
+        if (req.shoppingListCallout() != null) {
+            entity.setShoppingListCallout(req.shoppingListCallout());
+        }
+        if (req.footerNote() != null) {
+            entity.setFooterNote(req.footerNote());
+        }
+
+        final MealPlanEntity saved = mealPlanRepository.save(entity);
+        return new MealPlanHeaderDTO(
+                saved.getEyebrow(), saved.getTitle(), saved.getDescription(),
+                saved.getShoppingListTitle(), saved.getShoppingListNote(), saved.getShoppingListCallout(),
+                saved.getFooterNote());
+    }
+
+    /**
+     * Updates an existing headline statistic's label and/or value.
+     * Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if no stat with the given id exists.
+     *
+     * @param id  the UUID of the stat to update
+     * @param req the update request
+     * @return the updated stat DTO
+     */
+    @Transactional
+    public MealPlanStatDTO updateStat(UUID id, UpdateMealPlanStatRequest req) {
+        final MealPlanStatEntity stat = mealPlanStatRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan stat not found: " + id));
+
+        if (req.label() != null) {
+            stat.setLabel(req.label());
+        }
+        if (req.value() != null) {
+            stat.setValue(req.value());
+        }
+
+        final MealPlanStatEntity saved = mealPlanStatRepository.save(stat);
+        return mealPlanMapper.toStatDTO(saved);
+    }
+
+    /**
+     * Updates an existing footer source's label and/or URL.
+     * Only non-null fields from the request are applied.
+     * Throws {@link NoSuchElementException} if no source with the given id exists.
+     *
+     * @param id  the UUID of the source to update
+     * @param req the update request
+     * @return the updated source DTO
+     */
+    @Transactional
+    public MealPlanSourceDTO updateSource(UUID id, UpdateMealPlanSourceRequest req) {
+        final MealPlanSourceEntity source = mealPlanSourceRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan source not found: " + id));
+
+        if (req.label() != null) {
+            source.setLabel(req.label());
+        }
+        if (req.url() != null) {
+            source.setUrl(req.url());
+        }
+
+        final MealPlanSourceEntity saved = mealPlanSourceRepository.save(source);
+        return mealPlanMapper.toSourceDTO(saved);
+    }
+
+    /**
+     * Appends a new entry to the meal plan's changelog. The changelog is an append-only historical
+     * log; there is no update or delete operation for existing entries.
+     *
+     * @param req the create request, containing the required tag/text/sortOrder and optional was
+     * @return the created changelog entry DTO
+     */
+    @Transactional
+    public MealPlanChangelogEntryDTO addChangelogEntry(CreateMealPlanChangelogEntryRequest req) {
+        final MealPlanChangelogEntryEntity entity = new MealPlanChangelogEntryEntity();
+        entity.setMealPlanId(MealPlanEntity.SINGLETON_ID);
+        entity.setTag(req.tag());
+        entity.setWas(req.was());
+        entity.setText(req.text());
+        entity.setSortOrder(req.sortOrder());
+
+        final MealPlanChangelogEntryEntity saved = mealPlanChangelogEntryRepository.save(entity);
+        return mealPlanMapper.toChangelogEntryDTO(saved);
+    }
+
+    /**
+     * Updates an existing meal-plan section's title, note and/or callout.
+     * Delegates to {@link MealPlanSectionWriteService#updateSection(UUID, UpdateMealPlanSectionRequest)}.
+     *
+     * @param id  the UUID of the section to update
+     * @param req the update request
+     * @return the updated section DTO, including its rows
+     */
+    public MealPlanSectionDTO updateSection(UUID id, UpdateMealPlanSectionRequest req) {
+        return mealPlanSectionWriteService.updateSection(id, req);
+    }
+
+    /**
+     * Updates an existing meal-plan row's meal, details, quantity, kcal and/or protein.
+     * Delegates to {@link MealPlanSectionWriteService#updateRow(UUID, UpdateMealPlanRowRequest)}.
+     *
+     * @param id  the UUID of the row to update
+     * @param req the update request
+     * @return the updated row DTO
+     */
+    public MealPlanRowDTO updateRow(UUID id, UpdateMealPlanRowRequest req) {
+        return mealPlanSectionWriteService.updateRow(id, req);
+    }
+
+    /**
+     * Updates an existing shopping category's title.
+     * Delegates to
+     * {@link MealPlanShoppingListWriteService#updateShoppingCategory(UUID, UpdateMealPlanShoppingCategoryRequest)}.
+     *
+     * @param id  the UUID of the category to update
+     * @param req the update request
+     * @return the updated category DTO, including its items
+     */
+    public MealPlanShoppingCategoryDTO updateShoppingCategory(UUID id, UpdateMealPlanShoppingCategoryRequest req) {
+        return mealPlanShoppingListWriteService.updateShoppingCategory(id, req);
+    }
+
+    /**
+     * Updates an existing shopping item's name, brand, badge, badge text and/or quantity.
+     * Delegates to
+     * {@link MealPlanShoppingListWriteService#updateShoppingItem(UUID, UpdateMealPlanShoppingItemRequest)}.
+     *
+     * @param id  the UUID of the item to update
+     * @param req the update request
+     * @return the updated item DTO
+     */
+    public MealPlanShoppingItemDTO updateShoppingItem(UUID id, UpdateMealPlanShoppingItemRequest req) {
+        return mealPlanShoppingListWriteService.updateShoppingItem(id, req);
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
@@ -1,14 +1,37 @@
 package com.marvin.nutrition.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marvin.nutrition.dto.CreateMealPlanChangelogEntryRequest;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
 import com.marvin.nutrition.dto.MealPlanDTO;
 import com.marvin.nutrition.dto.MealPlanFooterDTO;
+import com.marvin.nutrition.dto.MealPlanHeaderDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
 import com.marvin.nutrition.dto.MealPlanShoppingListDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSourceRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanStatRequest;
 import com.marvin.nutrition.service.MealPlanService;
+import com.marvin.nutrition.service.MealPlanWriteService;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,16 +39,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-/** Unit tests for {@link MealPlanController} covering the read-only meal-plan endpoint. */
+/** Unit tests for {@link MealPlanController} covering the meal-plan read endpoint and its content-write endpoints. */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MealPlanController Tests")
 class MealPlanControllerTest {
 
     @Mock
     private MealPlanService mealPlanService;
+
+    @Mock
+    private MealPlanWriteService mealPlanWriteService;
 
     @InjectMocks
     private MealPlanController mealPlanController;
@@ -62,5 +89,297 @@ class MealPlanControllerTest {
                 .verifyComplete();
 
         verify(mealPlanService).getMealPlan();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateMealPlan returns 200 with the updated header")
+    void updateMealPlan_Returns200WithUpdatedHeader() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest("new eyebrow", null, null, null, null, null, null);
+        final MealPlanHeaderDTO headerDTO = new MealPlanHeaderDTO(
+                "new eyebrow", "title", "description", "shopping title", "shopping note", null, "footer");
+        when(mealPlanWriteService.updateMealPlan(req)).thenReturn(headerDTO);
+
+        final Mono<ResponseEntity<MealPlanHeaderDTO>> result = mealPlanController.updateMealPlan(req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(headerDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateMealPlan returns 404 when the meal plan is missing")
+    void updateMealPlan_NotFound_Returns404() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest("eyebrow", null, null, null, null, null, null);
+        when(mealPlanWriteService.updateMealPlan(req)).thenThrow(new NoSuchElementException("Meal plan not found"));
+
+        final Mono<ResponseEntity<MealPlanHeaderDTO>> result = mealPlanController.updateMealPlan(req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/sections/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateSection returns 200 with the updated section")
+    void updateSection_Returns200WithUpdatedSection() {
+        final UUID sectionId = UUID.randomUUID();
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("new title", null, null);
+        final MealPlanSectionDTO sectionDTO = new MealPlanSectionDTO(sectionId, "new title", "note", List.of(), null, null);
+        when(mealPlanWriteService.updateSection(eq(sectionId), any(UpdateMealPlanSectionRequest.class)))
+                .thenReturn(sectionDTO);
+
+        final Mono<ResponseEntity<MealPlanSectionDTO>> result = mealPlanController.updateSection(sectionId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(sectionDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateSection returns 404 when the section does not exist")
+    void updateSection_NotFound_Returns404() {
+        final UUID sectionId = UUID.randomUUID();
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("title", null, null);
+        when(mealPlanWriteService.updateSection(eq(sectionId), any(UpdateMealPlanSectionRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanSectionDTO>> result = mealPlanController.updateSection(sectionId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/rows/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateRow returns 200 with the updated row")
+    void updateRow_Returns200WithUpdatedRow() {
+        final UUID rowId = UUID.randomUUID();
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("meal", null, null, null, null);
+        final MealPlanRowDTO rowDTO = new MealPlanRowDTO(rowId, "meal", "details", "qty", "kcal", "protein");
+        when(mealPlanWriteService.updateRow(eq(rowId), any(UpdateMealPlanRowRequest.class))).thenReturn(rowDTO);
+
+        final Mono<ResponseEntity<MealPlanRowDTO>> result = mealPlanController.updateRow(rowId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(rowDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateRow returns 404 when the row does not exist")
+    void updateRow_NotFound_Returns404() {
+        final UUID rowId = UUID.randomUUID();
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("meal", null, null, null, null);
+        when(mealPlanWriteService.updateRow(eq(rowId), any(UpdateMealPlanRowRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanRowDTO>> result = mealPlanController.updateRow(rowId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/stats/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateStat returns 200 with the updated stat")
+    void updateStat_Returns200WithUpdatedStat() {
+        final UUID statId = UUID.randomUUID();
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("label", null);
+        final MealPlanStatDTO statDTO = new MealPlanStatDTO(statId, "label", "value");
+        when(mealPlanWriteService.updateStat(eq(statId), any(UpdateMealPlanStatRequest.class))).thenReturn(statDTO);
+
+        final Mono<ResponseEntity<MealPlanStatDTO>> result = mealPlanController.updateStat(statId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(statDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateStat returns 404 when the stat does not exist")
+    void updateStat_NotFound_Returns404() {
+        final UUID statId = UUID.randomUUID();
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("label", null);
+        when(mealPlanWriteService.updateStat(eq(statId), any(UpdateMealPlanStatRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanStatDTO>> result = mealPlanController.updateStat(statId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/shopping-categories/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateShoppingCategory returns 200 with the updated category")
+    void updateShoppingCategory_Returns200WithUpdatedCategory() {
+        final UUID categoryId = UUID.randomUUID();
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("title");
+        final MealPlanShoppingCategoryDTO categoryDTO = new MealPlanShoppingCategoryDTO(categoryId, "title", List.of());
+        when(mealPlanWriteService.updateShoppingCategory(eq(categoryId), any(UpdateMealPlanShoppingCategoryRequest.class)))
+                .thenReturn(categoryDTO);
+
+        final Mono<ResponseEntity<MealPlanShoppingCategoryDTO>> result =
+                mealPlanController.updateShoppingCategory(categoryId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(categoryDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateShoppingCategory returns 404 when the category does not exist")
+    void updateShoppingCategory_NotFound_Returns404() {
+        final UUID categoryId = UUID.randomUUID();
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("title");
+        when(mealPlanWriteService.updateShoppingCategory(eq(categoryId), any(UpdateMealPlanShoppingCategoryRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanShoppingCategoryDTO>> result =
+                mealPlanController.updateShoppingCategory(categoryId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/shopping-items/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateShoppingItem returns 200 with the updated item")
+    void updateShoppingItem_Returns200WithUpdatedItem() {
+        final UUID itemId = UUID.randomUUID();
+        final UpdateMealPlanShoppingItemRequest req = new UpdateMealPlanShoppingItemRequest("name", null, null, null, null);
+        final MealPlanShoppingItemDTO itemDTO = new MealPlanShoppingItemDTO(itemId, "name", null, null, null, "qty");
+        when(mealPlanWriteService.updateShoppingItem(eq(itemId), any(UpdateMealPlanShoppingItemRequest.class)))
+                .thenReturn(itemDTO);
+
+        final Mono<ResponseEntity<MealPlanShoppingItemDTO>> result = mealPlanController.updateShoppingItem(itemId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(itemDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateShoppingItem returns 404 when the item does not exist")
+    void updateShoppingItem_NotFound_Returns404() {
+        final UUID itemId = UUID.randomUUID();
+        final UpdateMealPlanShoppingItemRequest req = new UpdateMealPlanShoppingItemRequest("name", null, null, null, null);
+        when(mealPlanWriteService.updateShoppingItem(eq(itemId), any(UpdateMealPlanShoppingItemRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanShoppingItemDTO>> result = mealPlanController.updateShoppingItem(itemId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /nutrition/meal-plan/sources/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateSource returns 200 with the updated source")
+    void updateSource_Returns200WithUpdatedSource() {
+        final UUID sourceId = UUID.randomUUID();
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("label", null);
+        final MealPlanSourceDTO sourceDTO = new MealPlanSourceDTO(sourceId, "label", "url");
+        when(mealPlanWriteService.updateSource(eq(sourceId), any(UpdateMealPlanSourceRequest.class)))
+                .thenReturn(sourceDTO);
+
+        final Mono<ResponseEntity<MealPlanSourceDTO>> result = mealPlanController.updateSource(sourceId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertEquals(sourceDTO, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateSource returns 404 when the source does not exist")
+    void updateSource_NotFound_Returns404() {
+        final UUID sourceId = UUID.randomUUID();
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("label", null);
+        when(mealPlanWriteService.updateSource(eq(sourceId), any(UpdateMealPlanSourceRequest.class)))
+                .thenThrow(new NoSuchElementException("not found"));
+
+        final Mono<ResponseEntity<MealPlanSourceDTO>> result = mealPlanController.updateSource(sourceId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /nutrition/meal-plan/changelog
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addChangelogEntry returns 201 Created with Location header pointing to new entry")
+    void addChangelogEntry_Returns201WithLocation() {
+        final UUID entryId = UUID.randomUUID();
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("Whey", "80 g/Tag", "-> 40 g/Tag", 0);
+        final MealPlanChangelogEntryDTO entryDTO = new MealPlanChangelogEntryDTO(entryId, "Whey", "80 g/Tag", "-> 40 g/Tag");
+        when(mealPlanWriteService.addChangelogEntry(any(CreateMealPlanChangelogEntryRequest.class)))
+                .thenReturn(entryDTO);
+
+        final Mono<ResponseEntity<MealPlanChangelogEntryDTO>> result = mealPlanController.addChangelogEntry(req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(entryDTO, response.getBody());
+                    assertNotNull(response.getHeaders().getLocation());
+                    assertTrue(response.getHeaders().getLocation().toString().contains(entryId.toString()));
+                })
+                .verifyComplete();
+
+        verify(mealPlanWriteService).addChangelogEntry(any(CreateMealPlanChangelogEntryRequest.class));
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.marvin.nutrition.dto.MealPlanRowDTO;
 import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
 import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -40,12 +43,40 @@ class MealPlanMapperTest {
         section.setTotalsKcal("2.407 kcal");
         section.setTotalsProtein("182,2 g");
 
-        final MealPlanRowDTO row = new MealPlanRowDTO("Frühstück", "details", "qty", "519", "28,0 g");
+        final MealPlanRowDTO row = new MealPlanRowDTO(UUID.randomUUID(), "Frühstück", "details", "qty", "519", "28,0 g");
         final MealPlanSectionDTO dto = mealPlanMapper.toSectionDTO(section, List.of(row));
 
         assertEquals(List.of(row), dto.rows());
         assertEquals("Tagesgesamt", dto.totals().label());
         assertEquals("2.407 kcal", dto.totals().kcal());
         assertEquals("182,2 g", dto.totals().protein());
+    }
+
+    @Test
+    @DisplayName("toSectionDTO carries over the section entity's id")
+    void toSectionDTO_MapsId() {
+        final UUID sectionId = UUID.randomUUID();
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setId(sectionId);
+        section.setTitle("title");
+        section.setNote("note");
+
+        final MealPlanSectionDTO dto = mealPlanMapper.toSectionDTO(section, List.of());
+
+        assertEquals(sectionId, dto.id());
+    }
+
+    @Test
+    @DisplayName("toStatDTO carries over the stat entity's id")
+    void toStatDTO_MapsId() {
+        final UUID statId = UUID.randomUUID();
+        final MealPlanStatEntity stat = new MealPlanStatEntity();
+        stat.setId(statId);
+        stat.setLabel("label");
+        stat.setValue("value");
+
+        final MealPlanStatDTO dto = mealPlanMapper.toStatDTO(stat);
+
+        assertEquals(statId, dto.id());
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionAssemblerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionAssemblerTest.java
@@ -58,13 +58,15 @@ class MealPlanSectionAssemblerTest {
         rowTwoEntity.setId(UUID.randomUUID());
         rowTwoEntity.setMeal("Abendessen");
 
-        final MealPlanRowDTO rowOneDTO = new MealPlanRowDTO("Frühstück", "details", "qty", "519", "28,0 g");
-        final MealPlanRowDTO rowTwoDTO = new MealPlanRowDTO("Abendessen", "details", "qty", "923", "73,9 g");
+        final MealPlanRowDTO rowOneDTO =
+                new MealPlanRowDTO(rowOneEntity.getId(), "Frühstück", "details", "qty", "519", "28,0 g");
+        final MealPlanRowDTO rowTwoDTO =
+                new MealPlanRowDTO(rowTwoEntity.getId(), "Abendessen", "details", "qty", "923", "73,9 g");
 
         final MealPlanSectionDTO sectionOneDTO =
-                new MealPlanSectionDTO("1 · Tagesstruktur", "note", List.of(rowOneDTO), null, null);
+                new MealPlanSectionDTO(sectionOneId, "1 · Tagesstruktur", "note", List.of(rowOneDTO), null, null);
         final MealPlanSectionDTO sectionTwoDTO =
-                new MealPlanSectionDTO("2 · Wochentage", "note", List.of(rowTwoDTO), null, null);
+                new MealPlanSectionDTO(sectionTwoId, "2 · Wochentage", "note", List.of(rowTwoDTO), null, null);
 
         when(mealPlanSectionRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId))
                 .thenReturn(List.of(sectionOne, sectionTwo));

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionWriteServiceTest.java
@@ -1,0 +1,129 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.entity.MealPlanRowEntity;
+import com.marvin.nutrition.entity.MealPlanSectionEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanRowRepository;
+import com.marvin.nutrition.repository.MealPlanSectionRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link MealPlanSectionWriteService} covering section and row content updates. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanSectionWriteService Tests")
+class MealPlanSectionWriteServiceTest {
+
+    @Mock
+    private MealPlanSectionRepository mealPlanSectionRepository;
+
+    @Mock
+    private MealPlanRowRepository mealPlanRowRepository;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @InjectMocks
+    private MealPlanSectionWriteService mealPlanSectionWriteService;
+
+    // -----------------------------------------------------------------------
+    // updateSection
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateSection applies non-null fields, saves and returns the section with its rows")
+    void updateSection_AppliesNonNullFields_ReturnsUpdatedSectionWithRows() {
+        final UUID sectionId = UUID.randomUUID();
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setId(sectionId);
+        section.setTitle("old title");
+        section.setNote("old note");
+
+        final MealPlanRowEntity rowEntity = new MealPlanRowEntity();
+        rowEntity.setId(UUID.randomUUID());
+
+        final MealPlanRowDTO rowDTO = new MealPlanRowDTO(rowEntity.getId(), "Frühstück", "details", "qty", "519", "28,0 g");
+        final MealPlanSectionDTO sectionDTO =
+                new MealPlanSectionDTO(sectionId, "new title", "old note", List.of(rowDTO), null, null);
+
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("new title", null, null);
+
+        when(mealPlanSectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
+        when(mealPlanSectionRepository.save(section)).thenReturn(section);
+        when(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(sectionId))
+                .thenReturn(List.of(rowEntity));
+        when(mealPlanMapper.toRowDTOs(List.of(rowEntity))).thenReturn(List.of(rowDTO));
+        when(mealPlanMapper.toSectionDTO(section, List.of(rowDTO))).thenReturn(sectionDTO);
+
+        final MealPlanSectionDTO result = mealPlanSectionWriteService.updateSection(sectionId, req);
+
+        assertEquals("new title", section.getTitle());
+        assertEquals("old note", section.getNote());
+        assertEquals(sectionDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateSection throws NoSuchElementException when the section does not exist")
+    void updateSection_NotFound_ThrowsNoSuchElementException() {
+        final UUID sectionId = UUID.randomUUID();
+        when(mealPlanSectionRepository.findById(sectionId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("title", null, null);
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanSectionWriteService.updateSection(sectionId, req));
+    }
+
+    // -----------------------------------------------------------------------
+    // updateRow
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateRow applies non-null fields, saves and returns the updated row")
+    void updateRow_AppliesNonNullFields_ReturnsUpdatedRow() {
+        final UUID rowId = UUID.randomUUID();
+        final MealPlanRowEntity row = new MealPlanRowEntity();
+        row.setId(rowId);
+        row.setMeal("old meal");
+        row.setKcal("500");
+
+        final MealPlanRowDTO rowDTO = new MealPlanRowDTO(rowId, "new meal", "details", "qty", "500", "28,0 g");
+
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("new meal", null, null, null, null);
+
+        when(mealPlanRowRepository.findById(rowId)).thenReturn(Optional.of(row));
+        when(mealPlanRowRepository.save(row)).thenReturn(row);
+        when(mealPlanMapper.toRowDTO(row)).thenReturn(rowDTO);
+
+        final MealPlanRowDTO result = mealPlanSectionWriteService.updateRow(rowId, req);
+
+        assertEquals("new meal", row.getMeal());
+        assertEquals("500", row.getKcal());
+        assertEquals(rowDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateRow throws NoSuchElementException when the row does not exist")
+    void updateRow_NotFound_ThrowsNoSuchElementException() {
+        final UUID rowId = UUID.randomUUID();
+        when(mealPlanRowRepository.findById(rowId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("meal", null, null, null, null);
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanSectionWriteService.updateRow(rowId, req));
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanServiceTest.java
@@ -24,6 +24,7 @@ import com.marvin.nutrition.repository.MealPlanStatRepository;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -97,34 +98,35 @@ class MealPlanServiceTest {
                 new MealPlanStatEntity(), new MealPlanStatEntity(),
                 new MealPlanStatEntity(), new MealPlanStatEntity());
         statDTOs = List.of(
-                new MealPlanStatDTO("Tagesbudget (Ø)", "2.416 kcal"),
-                new MealPlanStatDTO("Protein", "~184 g"),
-                new MealPlanStatDTO("Kohlenhydrate", "~291 g"),
-                new MealPlanStatDTO("Fett", "~52 g"));
+                new MealPlanStatDTO(UUID.randomUUID(), "Tagesbudget (Ø)", "2.416 kcal"),
+                new MealPlanStatDTO(UUID.randomUUID(), "Protein", "~184 g"),
+                new MealPlanStatDTO(UUID.randomUUID(), "Kohlenhydrate", "~291 g"),
+                new MealPlanStatDTO(UUID.randomUUID(), "Fett", "~52 g"));
 
         changelogEntities = List.of(new MealPlanChangelogEntryEntity(), new MealPlanChangelogEntryEntity());
         changelogDTOs = List.of(
-                new MealPlanChangelogEntryDTO("Whey", "80 g/Tag (2×40 g)", "→ 40 g/Tag"),
-                new MealPlanChangelogEntryDTO("Magerquark", null, "neu: 300 g/Tag"));
+                new MealPlanChangelogEntryDTO(UUID.randomUUID(), "Whey", "80 g/Tag (2×40 g)", "→ 40 g/Tag"),
+                new MealPlanChangelogEntryDTO(UUID.randomUUID(), "Magerquark", null, "neu: 300 g/Tag"));
 
         sourceEntities = List.of(new MealPlanSourceEntity(), new MealPlanSourceEntity());
         sourceDTOs = List.of(
-                new MealPlanSourceDTO("Magerquark (fatsecret.de)", "https://www.fatsecret.de/magerquark"),
-                new MealPlanSourceDTO("Basmatireis (fatsecret.de)", "https://www.fatsecret.de/basmatireis"));
+                new MealPlanSourceDTO(UUID.randomUUID(), "Magerquark (fatsecret.de)", "https://www.fatsecret.de/magerquark"),
+                new MealPlanSourceDTO(UUID.randomUUID(), "Basmatireis (fatsecret.de)", "https://www.fatsecret.de/basmatireis"));
 
-        final MealPlanRowDTO row = new MealPlanRowDTO("Frühstück", "Haferflocken, Whey", "90g/20g", "519", "28,0 g");
+        final MealPlanRowDTO row =
+                new MealPlanRowDTO(UUID.randomUUID(), "Frühstück", "Haferflocken, Whey", "90g/20g", "519", "28,0 g");
         sectionDTOs = List.of(
-                new MealPlanSectionDTO("1 · Tagesstruktur", "note", List.of(row), null, "callout"),
-                new MealPlanSectionDTO("2 · Wochentage", "note", List.of(row), null, null),
-                new MealPlanSectionDTO("3 · Wochenende", "note", List.of(row), null, "callout"));
+                new MealPlanSectionDTO(UUID.randomUUID(), "1 · Tagesstruktur", "note", List.of(row), null, "callout"),
+                new MealPlanSectionDTO(UUID.randomUUID(), "2 · Wochentage", "note", List.of(row), null, null),
+                new MealPlanSectionDTO(UUID.randomUUID(), "3 · Wochenende", "note", List.of(row), null, "callout"));
 
         final MealPlanShoppingItemDTO plainItem =
-                new MealPlanShoppingItemDTO("Rinderhüftsteak", "Lidl", null, null, "435 g");
+                new MealPlanShoppingItemDTO(UUID.randomUUID(), "Rinderhüftsteak", "Lidl", null, null, "435 g");
         final MealPlanShoppingItemDTO badgedItem = new MealPlanShoppingItemDTO(
-                "Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
+                UUID.randomUUID(), "Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
         categoryDTOs = List.of(
-                new MealPlanShoppingCategoryDTO("Fleisch & Fisch", List.of(badgedItem, plainItem)),
-                new MealPlanShoppingCategoryDTO("Milchprodukte & Eier", List.of(plainItem)));
+                new MealPlanShoppingCategoryDTO(UUID.randomUUID(), "Fleisch & Fisch", List.of(badgedItem, plainItem)),
+                new MealPlanShoppingCategoryDTO(UUID.randomUUID(), "Milchprodukte & Eier", List.of(plainItem)));
     }
 
     /** Stubs every repository/assembler/mapper call needed for a full, successful {@code getMealPlan()} read. */

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListAssemblerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListAssemblerTest.java
@@ -58,15 +58,15 @@ class MealPlanShoppingListAssemblerTest {
         itemTwoEntity.setId(UUID.randomUUID());
         itemTwoEntity.setName("Magerquark");
 
-        final MealPlanShoppingItemDTO itemOneDTO =
-                new MealPlanShoppingItemDTO("Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
+        final MealPlanShoppingItemDTO itemOneDTO = new MealPlanShoppingItemDTO(
+                itemOneEntity.getId(), "Hähnchenbrustfilet", "frisch, Kühltheke", "warn", "nur 1.200 g verfügbar", "1.200 g");
         final MealPlanShoppingItemDTO itemTwoDTO =
-                new MealPlanShoppingItemDTO("Magerquark", "Milbona", null, null, "2.100 g");
+                new MealPlanShoppingItemDTO(itemTwoEntity.getId(), "Magerquark", "Milbona", null, null, "2.100 g");
 
         final MealPlanShoppingCategoryDTO categoryOneDTO =
-                new MealPlanShoppingCategoryDTO("Fleisch & Fisch", List.of(itemOneDTO));
+                new MealPlanShoppingCategoryDTO(categoryOneId, "Fleisch & Fisch", List.of(itemOneDTO));
         final MealPlanShoppingCategoryDTO categoryTwoDTO =
-                new MealPlanShoppingCategoryDTO("Milchprodukte & Eier", List.of(itemTwoDTO));
+                new MealPlanShoppingCategoryDTO(categoryTwoId, "Milchprodukte & Eier", List.of(itemTwoDTO));
 
         when(mealPlanShoppingCategoryRepository.findAllByMealPlanIdOrderBySortOrderAsc(mealPlanId))
                 .thenReturn(List.of(categoryOne, categoryTwo));

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanShoppingListWriteServiceTest.java
@@ -1,0 +1,131 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.entity.MealPlanShoppingCategoryEntity;
+import com.marvin.nutrition.entity.MealPlanShoppingItemEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanShoppingCategoryRepository;
+import com.marvin.nutrition.repository.MealPlanShoppingItemRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link MealPlanShoppingListWriteService} covering shopping category and item content updates. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanShoppingListWriteService Tests")
+class MealPlanShoppingListWriteServiceTest {
+
+    @Mock
+    private MealPlanShoppingCategoryRepository mealPlanShoppingCategoryRepository;
+
+    @Mock
+    private MealPlanShoppingItemRepository mealPlanShoppingItemRepository;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @InjectMocks
+    private MealPlanShoppingListWriteService mealPlanShoppingListWriteService;
+
+    // -----------------------------------------------------------------------
+    // updateShoppingCategory
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateShoppingCategory applies non-null fields, saves and returns the category with its items")
+    void updateShoppingCategory_AppliesNonNullFields_ReturnsUpdatedCategoryWithItems() {
+        final UUID categoryId = UUID.randomUUID();
+        final MealPlanShoppingCategoryEntity category = new MealPlanShoppingCategoryEntity();
+        category.setId(categoryId);
+        category.setTitle("old title");
+
+        final MealPlanShoppingItemEntity itemEntity = new MealPlanShoppingItemEntity();
+        itemEntity.setId(UUID.randomUUID());
+
+        final MealPlanShoppingItemDTO itemDTO =
+                new MealPlanShoppingItemDTO(itemEntity.getId(), "Hähnchenbrustfilet", null, null, null, "1.200 g");
+        final MealPlanShoppingCategoryDTO categoryDTO =
+                new MealPlanShoppingCategoryDTO(categoryId, "new title", List.of(itemDTO));
+
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("new title");
+
+        when(mealPlanShoppingCategoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        when(mealPlanShoppingCategoryRepository.save(category)).thenReturn(category);
+        when(mealPlanShoppingItemRepository.findAllByMealPlanShoppingCategoryIdOrderBySortOrderAsc(categoryId))
+                .thenReturn(List.of(itemEntity));
+        when(mealPlanMapper.toShoppingItemDTOs(List.of(itemEntity))).thenReturn(List.of(itemDTO));
+        when(mealPlanMapper.toShoppingCategoryDTO(category, List.of(itemDTO))).thenReturn(categoryDTO);
+
+        final MealPlanShoppingCategoryDTO result =
+                mealPlanShoppingListWriteService.updateShoppingCategory(categoryId, req);
+
+        assertEquals("new title", category.getTitle());
+        assertEquals(categoryDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateShoppingCategory throws NoSuchElementException when the category does not exist")
+    void updateShoppingCategory_NotFound_ThrowsNoSuchElementException() {
+        final UUID categoryId = UUID.randomUUID();
+        when(mealPlanShoppingCategoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("title");
+
+        assertThrows(NoSuchElementException.class,
+                () -> mealPlanShoppingListWriteService.updateShoppingCategory(categoryId, req));
+    }
+
+    // -----------------------------------------------------------------------
+    // updateShoppingItem
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateShoppingItem applies non-null fields, saves and returns the updated item")
+    void updateShoppingItem_AppliesNonNullFields_ReturnsUpdatedItem() {
+        final UUID itemId = UUID.randomUUID();
+        final MealPlanShoppingItemEntity item = new MealPlanShoppingItemEntity();
+        item.setId(itemId);
+        item.setName("old name");
+        item.setQty("500 g");
+
+        final MealPlanShoppingItemDTO itemDTO = new MealPlanShoppingItemDTO(itemId, "new name", null, null, null, "500 g");
+
+        final UpdateMealPlanShoppingItemRequest req = new UpdateMealPlanShoppingItemRequest("new name", null, null, null, null);
+
+        when(mealPlanShoppingItemRepository.findById(itemId)).thenReturn(Optional.of(item));
+        when(mealPlanShoppingItemRepository.save(item)).thenReturn(item);
+        when(mealPlanMapper.toShoppingItemDTO(item)).thenReturn(itemDTO);
+
+        final MealPlanShoppingItemDTO result = mealPlanShoppingListWriteService.updateShoppingItem(itemId, req);
+
+        assertEquals("new name", item.getName());
+        assertEquals("500 g", item.getQty());
+        assertEquals(itemDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateShoppingItem throws NoSuchElementException when the item does not exist")
+    void updateShoppingItem_NotFound_ThrowsNoSuchElementException() {
+        final UUID itemId = UUID.randomUUID();
+        when(mealPlanShoppingItemRepository.findById(itemId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanShoppingItemRequest req = new UpdateMealPlanShoppingItemRequest("name", null, null, null, null);
+
+        assertThrows(NoSuchElementException.class,
+                () -> mealPlanShoppingListWriteService.updateShoppingItem(itemId, req));
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanWriteServiceTest.java
@@ -1,0 +1,277 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.nutrition.dto.CreateMealPlanChangelogEntryRequest;
+import com.marvin.nutrition.dto.MealPlanChangelogEntryDTO;
+import com.marvin.nutrition.dto.MealPlanHeaderDTO;
+import com.marvin.nutrition.dto.MealPlanRowDTO;
+import com.marvin.nutrition.dto.MealPlanSectionDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingCategoryDTO;
+import com.marvin.nutrition.dto.MealPlanShoppingItemDTO;
+import com.marvin.nutrition.dto.MealPlanSourceDTO;
+import com.marvin.nutrition.dto.MealPlanStatDTO;
+import com.marvin.nutrition.dto.UpdateMealPlanRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanRowRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSectionRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingCategoryRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanShoppingItemRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanSourceRequest;
+import com.marvin.nutrition.dto.UpdateMealPlanStatRequest;
+import com.marvin.nutrition.entity.MealPlanChangelogEntryEntity;
+import com.marvin.nutrition.entity.MealPlanEntity;
+import com.marvin.nutrition.entity.MealPlanSourceEntity;
+import com.marvin.nutrition.entity.MealPlanStatEntity;
+import com.marvin.nutrition.mapper.MealPlanMapper;
+import com.marvin.nutrition.repository.MealPlanChangelogEntryRepository;
+import com.marvin.nutrition.repository.MealPlanRepository;
+import com.marvin.nutrition.repository.MealPlanSourceRepository;
+import com.marvin.nutrition.repository.MealPlanStatRepository;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link MealPlanWriteService}, covering the header/stat/source/changelog updates it
+ * owns directly, and the delegation to {@link MealPlanSectionWriteService} and
+ * {@link MealPlanShoppingListWriteService} for section/row and shopping category/item updates.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MealPlanWriteService Tests")
+class MealPlanWriteServiceTest {
+
+    @Mock
+    private MealPlanRepository mealPlanRepository;
+
+    @Mock
+    private MealPlanStatRepository mealPlanStatRepository;
+
+    @Mock
+    private MealPlanSourceRepository mealPlanSourceRepository;
+
+    @Mock
+    private MealPlanChangelogEntryRepository mealPlanChangelogEntryRepository;
+
+    @Mock
+    private MealPlanMapper mealPlanMapper;
+
+    @Mock
+    private MealPlanSectionWriteService mealPlanSectionWriteService;
+
+    @Mock
+    private MealPlanShoppingListWriteService mealPlanShoppingListWriteService;
+
+    @InjectMocks
+    private MealPlanWriteService mealPlanWriteService;
+
+    // -----------------------------------------------------------------------
+    // updateMealPlan
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateMealPlan applies non-null fields, saves and returns the updated header")
+    void updateMealPlan_AppliesNonNullFields_ReturnsUpdatedHeader() {
+        final MealPlanEntity entity = new MealPlanEntity();
+        entity.setId(MealPlanEntity.SINGLETON_ID);
+        entity.setEyebrow("old eyebrow");
+        entity.setTitle("old title");
+        entity.setDescription("old description");
+        entity.setShoppingListTitle("old shopping title");
+        entity.setShoppingListNote("old shopping note");
+        entity.setFooterNote("old footer");
+
+        final UpdateMealPlanRequest req =
+                new UpdateMealPlanRequest("new eyebrow", null, null, null, null, null, null);
+
+        when(mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)).thenReturn(Optional.of(entity));
+        when(mealPlanRepository.save(entity)).thenReturn(entity);
+
+        final MealPlanHeaderDTO result = mealPlanWriteService.updateMealPlan(req);
+
+        assertEquals("new eyebrow", entity.getEyebrow());
+        assertEquals("old title", entity.getTitle());
+        assertEquals(new MealPlanHeaderDTO(
+                "new eyebrow", "old title", "old description",
+                "old shopping title", "old shopping note", null, "old footer"), result);
+    }
+
+    @Test
+    @DisplayName("updateMealPlan throws NoSuchElementException when the singleton row is missing")
+    void updateMealPlan_NotFound_ThrowsNoSuchElementException() {
+        when(mealPlanRepository.findById(MealPlanEntity.SINGLETON_ID)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanRequest req =
+                new UpdateMealPlanRequest("eyebrow", null, null, null, null, null, null);
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanWriteService.updateMealPlan(req));
+    }
+
+    // -----------------------------------------------------------------------
+    // updateStat
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateStat applies non-null fields, saves and returns the updated stat")
+    void updateStat_AppliesNonNullFields_ReturnsUpdatedStat() {
+        final UUID statId = UUID.randomUUID();
+        final MealPlanStatEntity stat = new MealPlanStatEntity();
+        stat.setId(statId);
+        stat.setLabel("old label");
+        stat.setValue("old value");
+
+        final MealPlanStatDTO statDTO = new MealPlanStatDTO(statId, "new label", "old value");
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("new label", null);
+
+        when(mealPlanStatRepository.findById(statId)).thenReturn(Optional.of(stat));
+        when(mealPlanStatRepository.save(stat)).thenReturn(stat);
+        when(mealPlanMapper.toStatDTO(stat)).thenReturn(statDTO);
+
+        final MealPlanStatDTO result = mealPlanWriteService.updateStat(statId, req);
+
+        assertEquals("new label", stat.getLabel());
+        assertEquals(statDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateStat throws NoSuchElementException when the stat does not exist")
+    void updateStat_NotFound_ThrowsNoSuchElementException() {
+        final UUID statId = UUID.randomUUID();
+        when(mealPlanStatRepository.findById(statId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("label", null);
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanWriteService.updateStat(statId, req));
+    }
+
+    // -----------------------------------------------------------------------
+    // updateSource
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateSource applies non-null fields, saves and returns the updated source")
+    void updateSource_AppliesNonNullFields_ReturnsUpdatedSource() {
+        final UUID sourceId = UUID.randomUUID();
+        final MealPlanSourceEntity source = new MealPlanSourceEntity();
+        source.setId(sourceId);
+        source.setLabel("old label");
+        source.setUrl("https://old.example.com");
+
+        final MealPlanSourceDTO sourceDTO = new MealPlanSourceDTO(sourceId, "new label", "https://old.example.com");
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("new label", null);
+
+        when(mealPlanSourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+        when(mealPlanSourceRepository.save(source)).thenReturn(source);
+        when(mealPlanMapper.toSourceDTO(source)).thenReturn(sourceDTO);
+
+        final MealPlanSourceDTO result = mealPlanWriteService.updateSource(sourceId, req);
+
+        assertEquals("new label", source.getLabel());
+        assertEquals(sourceDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateSource throws NoSuchElementException when the source does not exist")
+    void updateSource_NotFound_ThrowsNoSuchElementException() {
+        final UUID sourceId = UUID.randomUUID();
+        when(mealPlanSourceRepository.findById(sourceId)).thenReturn(Optional.empty());
+
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("label", null);
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanWriteService.updateSource(sourceId, req));
+    }
+
+    // -----------------------------------------------------------------------
+    // addChangelogEntry
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("addChangelogEntry creates, saves and returns the new changelog entry")
+    void addChangelogEntry_CreatesAndReturnsEntry() {
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("Whey", "80 g/Tag", "-> 40 g/Tag", 0);
+
+        final MealPlanChangelogEntryEntity saved = new MealPlanChangelogEntryEntity();
+        saved.setId(UUID.randomUUID());
+        final MealPlanChangelogEntryDTO dto =
+                new MealPlanChangelogEntryDTO(saved.getId(), "Whey", "80 g/Tag", "-> 40 g/Tag");
+
+        when(mealPlanChangelogEntryRepository.save(any(MealPlanChangelogEntryEntity.class))).thenReturn(saved);
+        when(mealPlanMapper.toChangelogEntryDTO(saved)).thenReturn(dto);
+
+        final MealPlanChangelogEntryDTO result = mealPlanWriteService.addChangelogEntry(req);
+
+        assertEquals(dto, result);
+        verify(mealPlanChangelogEntryRepository).save(any(MealPlanChangelogEntryEntity.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // delegation to MealPlanSectionWriteService / MealPlanShoppingListWriteService
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateSection delegates to MealPlanSectionWriteService")
+    void updateSection_DelegatesToSectionWriteService() {
+        final UUID sectionId = UUID.randomUUID();
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("title", null, null);
+        final MealPlanSectionDTO sectionDTO = new MealPlanSectionDTO(sectionId, "title", "note", java.util.List.of(), null, null);
+
+        when(mealPlanSectionWriteService.updateSection(sectionId, req)).thenReturn(sectionDTO);
+
+        final MealPlanSectionDTO result = mealPlanWriteService.updateSection(sectionId, req);
+
+        assertEquals(sectionDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateRow delegates to MealPlanSectionWriteService")
+    void updateRow_DelegatesToSectionWriteService() {
+        final UUID rowId = UUID.randomUUID();
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("meal", null, null, null, null);
+        final MealPlanRowDTO rowDTO = new MealPlanRowDTO(rowId, "meal", "details", "qty", "kcal", "protein");
+
+        when(mealPlanSectionWriteService.updateRow(rowId, req)).thenReturn(rowDTO);
+
+        final MealPlanRowDTO result = mealPlanWriteService.updateRow(rowId, req);
+
+        assertEquals(rowDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateShoppingCategory delegates to MealPlanShoppingListWriteService")
+    void updateShoppingCategory_DelegatesToShoppingListWriteService() {
+        final UUID categoryId = UUID.randomUUID();
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("title");
+        final MealPlanShoppingCategoryDTO categoryDTO =
+                new MealPlanShoppingCategoryDTO(categoryId, "title", java.util.List.of());
+
+        when(mealPlanShoppingListWriteService.updateShoppingCategory(categoryId, req)).thenReturn(categoryDTO);
+
+        final MealPlanShoppingCategoryDTO result = mealPlanWriteService.updateShoppingCategory(categoryId, req);
+
+        assertEquals(categoryDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateShoppingItem delegates to MealPlanShoppingListWriteService")
+    void updateShoppingItem_DelegatesToShoppingListWriteService() {
+        final UUID itemId = UUID.randomUUID();
+        final UpdateMealPlanShoppingItemRequest req = new UpdateMealPlanShoppingItemRequest("name", null, null, null, null);
+        final MealPlanShoppingItemDTO itemDTO = new MealPlanShoppingItemDTO(itemId, "name", null, null, null, "qty");
+
+        when(mealPlanShoppingListWriteService.updateShoppingItem(itemId, req)).thenReturn(itemDTO);
+
+        final MealPlanShoppingItemDTO result = mealPlanWriteService.updateShoppingItem(itemId, req);
+
+        assertEquals(itemDTO, result);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PUT`/`POST` write endpoints to `MealPlanController` so meal-plan content (header, sections, rows, headline stats, shopping-list categories/items, footer sources, changelog) can be corrected through the REST API instead of hand-written SQL or new Flyway migrations.
- Exposes `id` on the read-side DTOs (`MealPlanSectionDTO`, `MealPlanRowDTO`, `MealPlanStatDTO`, `MealPlanShoppingCategoryDTO`, `MealPlanShoppingItemDTO`, `MealPlanSourceDTO`, `MealPlanChangelogEntryDTO`) so API consumers can address individual records — none of these previously exposed an id.
- New `MealPlanWriteService` facade owns header/stat/source/changelog writes directly, and delegates section/row and shopping-category/item writes to two new narrower services (`MealPlanSectionWriteService`, `MealPlanShoppingListWriteService`), mirroring the existing read-side assembler split (`MealPlanSectionAssembler` / `MealPlanShoppingListAssembler`) and keeping every constructor within the project's 7-parameter checkstyle limit.

## New endpoints
```
PUT  /nutrition/meal-plan                          UpdateMealPlanRequest                 -> 200 MealPlanHeaderDTO | 404
PUT  /nutrition/meal-plan/sections/{id}             UpdateMealPlanSectionRequest           -> 200 MealPlanSectionDTO | 404
PUT  /nutrition/meal-plan/rows/{id}                 UpdateMealPlanRowRequest               -> 200 MealPlanRowDTO | 404
PUT  /nutrition/meal-plan/stats/{id}                UpdateMealPlanStatRequest              -> 200 MealPlanStatDTO | 404
PUT  /nutrition/meal-plan/shopping-categories/{id}  UpdateMealPlanShoppingCategoryRequest  -> 200 MealPlanShoppingCategoryDTO | 404
PUT  /nutrition/meal-plan/shopping-items/{id}       UpdateMealPlanShoppingItemRequest      -> 200 MealPlanShoppingItemDTO | 404
PUT  /nutrition/meal-plan/sources/{id}              UpdateMealPlanSourceRequest            -> 200 MealPlanSourceDTO | 404
POST /nutrition/meal-plan/changelog                 CreateMealPlanChangelogEntryRequest    -> 201 MealPlanChangelogEntryDTO + Location
```
All update requests follow the existing `UpdateMealEntryRequest` partial-update pattern (nullable fields, `@NullOrNotBlank`; `null` = leave unchanged). The changelog POST is append-only (`tag`/`text`/`sortOrder` required, `was` optional).

## Test plan
- [x] `./gradlew :nutrition:test` — all tests pass except the 3 pre-existing Testcontainers/Docker-backed repository tests, which fail in this sandbox with `ContainerFetchException: Can't get Docker image` (no Docker available locally; unrelated to this change).
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — zero warnings.
- [x] TDD followed throughout: new tests written first for every new service/controller method; existing tests only had `id` fixture arguments added to keep them compiling (no existing assertions changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)