### PR TITLE
fix(nutrition): remove redundant Tagesstruktur section from meal plan

### DIFF
--- a/nutrition/src/main/resources/db/migration/nutrition/V1_14__remove_tagesstruktur_section.sql
+++ b/nutrition/src/main/resources/db/migration/nutrition/V1_14__remove_tagesstruktur_section.sql
@@ -1,0 +1,15 @@
+-- Removes the "Tagesstruktur" section (issue #227): every row it carried duplicates content that
+-- already lives in the other meal-plan sections ("siehe Tagesstruktur" rows), so the section itself
+-- is redundant. The frontend currently filters it out client-side as a stopgap
+-- (Marvin1912/frontend#281); this migration removes it at the data layer so the API stops
+-- returning it and that client-side filter can be dropped.
+--
+-- The section's rows are deleted first (FK safety), then the section itself, both identified by
+-- the fixed seed id from V1_10. Deleting rows explicitly here (rather than relying solely on the
+-- section's ON DELETE CASCADE) also covers any rows re-added under this section id via the write
+-- API after V1_11 replaced the original free-text rows with food-backed ones.
+DELETE FROM nutrition.meal_plan_row
+WHERE meal_plan_section_id = '5b21f5d0-5dd3-4653-8941-8920f7231447';
+
+DELETE FROM nutrition.meal_plan_section
+WHERE id = '5b21f5d0-5dd3-4653-8941-8920f7231447';

--- a/nutrition/src/main/resources/nutrition/meal-plan.json
+++ b/nutrition/src/main/resources/nutrition/meal-plan.json
@@ -21,16 +21,6 @@
   ],
   "sections": [
     {
-      "title": "1 · Tagesstruktur (täglich gleich)",
-      "note": "Frühstück & Nachmittag identisch an allen 7 Tagen",
-      "rows": [
-        {"meal": "Frühstück", "details": "Haferflocken, Haferdrink, Whey, TK-Himbeeren, Mandeln", "qty": "90g/200ml/20g/50g/10g", "kcal": "519", "protein": "28,0 g"},
-        {"meal": "Nachmittag", "details": "Whey, Magerquark, Banane", "qty": "20g/200g/1 Stk", "kcal": "314", "protein": "40,3 g"}
-      ],
-      "totals": null,
-      "callout": "Der Whey-Shake wird jetzt kleiner (20 g statt 40 g) und durch Magerquark ergänzt — pro 100 g liefert Magerquark 12 g Protein bei nur 66 kcal und 0,2 g Fett, macht das Cut-Ziel also nicht teurer. Ei und ein Teil des Magerquarks (100 g) sind aus dem Frühstück verschwunden und wandern ins Abendessen: das Frühstück besteht dadurch nur noch aus Haferflocken, Haferdrink, Whey, TK-Himbeeren und Mandeln. Magerquark ist damit auf Nachmittag (200 g) und Abendessen (100 g) verteilt, das Ei gibt es nur noch zu Mittag/Abendbrot am Wochenende bzw. zum Abendbrot an Wochentagen. Die Nachmittags-Portion Magerquark ist weiterhin bewusst größer als rechnerisch nötig (200 g statt 150 g) — das federt den Hähnchen-Engpass beim Abendessen ab."
-    },
-    {
       "title": "2 · Wochentage (Montag – Donnerstag)",
       "note": "Kantine am Mittag bleibt Richtwert",
       "rows": [


### PR DESCRIPTION
## Summary
- Removes the redundant "Tagesstruktur" section (id `5b21f5d0-5dd3-4653-8941-8920f7231447`) from the nutrition meal plan — all of its rows are duplicated in the other sections (marked `siehe Tagesstruktur`), and the frontend already filters it out client-side as a stopgap (Marvin1912/frontend#281).
- Adds a new Flyway migration `V1_14__remove_tagesstruktur_section.sql` that deletes the section's rows and then the section itself, so it works both for already-deployed databases and for a fresh full migration replay. The already-applied `V1_10` seed migration is intentionally left untouched to avoid a checksum/validation break.
- Updates the static fixture/reference file `nutrition/src/main/resources/nutrition/meal-plan.json` to drop the corresponding section so it stays consistent with the DB (this file is documentation only — not loaded by any Java code).

## Notes
- No Java source or test files needed changes: the only integration test touching this schema (`MealPlanRepositoryTest`) runs with `spring.flyway.enabled=false`, so it doesn't depend on seed migration data or its section count.
- Verified via `tdd-test-guardian` that no existing tests were modified.

## Test plan
- [x] `./gradlew :nutrition:test` — 362 tests, all pass except the 3 Testcontainers-based repository tests which fail in this sandbox due to no local Docker daemon (pre-existing environment limitation, unrelated to this change)
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — passes with zero warnings
- [ ] Reviewer: confirm migration applies cleanly against a real Postgres instance with Testcontainers/Docker available

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)