### PR TITLE
Add Bean Validation constraints to meal-plan request DTOs

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealPlanChangelogEntryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/CreateMealPlanChangelogEntryRequest.java
@@ -4,6 +4,7 @@ import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for appending a new entry to the meal plan's changelog.
@@ -18,10 +19,12 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "Request to append a new entry to the meal plan's changelog")
 public record CreateMealPlanChangelogEntryRequest(
         @NotBlank
+        @Size(max = 255)
         @Schema(description = "Short label identifying what changed", example = "Whey")
         String tag,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Previous value, absent if this is a newly introduced item", example = "80 g/Tag (2×40 g)")
         String was,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating the meal plan's header content.
@@ -18,10 +19,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update the meal plan's header content")
 public record UpdateMealPlanRequest(
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated small label shown above the title", example = "Version 3 — abgeglichen mit Tracking")
         String eyebrow,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated document title", example = "Ernährungsplan & Einkaufsliste")
         String title,
 
@@ -30,10 +33,12 @@ public record UpdateMealPlanRequest(
         String description,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated shopping list title", example = "4 · Einkaufsliste für Lidl (1 Woche)")
         String shoppingListTitle,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated shopping list note", example = "4× Kantine Mo–Do · 3× Selbstkochen Fr–So")
         String shoppingListNote,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRowRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanRowRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan row.
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan row")
 public record UpdateMealPlanRowRequest(
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated meal name", example = "Frühstück")
         String meal,
 
@@ -24,14 +26,17 @@ public record UpdateMealPlanRowRequest(
         String details,
 
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated quantities of the ingredients as a display string", example = "90g/200ml/20g/100g/50g/10g/1 Stk")
         String qty,
 
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated kilocalories as a display string", example = "663")
         String kcal,
 
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated grams of protein as a display string", example = "46,5 g")
         String protein
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan section.
@@ -14,10 +15,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan section")
 public record UpdateMealPlanSectionRequest(
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated section title", example = "1 · Tagesstruktur (täglich gleich)")
         String title,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated short note describing the section")
         String note,
 

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingCategoryRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingCategoryRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan shopping-list category.
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan shopping-list category")
 public record UpdateMealPlanShoppingCategoryRequest(
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated category title", example = "Fleisch & Fisch")
         String title
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingItemRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanShoppingItemRequest.java
@@ -2,6 +2,8 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan shopping-list item.
@@ -16,22 +18,27 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan shopping-list item")
 public record UpdateMealPlanShoppingItemRequest(
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated item name", example = "Hähnchenbrustfilet")
         String name,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated brand or sourcing note", example = "frisch, Kühltheke")
         String brand,
 
         @NullOrNotBlank
+        @Pattern(regexp = "^(ok|warn)$")
         @Schema(description = "Updated badge severity", example = "warn", allowableValues = {"ok", "warn"})
         String badge,
 
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated text shown alongside the badge", example = "nur 1.200 g verfügbar")
         String badgeText,
 
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated quantity to buy as a display string", example = "1.200 g")
         String qty
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSourceRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSourceRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan footer source.
@@ -13,10 +14,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan footer source")
 public record UpdateMealPlanSourceRequest(
         @NullOrNotBlank
+        @Size(max = 500)
         @Schema(description = "Updated display label of the source", example = "Magerquark (Milbona/Milsani, fatsecret.de)")
         String label,
 
         @NullOrNotBlank
+        @Size(max = 1000)
         @Schema(description = "Updated link to the source", example = "https://www.fatsecret.de/magerquark")
         String url
 ) {

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanStatRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanStatRequest.java
@@ -2,6 +2,7 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan headline statistic.
@@ -13,10 +14,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to update a meal-plan headline statistic")
 public record UpdateMealPlanStatRequest(
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated statistic label", example = "Tagesbudget (Ø)")
         String label,
 
         @NullOrNotBlank
+        @Size(max = 255)
         @Schema(description = "Updated statistic display value", example = "2.416 kcal")
         String value
 ) {

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/MealPlanRequestValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/MealPlanRequestValidationTest.java
@@ -1,0 +1,442 @@
+package com.marvin.nutrition.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests that validate Bean Validation constraints on the meal-plan write request records,
+ * ensuring oversized/malformed input is rejected as a 400 instead of reaching the database and
+ * surfacing as a generic 409 {@code DataIntegrityViolationException}.
+ */
+public class MealPlanRequestValidationTest {
+
+    private static final String BADGE_OK = "ok";
+    private static final String BADGE_WARN = "warn";
+
+    private final Validator validator = jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with all valid-length fields yields zero violations")
+    void updateMealPlanRequest_valid_noViolations() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                "eyebrow", "title", "description", "shoppingListTitle", "shoppingListNote",
+                "shoppingListCallout", "footerNote"
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with over-long eyebrow yields a violation on 'eyebrow'")
+    void updateMealPlanRequest_overLongEyebrow_yieldsViolation() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                "x".repeat(501), null, null, null, null, null, null
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for eyebrow exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("eyebrow")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with over-long title yields a violation on 'title'")
+    void updateMealPlanRequest_overLongTitle_yieldsViolation() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                null, "x".repeat(501), null, null, null, null, null
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for title exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("title")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with over-long shoppingListTitle yields a violation")
+    void updateMealPlanRequest_overLongShoppingListTitle_yieldsViolation() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                null, null, null, "x".repeat(501), null, null, null
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for shoppingListTitle exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("shoppingListTitle")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with over-long shoppingListNote yields a violation")
+    void updateMealPlanRequest_overLongShoppingListNote_yieldsViolation() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                null, null, null, null, "x".repeat(501), null, null
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for shoppingListNote exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("shoppingListNote")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRequest with unbounded TEXT fields at large size yields zero violations")
+    void updateMealPlanRequest_largeUnboundedTextFields_noViolations() {
+        final UpdateMealPlanRequest req = new UpdateMealPlanRequest(
+                null, null, "x".repeat(5000), null, null, "x".repeat(5000), "x".repeat(5000)
+        );
+
+        final Set<ConstraintViolation<UpdateMealPlanRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for unbounded TEXT columns regardless of length");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with valid-length fields yields zero violations")
+    void updateMealPlanSectionRequest_valid_noViolations() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("title", "note", "callout");
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with over-long title yields a violation")
+    void updateMealPlanSectionRequest_overLongTitle_yieldsViolation() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("x".repeat(501), null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for title exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("title")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with over-long note yields a violation")
+    void updateMealPlanSectionRequest_overLongNote_yieldsViolation() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, "x".repeat(501), null);
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for note exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("note")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with large unbounded callout yields zero violations")
+    void updateMealPlanSectionRequest_largeCallout_noViolations() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, null, "x".repeat(5000));
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for unbounded TEXT column regardless of length");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with valid-length fields yields zero violations")
+    void updateMealPlanRowRequest_valid_noViolations() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("meal", "details", "qty", "kcal", "protein");
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with over-long meal yields a violation")
+    void updateMealPlanRowRequest_overLongMeal_yieldsViolation() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest("x".repeat(256), null, null, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for meal exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("meal")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with over-long qty yields a violation")
+    void updateMealPlanRowRequest_overLongQty_yieldsViolation() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest(null, null, "x".repeat(256), null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for qty exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("qty")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with over-long kcal yields a violation")
+    void updateMealPlanRowRequest_overLongKcal_yieldsViolation() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest(null, null, null, "x".repeat(256), null);
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for kcal exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("kcal")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with over-long protein yields a violation")
+    void updateMealPlanRowRequest_overLongProtein_yieldsViolation() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest(null, null, null, null, "x".repeat(256));
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for protein exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("protein")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanRowRequest with large unbounded details yields zero violations")
+    void updateMealPlanRowRequest_largeDetails_noViolations() {
+        final UpdateMealPlanRowRequest req = new UpdateMealPlanRowRequest(null, "x".repeat(5000), null, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanRowRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for unbounded TEXT column regardless of length");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanStatRequest with valid-length fields yields zero violations")
+    void updateMealPlanStatRequest_valid_noViolations() {
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("label", "value");
+
+        final Set<ConstraintViolation<UpdateMealPlanStatRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanStatRequest with over-long label yields a violation")
+    void updateMealPlanStatRequest_overLongLabel_yieldsViolation() {
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest("x".repeat(256), null);
+
+        final Set<ConstraintViolation<UpdateMealPlanStatRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for label exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("label")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanStatRequest with over-long value yields a violation")
+    void updateMealPlanStatRequest_overLongValue_yieldsViolation() {
+        final UpdateMealPlanStatRequest req = new UpdateMealPlanStatRequest(null, "x".repeat(256));
+
+        final Set<ConstraintViolation<UpdateMealPlanStatRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for value exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("value")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingCategoryRequest with valid-length title yields zero violations")
+    void updateMealPlanShoppingCategoryRequest_valid_noViolations() {
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("title");
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingCategoryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingCategoryRequest with over-long title yields a violation")
+    void updateMealPlanShoppingCategoryRequest_overLongTitle_yieldsViolation() {
+        final UpdateMealPlanShoppingCategoryRequest req = new UpdateMealPlanShoppingCategoryRequest("x".repeat(501));
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingCategoryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for title exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("title")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with valid-length fields and null badge yields zero violations")
+    void updateMealPlanShoppingItemRequest_validNullBadge_noViolations() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest("name", "brand", null, "badgeText", "qty");
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations when badge is null");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with badge 'ok' yields zero violations")
+    void updateMealPlanShoppingItemRequest_badgeOk_noViolations() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, BADGE_OK, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for badge 'ok'");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with badge 'warn' yields zero violations")
+    void updateMealPlanShoppingItemRequest_badgeWarn_noViolations() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, BADGE_WARN, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for badge 'warn'");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with invalid badge value yields a violation on 'badge'")
+    void updateMealPlanShoppingItemRequest_invalidBadge_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, "warning", null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for badge value not in {ok, warn}");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("badge")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with blank badge yields a violation on 'badge'")
+    void updateMealPlanShoppingItemRequest_blankBadge_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, "   ", null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for blank badge");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("badge")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with over-long name yields a violation")
+    void updateMealPlanShoppingItemRequest_overLongName_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest("x".repeat(256), null, null, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for name exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("name")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with over-long brand yields a violation")
+    void updateMealPlanShoppingItemRequest_overLongBrand_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, "x".repeat(501), null, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for brand exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("brand")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with over-long badgeText yields a violation")
+    void updateMealPlanShoppingItemRequest_overLongBadgeText_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, null, "x".repeat(501), null);
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for badgeText exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("badgeText")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanShoppingItemRequest with over-long qty yields a violation")
+    void updateMealPlanShoppingItemRequest_overLongQty_yieldsViolation() {
+        final UpdateMealPlanShoppingItemRequest req =
+                new UpdateMealPlanShoppingItemRequest(null, null, null, null, "x".repeat(256));
+
+        final Set<ConstraintViolation<UpdateMealPlanShoppingItemRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for qty exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("qty")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSourceRequest with valid-length fields yields zero violations")
+    void updateMealPlanSourceRequest_valid_noViolations() {
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("label", "https://example.com");
+
+        final Set<ConstraintViolation<UpdateMealPlanSourceRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSourceRequest with over-long label yields a violation")
+    void updateMealPlanSourceRequest_overLongLabel_yieldsViolation() {
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("x".repeat(501), null);
+
+        final Set<ConstraintViolation<UpdateMealPlanSourceRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for label exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("label")));
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSourceRequest with over-long url yields a violation")
+    void updateMealPlanSourceRequest_overLongUrl_yieldsViolation() {
+        final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest(null, "x".repeat(1001));
+
+        final Set<ConstraintViolation<UpdateMealPlanSourceRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for url exceeding 1000 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("url")));
+    }
+
+    @Test
+    @DisplayName("CreateMealPlanChangelogEntryRequest with valid-length fields yields zero violations")
+    void createMealPlanChangelogEntryRequest_valid_noViolations() {
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("tag", "was", "text", 0);
+
+        final Set<ConstraintViolation<CreateMealPlanChangelogEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a valid request");
+    }
+
+    @Test
+    @DisplayName("CreateMealPlanChangelogEntryRequest with over-long tag yields a violation")
+    void createMealPlanChangelogEntryRequest_overLongTag_yieldsViolation() {
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("x".repeat(256), null, "text", 0);
+
+        final Set<ConstraintViolation<CreateMealPlanChangelogEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for tag exceeding 255 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("tag")));
+    }
+
+    @Test
+    @DisplayName("CreateMealPlanChangelogEntryRequest with over-long was yields a violation")
+    void createMealPlanChangelogEntryRequest_overLongWas_yieldsViolation() {
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("tag", "x".repeat(501), "text", 0);
+
+        final Set<ConstraintViolation<CreateMealPlanChangelogEntryRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for was exceeding 500 chars");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("was")));
+    }
+
+    @Test
+    @DisplayName("CreateMealPlanChangelogEntryRequest with large unbounded text yields zero violations")
+    void createMealPlanChangelogEntryRequest_largeText_noViolations() {
+        final CreateMealPlanChangelogEntryRequest req =
+                new CreateMealPlanChangelogEntryRequest("tag", null, "x".repeat(5000), 0);
+
+        final Set<ConstraintViolation<CreateMealPlanChangelogEntryRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for unbounded TEXT column regardless of length");
+    }
+}


### PR DESCRIPTION
## Summary
- Addresses a non-blocking review finding on PR #215: the meal-plan write request DTOs relied solely on DB column constraints (VARCHAR length, `badge` CHECK constraint), so malformed input surfaced as a generic `DataIntegrityViolationException` → 409 instead of a clean 400 Bean Validation error.
- Added `@Size(max = N)` to every bounded VARCHAR field across `UpdateMealPlanRequest`, `UpdateMealPlanSectionRequest`, `UpdateMealPlanRowRequest`, `UpdateMealPlanStatRequest`, `UpdateMealPlanShoppingCategoryRequest`, `UpdateMealPlanShoppingItemRequest`, `UpdateMealPlanSourceRequest`, and `CreateMealPlanChangelogEntryRequest`, mirroring the backing `@Column(length = N)` / migration constraint (verified against `V1_10__nutrition_meal_plan.sql`). Unbounded TEXT columns were left unconstrained.
- Replaced the `badge` field's length-only guard with `@Pattern(regexp = "^(ok|warn)$")`, enforcing the DB's `CHECK (badge IN ('ok', 'warn') OR badge IS NULL)` constraint. Existing `@NullOrNotBlank` annotations were kept as-is; both coexist without conflict since each independently allows `null`.

## Test plan
- [x] Added `MealPlanRequestValidationTest` (TDD: written first, confirmed 22 failing assertions against the un-annotated DTOs, then made green) covering oversized-string rejection, valid-length acceptance, unbounded TEXT fields, and all four `badge` cases (null valid, blank rejected, `"warning"` rejected, `ok`/`warn` accepted).
- [x] `./gradlew :nutrition:test` — new test class and all other non-Testcontainers tests pass (3 pre-existing Testcontainers-backed repository tests fail in this sandbox because Docker isn't available here; unrelated to this change).
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)