### PR TITLE
Handle CAMT file overwrites in done directory

### DIFF
--- a/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
+++ b/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
@@ -6,6 +6,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
@@ -80,7 +81,8 @@ public class DirectoryWatcher {
                 if (!Files.isDirectory(file)) {
                     try {
                         final Path moved = Files.move(file,
-                                directoryDone.resolve(file.getFileName()));
+                                directoryDone.resolve(file.getFileName()),
+                                StandardCopyOption.REPLACE_EXISTING);
                         LOGGER.info("Moved {} to {}!", file.getFileName(), moved);
                         eventPublisher.publishEvent(new NewFileEvent(moved));
                     } catch (Exception e) {


### PR DESCRIPTION
## Summary

Allow CAMT files with the same name to be reprocessed by replacing existing files in the done directory.

## Changes

- Added `REPLACE_EXISTING` option to `Files.move()` call in DirectoryWatcher
- Allows the same CAMT file to be uploaded and reprocessed multiple times
- Previously failed with `FileAlreadyExistsException` when file already existed in done/

🤖 Generated with [Claude Code](https://claude.com/claude-code)