### PR TITLE
fix(nutrition): add day-count to meal-plan sections for shopping-list scaling

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealPlanController.java
@@ -123,7 +123,7 @@ public class MealPlanController {
     @PutMapping("/sections/{id}")
     @Operation(
             summary = "Update a meal-plan section",
-            description = "Applies partial updates to an existing meal-plan section's title, note and/or callout.",
+            description = "Applies partial updates to an existing meal-plan section's title, note, callout and/or day count.",
             responses = {
                 @ApiResponse(
                         responseCode = "200",

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/MealPlanSectionDTO.java
@@ -8,11 +8,14 @@ import java.util.UUID;
  * Data Transfer Object representing a single section of the meal plan, e.g. a daily structure or a
  * group of weekdays sharing the same meals.
  *
- * @param id      the section's unique identifier
- * @param title   the section's title
- * @param note    short note describing the section
- * @param rows    the meal rows making up this section
- * @param callout optional explanatory callout text, or {@code null} if none
+ * @param id        the section's unique identifier
+ * @param title     the section's title
+ * @param note      short note describing the section
+ * @param rows      the meal rows making up this section
+ * @param callout   optional explanatory callout text, or {@code null} if none
+ * @param dayCount  number of calendar days per week this section applies to, e.g. 4 for a
+ *                  Monday-Thursday block; used to scale row quantities when aggregating a
+ *                  shopping list across the week
  */
 @Schema(description = "A single section of the meal plan")
 public record MealPlanSectionDTO(
@@ -29,6 +32,23 @@ public record MealPlanSectionDTO(
         List<MealPlanRowDTO> rows,
 
         @Schema(description = "Optional explanatory callout text, absent if none")
-        String callout
+        String callout,
+
+        @Schema(description = "Number of calendar days per week this section applies to", example = "4")
+        Integer dayCount
 ) {
+
+    /**
+     * Preserves the pre-{@code dayCount} constructor signature for existing callers, defaulting
+     * {@code dayCount} to {@code 1} (a single day), matching the entity's own default.
+     *
+     * @param id      the section's unique identifier
+     * @param title   the section's title
+     * @param note    short note describing the section
+     * @param rows    the meal rows making up this section
+     * @param callout optional explanatory callout text, or {@code null} if none
+     */
+    public MealPlanSectionDTO(UUID id, String title, String note, List<MealPlanRowDTO> rows, String callout) {
+        this(id, title, note, rows, callout, 1);
+    }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/dto/UpdateMealPlanSectionRequest.java
@@ -2,15 +2,17 @@ package com.marvin.nutrition.dto;
 
 import com.marvin.nutrition.dto.validation.NullOrNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 /**
  * Request body for updating a meal-plan section.
  * All fields are optional; only non-null values are applied.
  *
- * @param title   updated section title (nullable)
- * @param note    updated short note describing the section (nullable)
- * @param callout updated explanatory callout text (nullable)
+ * @param title     updated section title (nullable)
+ * @param note      updated short note describing the section (nullable)
+ * @param callout   updated explanatory callout text (nullable)
+ * @param dayCount  updated number of calendar days per week this section applies to (nullable)
  */
 @Schema(description = "Request to update a meal-plan section")
 public record UpdateMealPlanSectionRequest(
@@ -26,6 +28,23 @@ public record UpdateMealPlanSectionRequest(
 
         @NullOrNotBlank
         @Schema(description = "Updated explanatory callout text")
-        String callout
+        String callout,
+
+        @Positive
+        @Schema(description = "Updated number of calendar days per week this section applies to", example = "4")
+        Integer dayCount
 ) {
+
+    /**
+     * Preserves the pre-{@code dayCount} constructor signature for existing callers; omitting
+     * {@code dayCount} means "leave unchanged", consistent with this record's partial-update
+     * semantics for every other field.
+     *
+     * @param title   updated section title (nullable)
+     * @param note    updated short note describing the section (nullable)
+     * @param callout updated explanatory callout text (nullable)
+     */
+    public UpdateMealPlanSectionRequest(String title, String note, String callout) {
+        this(title, note, callout, null);
+    }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSectionEntity.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/entity/MealPlanSectionEntity.java
@@ -39,6 +39,9 @@ public class MealPlanSectionEntity extends BasicEntity {
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder;
 
+    @Column(name = "day_count", nullable = false)
+    private Integer dayCount = 1;
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionWriteService.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/MealPlanSectionWriteService.java
@@ -60,7 +60,7 @@ public class MealPlanSectionWriteService {
     }
 
     /**
-     * Updates an existing meal-plan section's title, note and/or callout.
+     * Updates an existing meal-plan section's title, note, callout and/or day count.
      * Only non-null fields from the request are applied. The returned DTO
      * includes the section's current (unmodified) rows.
      * Throws {@link NoSuchElementException} if no section with the given id exists.
@@ -82,6 +82,9 @@ public class MealPlanSectionWriteService {
         }
         if (req.callout() != null) {
             section.setCallout(req.callout());
+        }
+        if (req.dayCount() != null) {
+            section.setDayCount(req.dayCount());
         }
 
         final MealPlanSectionEntity saved = mealPlanSectionRepository.save(section);

--- a/nutrition/src/main/resources/db/migration/nutrition/V1_13__meal_plan_section_day_count.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_13__meal_plan_section_day_count.sql
@@ -1,0 +1,14 @@
+-- Adds an explicit day-count to each meal-plan section. Sections like "2 · Wochentage (Montag –
+-- Donnerstag)" represent several calendar days of the week, not one, but the shopping-list
+-- aggregation only ever summed each row's quantityG once per section regardless of how many days
+-- it actually spans -- undercounting total quantities needed for the week (e.g. a 300 g/day row in
+-- a 4-day section needs 1200 g bought, not 300 g). day_count lets that calculation scale each
+-- section's row quantities by the number of days it applies to.
+ALTER TABLE nutrition.meal_plan_section
+    ADD COLUMN day_count INTEGER NOT NULL DEFAULT 1;
+
+-- Correct the day counts for the currently seeded sections (identified by title, since sections
+-- have no other stable natural key here).
+UPDATE nutrition.meal_plan_section SET day_count = 7 WHERE title LIKE '%Tagesstruktur%';
+UPDATE nutrition.meal_plan_section SET day_count = 4 WHERE title LIKE '%Wochentage%';
+UPDATE nutrition.meal_plan_section SET day_count = 3 WHERE title LIKE '%Wochenende%';

--- a/nutrition/src/test/java/com/marvin/nutrition/dto/MealPlanRequestValidationTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/dto/MealPlanRequestValidationTest.java
@@ -107,6 +107,37 @@ public class MealPlanRequestValidationTest {
     }
 
     @Test
+    @DisplayName("UpdateMealPlanSectionRequest with a null dayCount (partial update) yields zero violations")
+    void updateMealPlanSectionRequest_nullDayCount_noViolations() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, null, null, null);
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations when dayCount is omitted");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with a positive dayCount yields zero violations")
+    void updateMealPlanSectionRequest_positiveDayCount_noViolations() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, null, null, 4);
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertTrue(violations.isEmpty(), "Expected zero violations for a positive dayCount");
+    }
+
+    @Test
+    @DisplayName("UpdateMealPlanSectionRequest with zero or negative dayCount yields a violation")
+    void updateMealPlanSectionRequest_nonPositiveDayCount_yieldsViolation() {
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, null, null, 0);
+
+        final Set<ConstraintViolation<UpdateMealPlanSectionRequest>> violations = validator.validate(req);
+
+        assertFalse(violations.isEmpty(), "Expected a violation for non-positive dayCount");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("dayCount")));
+    }
+
+    @Test
     @DisplayName("UpdateMealPlanSourceRequest with valid-length fields yields zero violations")
     void updateMealPlanSourceRequest_valid_noViolations() {
         final UpdateMealPlanSourceRequest req = new UpdateMealPlanSourceRequest("label", "https://example.com");

--- a/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/mapper/MealPlanMapperTest.java
@@ -88,4 +88,18 @@ class MealPlanMapperTest {
 
         assertEquals(null, dto.callout());
     }
+
+    @Test
+    @DisplayName("toSectionDTO carries over the section's dayCount")
+    void toSectionDTO_MapsDayCount() {
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setId(UUID.randomUUID());
+        section.setTitle("2 · Wochentage (Montag – Donnerstag)");
+        section.setNote("note");
+        section.setDayCount(4);
+
+        final MealPlanSectionDTO dto = mealPlanMapper.toSectionDTO(section, List.of());
+
+        assertEquals(4, dto.dayCount());
+    }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/repository/MealPlanRepositoryTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/repository/MealPlanRepositoryTest.java
@@ -185,6 +185,28 @@ class MealPlanRepositoryTest {
     }
 
     @Test
+    void newSectionDefaultsDayCountToOne() {
+        final MealPlanSectionEntity section = saveSection("Section", "note", 0);
+
+        assertThat(section.getDayCount()).isEqualTo(1);
+    }
+
+    @Test
+    void savesAndFindsSectionWithExplicitDayCount() {
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setMealPlanId(mealPlan.getId());
+        section.setTitle("2 · Wochentage");
+        section.setNote("note");
+        section.setSortOrder(0);
+        section.setDayCount(4);
+        final MealPlanSectionEntity saved = mealPlanSectionRepository.save(section);
+
+        final MealPlanSectionEntity found = mealPlanSectionRepository.findById(saved.getId()).orElseThrow();
+
+        assertThat(found.getDayCount()).isEqualTo(4);
+    }
+
+    @Test
     void countByFoodIdCountsRowsReferencingTheFood() {
         final MealPlanSectionEntity section = saveSection("Section", "note", 0);
         saveRow(section.getId(), MealType.BREAKFAST, BigDecimal.valueOf(90), 0);

--- a/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionWriteServiceTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/MealPlanSectionWriteServiceTest.java
@@ -126,6 +126,58 @@ class MealPlanSectionWriteServiceTest {
         assertThrows(NoSuchElementException.class, () -> mealPlanSectionWriteService.updateSection(sectionId, req));
     }
 
+    @Test
+    @DisplayName("updateSection applies a non-null dayCount")
+    void updateSection_AppliesDayCount() {
+        final UUID sectionId = UUID.randomUUID();
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setId(sectionId);
+        section.setDayCount(1);
+
+        final MealPlanRowDTO rowDTO = new MealPlanRowDTO(
+                UUID.randomUUID(), MealType.BREAKFAST, UUID.randomUUID(), "Haferflocken",
+                new BigDecimal("90.00"), new BigDecimal("519.00"), new BigDecimal("28.00"),
+                new BigDecimal("60.00"), new BigDecimal("10.00"));
+        final MealPlanSectionDTO sectionDTO =
+                new MealPlanSectionDTO(sectionId, "title", "note", List.of(rowDTO), null, 4);
+
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest(null, null, null, 4);
+
+        when(mealPlanSectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
+        when(mealPlanSectionRepository.save(section)).thenReturn(section);
+        when(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(sectionId))
+                .thenReturn(List.of());
+        when(mealPlanMapper.toRowDTOs(List.of())).thenReturn(List.of(rowDTO));
+        when(mealPlanMapper.toSectionDTO(section, List.of(rowDTO))).thenReturn(sectionDTO);
+
+        final MealPlanSectionDTO result = mealPlanSectionWriteService.updateSection(sectionId, req);
+
+        assertEquals(4, section.getDayCount());
+        assertEquals(sectionDTO, result);
+    }
+
+    @Test
+    @DisplayName("updateSection leaves dayCount unchanged when the request's dayCount is null")
+    void updateSection_NullDayCount_LeavesDayCountUnchanged() {
+        final UUID sectionId = UUID.randomUUID();
+        final MealPlanSectionEntity section = new MealPlanSectionEntity();
+        section.setId(sectionId);
+        section.setDayCount(4);
+
+        final UpdateMealPlanSectionRequest req = new UpdateMealPlanSectionRequest("new title", null, null);
+
+        when(mealPlanSectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
+        when(mealPlanSectionRepository.save(section)).thenReturn(section);
+        when(mealPlanRowRepository.findAllByMealPlanSectionIdOrderBySortOrderAsc(sectionId))
+                .thenReturn(List.of());
+        when(mealPlanMapper.toRowDTOs(List.of())).thenReturn(List.of());
+        when(mealPlanMapper.toSectionDTO(section, List.of())).thenReturn(null);
+
+        mealPlanSectionWriteService.updateSection(sectionId, req);
+
+        assertEquals(4, section.getDayCount());
+    }
+
     // -----------------------------------------------------------------------
     // addRow
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds a `day_count` column to `nutrition.meal_plan_section` (migration `V1_13`), defaulting to 1 and set to the correct values for the currently seeded sections (Tagesstruktur=7, Wochentage=4, Wochenende=3).
- `GET /nutrition/meal-plan` now reports each section's `dayCount`; `PUT /nutrition/meal-plan/sections/{id}` accepts an optional `dayCount` to update it.
- Root cause: a section like "Wochentage (Montag – Donnerstag)" represents 4 calendar days, but its row quantities were only ever counted once when the frontend aggregated a weekly shopping list — undercounting how much of an ingredient is actually needed (e.g. a 300 g/day row needs 1200 g bought across 4 days, not 300 g).
- `MealPlanSectionDTO` and `UpdateMealPlanSectionRequest` keep a secondary constructor at their pre-existing arity, so all current callers/tests compile and pass unchanged — no existing test was modified, only new tests added.

## Test plan
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` passes
- [x] `./gradlew :nutrition:test` — 362 tests, only the 3 pre-existing Testcontainers/Docker-environment failures (unrelated to this change, not reproducible with a working Docker daemon) fail; all new and existing meal-plan tests are green
- [ ] Corresponding frontend change (multiplies shopping-list quantities by `section.dayCount`) ships alongside this

🤖 Generated with [Claude Code](https://claude.com/claude-code)