### PR TITLE
feat(nutrition): Claude canteen meal photo estimator

### DIFF
--- a/nutrition/src/main/java/com/marvin/nutrition/controller/MealEstimateController.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/controller/MealEstimateController.java
@@ -3,22 +3,29 @@ package com.marvin.nutrition.controller;
 import com.marvin.nutrition.dto.MealEstimateDTO;
 import com.marvin.nutrition.dto.MealEstimateRequest;
 import com.marvin.nutrition.service.MealEstimator;
+import com.marvin.nutrition.service.PhotoMealEstimator;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 /**
- * REST controller that estimates macros for a described canteen meal via Claude.
+ * REST controller that estimates macros for a described or photographed canteen meal via Claude.
  * The result is transient — nothing is persisted by this endpoint.
  */
 @RestController
@@ -26,15 +33,21 @@ import reactor.core.publisher.Mono;
 @Tag(name = "Nutrition", description = "Nutrition profile, weight tracking and target calculation")
 public class MealEstimateController {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MealEstimateController.class);
+    private static final int MAX_MEAL_PHOTO_SIZE_BYTES = 10 * 1024 * 1024;
+
     private final MealEstimator mealEstimator;
+    private final PhotoMealEstimator photoMealEstimator;
 
     /**
      * Creates a new MealEstimateController.
      *
-     * @param mealEstimator the service that estimates meal macros via Claude
+     * @param mealEstimator      the service that estimates meal macros from a text description via Claude
+     * @param photoMealEstimator the service that estimates meal macros from a photo via Claude Vision
      */
-    public MealEstimateController(MealEstimator mealEstimator) {
+    public MealEstimateController(MealEstimator mealEstimator, PhotoMealEstimator photoMealEstimator) {
         this.mealEstimator = mealEstimator;
+        this.photoMealEstimator = photoMealEstimator;
     }
 
     /**
@@ -62,5 +75,57 @@ public class MealEstimateController {
     public Mono<ResponseEntity<MealEstimateDTO>> estimate(@Valid @RequestBody MealEstimateRequest request) {
         return mealEstimator.estimate(request.description(), request.portionHint())
                 .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Accepts a meal photo, calls Claude Vision to estimate macros, and returns the estimate.
+     * Nothing is persisted — the returned estimate is only held in memory.
+     *
+     * @param filePart    the multipart file containing the meal photo (JPEG or PNG)
+     * @param portionHint optional hint about the portion size; may be {@code null}
+     * @return a Mono with 200 OK and the parsed macro estimate DTO
+     */
+    @PostMapping(path = "/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Estimate macros for a photographed meal",
+            description = "Sends the uploaded meal photo to Claude Vision and returns a transient macro estimate. "
+                    + "Provide an optional portion hint to improve accuracy. The estimate is never persisted.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Macro estimate successfully returned",
+                        content = @Content(schema = @Schema(implementation = MealEstimateDTO.class))
+                ),
+                @ApiResponse(responseCode = "413", description = "Uploaded file exceeds the maximum allowed size"),
+                @ApiResponse(responseCode = "422", description = "Estimation failed — Claude could not produce a usable result")
+            }
+    )
+    public Mono<ResponseEntity<MealEstimateDTO>> estimateFromPhoto(
+            @RequestPart("file")
+            @Parameter(description = "Meal photo file (JPEG or PNG)") FilePart filePart,
+            @RequestPart(value = "portionHint", required = false)
+            @Parameter(description = "Optional hint about the portion size") String portionHint) {
+        LOGGER.info("Received estimate/photo request: filename={}", filePart.filename());
+        return extractBytes(filePart)
+                .flatMap(bytes -> photoMealEstimator.estimateFromPhoto(bytes, portionHint))
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Reads all bytes from the given FilePart reactively.
+     *
+     * @param filePart the file part to read
+     * @return a Mono emitting the complete file bytes
+     */
+    private Mono<byte[]> extractBytes(FilePart filePart) {
+        return DataBufferUtils.join(filePart.content(), MAX_MEAL_PHOTO_SIZE_BYTES)
+                .map(dataBuffer -> {
+                    final byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(bytes);
+                    DataBufferUtils.release(dataBuffer);
+                    return bytes;
+                })
+                .doOnError(e -> LOGGER.error("Failed to read uploaded meal photo", e));
     }
 }

