### PR TITLE
Fix CAMT import detection for file overwrites

### DIFF
--- a/costs/src/main/java/com/marvin/costs/service/Delegator.java
+++ b/costs/src/main/java/com/marvin/costs/service/Delegator.java
@@ -68,22 +68,23 @@ public class Delegator {
      */
     @EventListener(NewFileEvent.class)
     public void startUpWatchService(NewFileEvent newFileEvent) throws Exception {
+        LOGGER.info("Processing CAMT file: {}", newFileEvent.path().getFileName());
 
         final Flux<BookingEntryDTO> bookingEntryStream = getBookingEntries(
                 Files.newInputStream(newFileEvent.path()))
                 .publish().autoConnect(4);
 
         monthlyCostImportService.importMonthlyCost(bookingEntryStream)
-                .subscribe(LOGGER::info);
+                .subscribe(LOGGER::info, e -> LOGGER.error("Monthly cost import failed", e));
 
         specialCostImportService.importSpecialCost(bookingEntryStream)
-                .subscribe(LOGGER::info);
+                .subscribe(LOGGER::info, e -> LOGGER.error("Special cost import failed", e));
 
         salaryImportService.importSalary(bookingEntryStream)
-                .subscribe(LOGGER::info);
+                .subscribe(LOGGER::info, e -> LOGGER.error("Salary import failed", e));
 
         dailyCostImportService.importDailyCost(bookingEntryStream)
-                .subscribe(LOGGER::info);
+                .subscribe(LOGGER::info, e -> LOGGER.error("Daily cost import failed", e));
     }
 
     private Flux<BookingEntryDTO> getBookingEntries(InputStream inputStream) {

--- a/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
+++ b/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
@@ -69,7 +69,8 @@ public class DirectoryWatcher {
 
     private void watchDirectory() throws Exception {
         final WatchService watchService = FileSystems.getDefault().newWatchService();
-        directoryIn.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        directoryIn.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_MODIFY);
 
         WatchKey key;
         while (IS_RUNNING.get() && (key = watchService.take()) != null) {
@@ -77,10 +78,14 @@ public class DirectoryWatcher {
                 final Path file = Paths.get(directoryIn.toString(),
                         event.context().toString());
                 if (!Files.isDirectory(file)) {
-                    eventPublisher.publishEvent(new NewFileEvent(file));
-                    final Path moved = Files.move(file,
-                            directoryDone.resolve(file.getFileName()));
-                    LOGGER.info("Moved {} to {}!", file.getFileName(), moved);
+                    try {
+                        final Path moved = Files.move(file,
+                                directoryDone.resolve(file.getFileName()));
+                        LOGGER.info("Moved {} to {}!", file.getFileName(), moved);
+                        eventPublisher.publishEvent(new NewFileEvent(moved));
+                    } catch (Exception e) {
+                        LOGGER.error("Failed to move file {} to done directory", file.getFileName(), e);
+                    }
                 }
             }
             key.reset();


### PR DESCRIPTION
## Summary

Fixed two issues with CAMT file import processing:
1. DirectoryWatcher now detects file overwrites (ENTRY_MODIFY events)
2. Eliminated race condition where Delegator couldn't read files being moved

## Changes

- DirectoryWatcher watches both ENTRY_CREATE and ENTRY_MODIFY events
- File is moved to done/ directory BEFORE publishing event (fixes race condition)
- Added logging to Delegator for file processing and error visibility
- Added error handling in DirectoryWatcher for move failures

## Why

Previously, uploading the same CAMT file multiple times would overwrite the existing file, triggering ENTRY_MODIFY instead of ENTRY_CREATE, so the watcher wouldn't detect it. Additionally, there was a race condition where the file would be moved to done/ before Delegator could open it for processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)