### PR TITLE
Fix CAMT directory watcher race on duplicate file events

### DIFF
--- a/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
+++ b/costs/src/main/java/com/marvin/costs/service/DirectoryWatcher.java
@@ -78,7 +78,9 @@ public class DirectoryWatcher {
             for (WatchEvent<?> event : key.pollEvents()) {
                 final Path file = Paths.get(directoryIn.toString(),
                         event.context().toString());
-                if (!Files.isDirectory(file)) {
+                if (!Files.exists(file)) {
+                    LOGGER.debug("Skipping {}, already moved by a previous event for the same file", file.getFileName());
+                } else if (!Files.isDirectory(file)) {
                     try {
                         final Path moved = Files.move(file,
                                 directoryDone.resolve(file.getFileName()),


### PR DESCRIPTION
## Summary
- Fixes `NoSuchFileException` in `DirectoryWatcher` when a file upload fires multiple filesystem events (ENTRY_CREATE + ENTRY_MODIFY) for the same file
- The first event moves the file to the done directory; subsequent duplicate events for the same filename now skip cleanly instead of erroring, since the file no longer exists at that path

## Test plan
- [x] `./gradlew :costs:compileJava :costs:checkstyleMain` passes