--- a/nutrition/src/main/java/com/marvin/nutrition/service/PhotoMealEstimator.java
+++ b/nutrition/src/main/java/com/marvin/nutrition/service/PhotoMealEstimator.java
@@ -1,0 +1,165 @@
+package com.marvin.nutrition.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.nutrition.dto.MealEstimateDTO;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Estimates nutritional macros for a photographed canteen meal by calling the Anthropic Claude
+ * Vision API. Returns a transient {@link MealEstimateDTO} — nothing is persisted.
+ */
+@Service
+public class PhotoMealEstimator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhotoMealEstimator.class);
+    private static final String MODEL = "claude-sonnet-4-6";
+    private static final int MAX_TOKENS = 1024;
+    private static final String PHOTO_ESTIMATE_PROMPT = """
+            You are a nutritionist estimating macros for a canteen meal shown in a photo.
+            Identify the food shown in the image and estimate its nutritional values.
+            Return ONLY a strict JSON object with no markdown, no explanation, and no code block — just the raw JSON.
+            Use exactly these keys: kcal, proteinG, carbsG, fatG, assumptions.
+            The "assumptions" field must contain a concise English sentence describing your assumptions
+            (e.g. what food was identified and the portion size used).
+            Numbers must be plain decimals without units.""";
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a new PhotoMealEstimator.
+     *
+     * @param webClientBuilder the Spring WebClient builder
+     * @param apiKey           the Anthropic API key (from {@code nutrition.claude.api-key})
+     * @param objectMapper     Jackson mapper used to parse Claude's JSON response
+     */
+    public PhotoMealEstimator(
+            WebClient.Builder webClientBuilder,
+            @Value("${nutrition.claude.api-key}") String apiKey,
+            ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", apiKey)
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Sends the meal photo (and optional portion hint) to Claude and returns a parsed
+     * {@link MealEstimateDTO}.
+     * Emits {@link MealEstimateException} if Claude's response cannot be parsed as JSON,
+     * if the response contains no content, or if the result lacks a usable {@code kcal} value.
+     *
+     * @param imageBytes  raw bytes of the meal photo (JPEG or PNG)
+     * @param portionHint optional hint about the portion size; may be {@code null}
+     * @return a Mono emitting the parsed macro estimate, or an error if estimation fails
+     */
+    public Mono<MealEstimateDTO> estimateFromPhoto(byte[] imageBytes, String portionHint) {
+        LOGGER.info("Sending meal photo ({} bytes) to Claude Vision estimator API", imageBytes.length);
+        final String base64 = Base64.getEncoder().encodeToString(imageBytes);
+        final String mediaType = detectMediaType(imageBytes);
+        final Map<String, Object> request = buildRequest(base64, mediaType, portionHint);
+
+        return webClient.post()
+                .uri("/v1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .onErrorMap(WebClientResponseException.class,
+                        e -> new MealEstimateException("Claude API request failed: " + e.getStatusCode(), e))
+                .flatMap(this::parseClaudeResponse)
+                .doOnError(e -> LOGGER.error("Photo meal estimation failed", e));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<MealEstimateDTO> parseClaudeResponse(Map<?, ?> response) {
+        final List<?> content = (List<?>) response.get("content");
+        if (content == null || content.isEmpty()) {
+            return Mono.error(new MealEstimateException("Claude returned an empty content list"));
+        }
+        final Optional<String> text = findFirstTextBlock(content);
+        if (text.isEmpty()) {
+            return Mono.error(new MealEstimateException("Claude returned no text content block"));
+        }
+        return parseEstimate(text.get());
+    }
+
+    /**
+     * Parses the given text as a {@link MealEstimateDTO} and validates that a usable kcal value is present.
+     *
+     * @param text the trimmed text content extracted from Claude's response
+     * @return a Mono emitting the parsed estimate, or an error if parsing or validation fails
+     */
+    private Mono<MealEstimateDTO> parseEstimate(String text) {
+        try {
+            final MealEstimateDTO estimate = objectMapper.readValue(text, MealEstimateDTO.class);
+            if (estimate.kcal() == null) {
+                return Mono.error(new MealEstimateException("Claude returned no usable macro estimate"));
+            }
+            LOGGER.info("Parsed photo meal estimate: kcal={}", estimate.kcal());
+            return Mono.just(estimate);
+        } catch (Exception e) {
+            LOGGER.warn("Claude returned non-JSON text: {}", text);
+            return Mono.error(new MealEstimateException("Claude returned a non-JSON response: " + text, e));
+        }
+    }
+
+    private Map<String, Object> buildRequest(String base64, String mediaType, String portionHint) {
+        final StringBuilder promptText = new StringBuilder(PHOTO_ESTIMATE_PROMPT);
+        if (portionHint != null && !portionHint.isBlank()) {
+            promptText.append("\nPortion: ").append(portionHint);
+        }
+        final Map<String, Object> imageSource = Map.of(
+                "type", "base64",
+                "media_type", mediaType,
+                "data", base64);
+        final Map<String, Object> imageBlock = Map.of("type", "image", "source", imageSource);
+        final Map<String, Object> textBlock = Map.of("type", "text", "text", promptText.toString());
+        final Map<String, Object> message = Map.of("role", "user", "content", List.of(imageBlock, textBlock));
+        return Map.of("model", MODEL, "max_tokens", MAX_TOKENS, "messages", List.of(message));
+    }
+
+    /**
+     * Finds the first content block whose {@code type} is {@code "text"} and returns its trimmed {@code text}.
+     * Blocks that are not maps, or whose type is not {@code "text"}, are skipped.
+     *
+     * @param content the list of content blocks returned by Claude
+     * @return the trimmed text of the first text block, or empty if none was found
+     */
+    private Optional<String> findFirstTextBlock(List<?> content) {
+        for (final Object blockObj : content) {
+            if (!(blockObj instanceof Map<?, ?> block)) {
+                continue;
+            }
+            if ("text".equals(String.valueOf(block.get("type")))) {
+                final Object textObj = block.get("text");
+                final String text = textObj != null ? textObj.toString().trim() : "";
+                return Optional.of(text);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String detectMediaType(byte[] bytes) {
+        if (bytes.length >= 4 && bytes[0] == (byte) 0x89 && bytes[1] == 'P' && bytes[2] == 'N' && bytes[3] == 'G') {
+            return "image/png";
+        }
+        if (bytes.length >= 2 && bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8) {
+            return "image/jpeg";
+        }
+        return "image/jpeg";
+    }
+}

--- a/nutrition/src/test/java/com/marvin/nutrition/controller/MealEstimateControllerTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/controller/MealEstimateControllerTest.java
@@ -12,6 +12,7 @@ import com.marvin.nutrition.dto.MealEstimateDTO;
 import com.marvin.nutrition.dto.MealEstimateRequest;
 import com.marvin.nutrition.service.MealEstimateException;
 import com.marvin.nutrition.service.MealEstimator;
+import com.marvin.nutrition.service.PhotoMealEstimator;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +21,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferLimitException;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -31,6 +37,12 @@ class MealEstimateControllerTest {
 
     @Mock
     private MealEstimator mealEstimator;
+
+    @Mock
+    private PhotoMealEstimator photoMealEstimator;
+
+    @Mock
+    private FilePart filePart;
 
     @InjectMocks
     private MealEstimateController mealEstimateController;
@@ -107,5 +119,87 @@ class MealEstimateControllerTest {
                 .verify();
 
         verify(mealEstimator).estimate(any(String.class), isNull());
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto returns 200 with MealEstimateDTO when photo estimator succeeds without portionHint")
+    void estimateFromPhoto_Success_NoPortionHint_Returns200WithDTO() {
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+        when(photoMealEstimator.estimateFromPhoto(any(byte[].class), isNull()))
+                .thenReturn(Mono.just(estimateDTO));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result =
+                mealEstimateController.estimateFromPhoto(filePart, null);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(0, new BigDecimal("650.00").compareTo(response.getBody().kcal()));
+                })
+                .verifyComplete();
+
+        verify(photoMealEstimator).estimateFromPhoto(any(byte[].class), isNull());
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto returns 200 with MealEstimateDTO when photo estimator succeeds with portionHint")
+    void estimateFromPhoto_Success_WithPortionHint_Returns200WithDTO() {
+        final byte[] imageBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+        when(photoMealEstimator.estimateFromPhoto(any(byte[].class), eq("one plate")))
+                .thenReturn(Mono.just(estimateDTO));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result =
+                mealEstimateController.estimateFromPhoto(filePart, "one plate");
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                })
+                .verifyComplete();
+
+        verify(photoMealEstimator).estimateFromPhoto(any(byte[].class), eq("one plate"));
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto propagates MealEstimateException when photo estimator fails")
+    void estimateFromPhoto_EstimatorFails_PropagatesMealEstimateException() {
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(imageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+        when(photoMealEstimator.estimateFromPhoto(any(byte[].class), isNull()))
+                .thenReturn(Mono.error(new MealEstimateException("Claude returned a non-JSON response")));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result =
+                mealEstimateController.estimateFromPhoto(filePart, null);
+
+        StepVerifier.create(result)
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto propagates DataBufferLimitException when upload exceeds the maximum allowed size")
+    void estimateFromPhoto_UploadExceedsMaxSize_PropagatesError() {
+        // 10 MB cap configured in MealEstimateController.MAX_MEAL_PHOTO_SIZE_BYTES; one byte over the cap.
+        final byte[] oversizedImageBytes = new byte[10 * 1024 * 1024 + 1];
+        final DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap(oversizedImageBytes);
+
+        when(filePart.content()).thenReturn(Flux.just(dataBuffer));
+
+        final Mono<ResponseEntity<MealEstimateDTO>> result =
+                mealEstimateController.estimateFromPhoto(filePart, null);
+
+        StepVerifier.create(result)
+                .expectError(DataBufferLimitException.class)
+                .verify();
     }
 }

--- a/nutrition/src/test/java/com/marvin/nutrition/service/PhotoMealEstimatorTest.java
+++ b/nutrition/src/test/java/com/marvin/nutrition/service/PhotoMealEstimatorTest.java
@@ -1,0 +1,219 @@
+package com.marvin.nutrition.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link PhotoMealEstimator} covering success and error paths. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PhotoMealEstimatorTest")
+class PhotoMealEstimatorTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private PhotoMealEstimator photoMealEstimator;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Sets up the WebClient mock chain and creates the service under test. */
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClientBuilder.baseUrl(any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.defaultHeader(any(String.class), any(String.class))).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(webClient);
+
+        photoMealEstimator = new PhotoMealEstimator(webClientBuilder, "test-api-key", objectMapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubWebClientChain(Mono<?> responseMono) {
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(any(String.class))).thenReturn(requestBodySpec);
+        when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
+        doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any());
+        doReturn(responseSpec).when(requestHeadersSpec).retrieve();
+        doReturn(responseMono).when(responseSpec).bodyToMono(any(Class.class));
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto returns parsed MealEstimateDTO for valid JSON response without portionHint")
+    void estimateFromPhoto_ValidJson_NoPortion_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 650.0,
+                    "proteinG": 45.0,
+                    "carbsG": 70.0,
+                    "fatG": 18.0,
+                    "assumptions": "Estimated for a standard canteen portion of 400 g"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "text", "text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(pngBytes, null))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("650.0").compareTo(dto.kcal()));
+                    assertEquals(0, new BigDecimal("45.0").compareTo(dto.proteinG()));
+                    assertEquals(0, new BigDecimal("70.0").compareTo(dto.carbsG()));
+                    assertEquals(0, new BigDecimal("18.0").compareTo(dto.fatG()));
+                    assertEquals("Estimated for a standard canteen portion of 400 g", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto returns parsed MealEstimateDTO for valid JSON response with portionHint")
+    void estimateFromPhoto_ValidJson_WithPortionHint_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 450.0,
+                    "proteinG": 30.0,
+                    "carbsG": 50.0,
+                    "fatG": 12.0,
+                    "assumptions": "Used the provided portion hint of one small plate"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "text", "text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] jpegBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(jpegBytes, "one small plate"))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("450.0").compareTo(dto.kcal()));
+                    assertEquals(0, new BigDecimal("30.0").compareTo(dto.proteinG()));
+                    assertEquals("Used the provided portion hint of one small plate", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto emits MealEstimateException when Claude returns non-JSON garbage text")
+    void estimateFromPhoto_GarbageText_EmitsMealEstimateException() {
+        final String garbageText = "Sorry, I cannot estimate the meal from that image.";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "text", "text", garbageText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(imageBytes, null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto emits MealEstimateException when Claude response has empty content list")
+    void estimateFromPhoto_EmptyContent_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of("content", List.of());
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0xFF, (byte) 0xD8};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(imageBytes, null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto emits MealEstimateException when Claude API returns HTTP 401")
+    void estimateFromPhoto_ApiReturns401_EmitsMealEstimateException() {
+        final WebClientResponseException unauthorizedException = WebClientResponseException.create(
+                401, "Unauthorized", HttpHeaders.EMPTY, new byte[0], null);
+        stubWebClientChain(Mono.error(unauthorizedException));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(imageBytes, null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto emits MealEstimateException when Claude returns valid JSON with null kcal")
+    void estimateFromPhoto_EmptyJsonObject_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "text", "text", "{}"))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(imageBytes, null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto returns parsed MealEstimateDTO when a non-text block precedes the text block")
+    void estimateFromPhoto_LeadingNonTextBlock_ReturnsParsedDTO() {
+        final String jsonText = """
+                {
+                    "kcal": 500.0,
+                    "proteinG": 35.0,
+                    "carbsG": 55.0,
+                    "fatG": 15.0,
+                    "assumptions": "Estimated for a standard portion"
+                }""";
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(
+                        Map.of("type", "thinking", "thinking", "Let me look at this photo..."),
+                        Map.of("type", "text", "text", jsonText))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(pngBytes, null))
+                .assertNext(dto -> {
+                    assertEquals(0, new BigDecimal("500.0").compareTo(dto.kcal()));
+                    assertEquals("Estimated for a standard portion", dto.assumptions());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("estimateFromPhoto emits MealEstimateException when no content block has type text")
+    void estimateFromPhoto_NoTextBlock_EmitsMealEstimateException() {
+        final Map<String, Object> claudeResponse = Map.of(
+                "content", List.of(Map.of("type", "thinking", "thinking", "Hmm..."))
+        );
+        stubWebClientChain(Mono.just(claudeResponse));
+
+        final byte[] imageBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+        StepVerifier.create(photoMealEstimator.estimateFromPhoto(imageBytes, null))
+                .expectError(MealEstimateException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /nutrition/estimate/photo` to estimate meal macros from a photo, reusing the Claude Vision pattern from `LabelReader`/`FoodController.scanLabel`.
- New `PhotoMealEstimator` service builds a Claude Vision request (with optional `portionHint`) and reuses the existing `MealEstimateDTO`/`MealEstimateException` (mapped to 422).
- Multipart upload capped at 10 MB (mirrors `FoodController`, 413 on oversize via existing global handler).

Closes #229

## Test plan
- [x] `PhotoMealEstimatorTest` — success with/without hint, non-JSON text, empty content, HTTP error, missing kcal, no-text-block
- [x] `MealEstimateControllerTest` — success with/without hint, estimator failure, oversize upload
- [x] `./gradlew :nutrition:checkstyleMain :nutrition:checkstyleTest` — BUILD SUCCESSFUL, zero warnings
- [x] tdd-test-guardian confirmed all test-file changes are purely additive (no existing tests modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)