### PR TITLE
Add DELETE endpoint for meal-plan footer sources

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
@@ -31,6 +31,7 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -297,6 +298,29 @@ public class MealPlanController {
         return Mono.fromCallable(() -> mealPlanWriteService.updateSource(id, req))
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes a meal-plan footer source, or returns 404 if not found.
+     *
+     * @param id the UUID of the source to delete
+     * @return a Mono with 204 on success, or 404 if not found
+     */
+    @DeleteMapping("/sources/{id}")
+    @Operation(
+            summary = "Delete a meal-plan footer source",
+            description = "Deletes an existing footer source.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Source deleted"),
+                @ApiResponse(responseCode = "404", description = "Source not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteSource(
+            @PathVariable @Parameter(description = "UUID of the source to delete") UUID id) {
+        return Mono.fromRunnable(() -> mealPlanWriteService.deleteSource(id))
+                .subscribeOn(Schedulers.boundedElastic())
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
                 .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
     }
 

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanWriteService.java
@@ -179,6 +179,19 @@ public class MealPlanWriteService {
     }
 
     /**
+     * Deletes the footer source with the given id.
+     * Throws {@link NoSuchElementException} if no source with the given id exists.
+     *
+     * @param id the UUID of the source to delete
+     */
+    @Transactional
+    public void deleteSource(UUID id) {
+        final MealPlanSourceEntity source = mealPlanSourceRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Meal plan source not found: " + id));
+        mealPlanSourceRepository.delete(source);
+    }
+
+    /**
      * Appends a new entry to the meal plan's changelog. The changelog is an append-only historical
      * log; there is no update or delete operation for existing entries.
      *

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealPlanControllerTest.java
@@ -2,9 +2,11 @@ package com.marvin.nutrition.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -348,6 +350,39 @@ class MealPlanControllerTest {
                 .thenThrow(new NoSuchElementException("not found"));
 
         final Mono<ResponseEntity<MealPlanSourceDTO>> result = mealPlanController.updateSource(sourceId, req);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE /nutrition/meal-plan/sources/{id}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteSource returns 204 with no body")
+    void deleteSource_Returns204() {
+        final UUID sourceId = UUID.randomUUID();
+
+        final Mono<ResponseEntity<Void>> result = mealPlanController.deleteSource(sourceId);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(204, response.getStatusCode().value());
+                    assertNull(response.getBody());
+                })
+                .verifyComplete();
+        verify(mealPlanWriteService).deleteSource(sourceId);
+    }
+
+    @Test
+    @DisplayName("deleteSource returns 404 when the source does not exist")
+    void deleteSource_NotFound_Returns404() {
+        final UUID sourceId = UUID.randomUUID();
+        doThrow(new NoSuchElementException("not found")).when(mealPlanWriteService).deleteSource(sourceId);
+
+        final Mono<ResponseEntity<Void>> result = mealPlanController.deleteSource(sourceId);
 
         StepVerifier.create(result)
                 .assertNext(response -> assertEquals(404, response.getStatusCode().value()))

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanWriteServiceTest.java
@@ -191,6 +191,33 @@ class MealPlanWriteServiceTest {
     }
 
     // -----------------------------------------------------------------------
+    // deleteSource
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteSource deletes the found source entity")
+    void deleteSource_DeletesFoundEntity() {
+        final UUID sourceId = UUID.randomUUID();
+        final MealPlanSourceEntity source = new MealPlanSourceEntity();
+        source.setId(sourceId);
+
+        when(mealPlanSourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+
+        mealPlanWriteService.deleteSource(sourceId);
+
+        verify(mealPlanSourceRepository).delete(source);
+    }
+
+    @Test
+    @DisplayName("deleteSource throws NoSuchElementException when the source does not exist")
+    void deleteSource_NotFound_ThrowsNoSuchElementException() {
+        final UUID sourceId = UUID.randomUUID();
+        when(mealPlanSourceRepository.findById(sourceId)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> mealPlanWriteService.deleteSource(sourceId));
+    }
+
+    // -----------------------------------------------------------------------
     // addChangelogEntry
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `DELETE /nutrition/meal-plan/sources/{id}` to remove an individual footer source entry, returning 204 on success and 404 if the id doesn't exist, mirroring the existing `PUT /sources/{id}` update endpoint.
- New `MealPlanWriteService.deleteSource(UUID id)` looks up the entity via `MealPlanSourceRepository`, throws `NoSuchElementException` when absent, and deletes it otherwise.

Closes #220

Note: removal of the orphaned "Basmatireis Lidl, roh (fatsecret.de)" seed entry itself is deferred to a follow-up once this endpoint is deployed, per the issue's scope.

## Test plan
- [x] New controller tests: `deleteSource_Returns204`, `deleteSource_NotFound_Returns404`
- [x] New service tests: `deleteSource_DeletesFoundEntity`, `deleteSource_NotFound_ThrowsNoSuchElementException`
- [x] `./gradlew :nutrition:checkstyleMain checkstyleTest` — zero warnings
- [x] `./gradlew :nutrition:test` — passes (pre-existing Testcontainers failures unrelated, no Docker locally)
- [x] `./gradlew :nutrition:build -x test` — BUILD SUCCESSFUL
- [x] tdd-test-guardian confirmed no existing tests were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)