### PR TITLE
Fix WebFlux exception handlers to catch WebExchangeBindException

### DIFF
--- a/it-news/src/main/java/com/marvin/itnews/controller/ItNewsExceptionHandler.java
+++ b/it-news/src/main/java/com/marvin/itnews/controller/ItNewsExceptionHandler.java
@@ -5,26 +5,49 @@ import java.util.stream.Collectors;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
 
+/** Global exception handler for the it-news module REST controllers. */
 @RestControllerAdvice(basePackages = "com.marvin.itnews")
 public class ItNewsExceptionHandler {
 
+    /**
+     * Maps {@link EntityNotFoundException} to HTTP 404.
+     *
+     * @param ex the exception
+     * @return 404 response with the exception message
+     */
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<String> handleNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 
+    /**
+     * Maps {@link DataIntegrityViolationException} to HTTP 409 Conflict.
+     *
+     * @param ex the exception
+     * @return 409 response with a message describing the conflict
+     */
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<String> handleConflict(DataIntegrityViolationException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body("A feed config with this URL already exists");
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
+    /**
+     * Maps bean-validation failures on {@code @Valid @RequestBody} arguments
+     * ({@link WebExchangeBindException}) to HTTP 400.
+     *
+     * <p>WebFlux annotated controllers raise {@link WebExchangeBindException} for these failures,
+     * not the Spring MVC {@code MethodArgumentNotValidException}.</p>
+     *
+     * @param ex the exception carrying field error details
+     * @return 400 response with comma-separated field error messages
+     */
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<String> handleValidation(WebExchangeBindException ex) {
         final String errors = ex.getBindingResult().getFieldErrors().stream()
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));

--- a/it-news/src/test/java/com/marvin/itnews/ItNewsTestApplication.java
+++ b/it-news/src/test/java/com/marvin/itnews/ItNewsTestApplication.java
@@ -1,0 +1,10 @@
+package com.marvin.itnews;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application used as context anchor for slice tests.
+ */
+@SpringBootApplication
+class ItNewsTestApplication {
+}

--- a/it-news/src/test/java/com/marvin/itnews/controller/FeedConfigControllerBodyValidationTest.java
+++ b/it-news/src/test/java/com/marvin/itnews/controller/FeedConfigControllerBodyValidationTest.java
@@ -1,0 +1,55 @@
+package com.marvin.itnews.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.itnews.dto.FeedSourceDTO;
+import com.marvin.itnews.service.FeedConfigService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies that Bean Validation failures on {@code @Valid @RequestBody} arguments are routed
+ * through {@link ItNewsExceptionHandler#handleValidation} and produce the field-level error
+ * message, rather than falling through to the WebFlux default error body.
+ *
+ * <p>Spring WebFlux annotated controllers raise {@code WebExchangeBindException} for
+ * {@code @Valid @RequestBody} failures, not the Spring MVC {@code MethodArgumentNotValidException}
+ * that the handler was originally written against.</p>
+ */
+@WebFluxTest(
+        controllers = FeedConfigController.class,
+        excludeAutoConfiguration = ReactiveSecurityAutoConfiguration.class
+)
+@DisplayName("FeedConfigController request body validation Tests")
+class FeedConfigControllerBodyValidationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private FeedConfigService feedConfigService;
+
+    @Test
+    @DisplayName("POST /it-news/feeds/ with a blank name returns 400 with the field-level error message")
+    void createFeedConfig_BlankName_ReturnsFieldLevelValidationMessage() {
+        final FeedSourceDTO invalid = new FeedSourceDTO(null, "", "https://example.com/rss", "Java", true);
+
+        final String body = webTestClient.post()
+                .uri("/it-news/feeds/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalid)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(body).contains("name");
+    }
+}

--- a/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/NutritionExceptionHandler.java
@@ -12,9 +12,9 @@ import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
 
 /** Global exception handler for the nutrition module REST controllers. */
 @RestControllerAdvice(basePackages = "com.marvin.nutrition")
@@ -147,13 +147,17 @@ public class NutritionExceptionHandler {
     }
 
     /**
-     * Maps bean-validation failures ({@link MethodArgumentNotValidException}) to HTTP 400.
+     * Maps bean-validation failures on {@code @Valid @RequestBody} arguments
+     * ({@link WebExchangeBindException}) to HTTP 400.
+     *
+     * <p>WebFlux annotated controllers raise {@link WebExchangeBindException} for these failures,
+     * not the Spring MVC {@code MethodArgumentNotValidException}.</p>
      *
      * @param ex the exception carrying field error details
      * @return 400 response with comma-separated field error messages
      */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<String> handleValidation(WebExchangeBindException ex) {
         final String errors = ex.getBindingResult().getFieldErrors().stream()
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerBodyValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/FoodControllerBodyValidationTest.java
@@ -1,0 +1,76 @@
+package com.marvin.nutrition.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.nutrition.dto.FoodDTO;
+import com.marvin.nutrition.entity.FoodSource;
+import com.marvin.nutrition.service.BarcodeLookup;
+import com.marvin.nutrition.service.FoodService;
+import com.marvin.nutrition.service.LabelReader;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies that Bean Validation failures on {@code @Valid @RequestBody} arguments are routed
+ * through {@link NutritionExceptionHandler#handleValidation} and produce the field-level error
+ * message, rather than falling through to the WebFlux default error body.
+ *
+ * <p>Spring WebFlux annotated controllers raise {@code WebExchangeBindException} for
+ * {@code @Valid @RequestBody} failures, not the Spring MVC {@code MethodArgumentNotValidException}
+ * that the handler was originally written against.</p>
+ */
+@WebFluxTest(
+        controllers = FoodController.class,
+        excludeAutoConfiguration = ReactiveSecurityAutoConfiguration.class
+)
+@DisplayName("FoodController request body validation Tests")
+class FoodControllerBodyValidationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private FoodService foodService;
+
+    @MockitoBean
+    private LabelReader labelReader;
+
+    @MockitoBean
+    private BarcodeLookup barcodeLookup;
+
+    @Test
+    @DisplayName("POST /nutrition/foods with a blank name returns 400 with the field-level error message")
+    void createFood_BlankName_ReturnsFieldLevelValidationMessage() {
+        final FoodDTO invalid = new FoodDTO(
+                null,
+                "",
+                null,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                null,
+                null,
+                FoodSource.MANUAL
+        );
+
+        final String body = webTestClient.post()
+                .uri("/nutrition/foods")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalid)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(body).contains("name");
+    }
+}


### PR DESCRIPTION
## Summary
- Bug found during review of #216: `NutritionExceptionHandler` and `ItNewsExceptionHandler` declared `@ExceptionHandler(MethodArgumentNotValidException.class)` to turn Bean Validation failures on `@Valid @RequestBody` arguments into a clean 400 with a `field: message` body. That exception type is Spring **MVC**'s; this codebase is pure Spring **WebFlux**, where annotated controllers raise `org.springframework.web.bind.support.WebExchangeBindException` instead. Since `WebExchangeBindException` does not extend `MethodArgumentNotValidException`, the handler never matched.
- Practical impact: every `@Valid @RequestBody` validation failure across the `nutrition` and `it-news` modules (including the `@Size`/`@Pattern` constraints added to the meal-plan DTOs in #216) fell through to WebFlux's default error handling instead of the intended field-level message. The response status still happened to be 400 (inherited from `ServerWebInputException`), which is likely why this went unnoticed — only the response body was wrong/generic.
- Fix: changed both `@ExceptionHandler` methods to catch `WebExchangeBindException` (which implements `BindingResult`, so the existing field-error-extraction logic is unchanged).

## Test plan
- [x] TDD: added `FoodControllerBodyValidationTest` (nutrition) as a `@WebFluxTest` hitting `POST /nutrition/foods` with a blank `name`, asserting the response body contains the field-level message. Confirmed it failed against the un-fixed handler, then went green after the fix.
- [x] Added the equivalent `FeedConfigControllerBodyValidationTest` (it-news) for `POST /it-news/feeds/`, same pattern. This required adding a minimal `ItNewsTestApplication` `@SpringBootConfiguration` anchor (it-news has no Spring Boot app class of its own, unlike nutrition's existing `NutritionTestApplication`), since `@WebFluxTest` needs one to bootstrap the slice context.
- [x] `./gradlew :nutrition:test` — new test passes; 3 pre-existing Testcontainers-backed repository tests fail in this sandbox because Docker isn't available (unrelated, sandbox-only).
- [x] `./gradlew :it-news:test` — new test passes; 1 pre-existing failure in `RssFetcherServiceTest.shouldSaveArticlePublishedWithinOneMonth()` confirmed to fail identically on unmodified `master` (unrelated flaky/pre-existing test, not touched here).
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest :it-news:checkstyleMain :it-news:checkstyleTest` — zero warnings.
- [x] tdd-test-guardian confirmed no existing test files were modified — only new test files added alongside the two production handler fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)