### PR TITLE
feat(grocery): add price-history endpoints for products

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ReceiptController.java
@@ -1,10 +1,13 @@
 package com.marvin.grocery.controller;
 
 import com.marvin.grocery.dto.AddReceiptItemRequest;
+import com.marvin.grocery.dto.PriceHistoryPointDTO;
+import com.marvin.grocery.dto.ProductPriceSummaryDTO;
 import com.marvin.grocery.dto.ReceiptDTO;
 import com.marvin.grocery.dto.ReceiptItemDTO;
 import com.marvin.grocery.dto.UpdateReceiptItemRequest;
 import com.marvin.grocery.dto.UpdateSupermarketRequest;
+import com.marvin.grocery.service.PriceTrendService;
 import com.marvin.grocery.service.ReceiptService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
@@ -51,14 +55,17 @@ public class ReceiptController {
     private static final String RECEIPTS_LOCATION_PREFIX = "/receipts/";
 
     private final ReceiptService receiptService;
+    private final PriceTrendService priceTrendService;
 
     /**
-     * Creates a new ReceiptController with the required service.
+     * Creates a new ReceiptController with the required services.
      *
-     * @param receiptService the service handling receipt processing and retrieval
+     * @param receiptService    the service handling receipt processing and retrieval
+     * @param priceTrendService the service handling price-history and price-trend aggregation
      */
-    public ReceiptController(ReceiptService receiptService) {
+    public ReceiptController(ReceiptService receiptService, PriceTrendService priceTrendService) {
         this.receiptService = receiptService;
+        this.priceTrendService = priceTrendService;
     }
 
     /**
@@ -247,6 +254,52 @@ public class ReceiptController {
         return receiptService.deleteReceipt(id)
                 .thenReturn(noContent)
                 .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+
+    /**
+     * Lists price-trend summaries for every distinct product recorded across all receipts.
+     *
+     * @return a Flux emitting one price summary per distinct product
+     */
+    @GetMapping("/products")
+    @Operation(
+            summary = "List product price trends",
+            description = "Returns aggregated first/latest price, percent change, and purchase history for every "
+                    + "distinct product, matched by normalized (case-insensitive, trimmed) name.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Product price summaries returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProductPriceSummaryDTO.class)))
+                )
+            }
+    )
+    public Flux<ProductPriceSummaryDTO> listProductSummaries() {
+        return priceTrendService.findAllProductSummaries();
+    }
+
+    /**
+     * Returns the chronologically ordered price history for a single product.
+     *
+     * @param name the product name; matched case-insensitively and whitespace-trimmed
+     * @return a Mono emitting the ordered list of price-history points, empty if the product was never purchased
+     */
+    @GetMapping("/products/history")
+    @Operation(
+            summary = "Get price history for a product",
+            description = "Returns the chronologically ordered price history for the given product name, "
+                    + "matched by normalized (case-insensitive, trimmed) name.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Price history returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = PriceHistoryPointDTO.class)))
+                )
+            }
+    )
+    public Mono<List<PriceHistoryPointDTO>> getProductHistory(
+            @RequestParam @Parameter(description = "Product name (case-insensitive, whitespace-trimmed)") String name) {
+        return priceTrendService.findHistory(name);
     }
 
     /**

--- a/grocery/src/main/java/com/marvin/grocery/dto/PriceHistoryPointDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/PriceHistoryPointDTO.java
@@ -1,0 +1,35 @@
+package com.marvin.grocery.dto;
+
+import com.marvin.grocery.entity.Supermarket;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a single historical price data point for a product.
+ *
+ * @param date        effective purchase date (the receipt's receiptDate, falling back to its creationDate)
+ * @param singlePrice price per unit at this purchase
+ * @param quantity    number of units purchased
+ * @param supermarket supermarket where this purchase was made; null if not set
+ * @param receiptId   id of the receipt this purchase belongs to
+ */
+@Schema(description = "A single historical price data point for a product")
+public record PriceHistoryPointDTO(
+        @Schema(description = "Effective purchase date (receiptDate, falling back to creationDate)")
+        LocalDate date,
+
+        @Schema(description = "Price per unit at this purchase", example = "1.29")
+        BigDecimal singlePrice,
+
+        @Schema(description = "Number of units purchased", example = "2")
+        int quantity,
+
+        @Schema(description = "Supermarket where this purchase was made; null if not set")
+        Supermarket supermarket,
+
+        @Schema(description = "Id of the receipt this purchase belongs to")
+        UUID receiptId
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/dto/ProductPriceSummaryDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ProductPriceSummaryDTO.java
@@ -1,0 +1,52 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Data Transfer Object representing the aggregated price trend for a single product across all receipts.
+ * Products are matched across receipts by exact name match, case-insensitive and whitespace-trimmed.
+ *
+ * @param name              display name of the product, taken from the most recent purchase
+ * @param normalizedName    lower-cased, trimmed name used to group purchases of the same product
+ * @param firstPrice        single price at the chronologically first recorded purchase
+ * @param firstPurchaseDate date of the chronologically first recorded purchase
+ * @param latestPrice       single price at the chronologically latest recorded purchase
+ * @param latestPurchaseDate date of the chronologically latest recorded purchase
+ * @param percentChange     percentage change from firstPrice to latestPrice; null if firstPrice is zero
+ * @param purchaseCount     number of recorded purchases of this product
+ * @param sparklinePrices   chronologically ordered single prices, for sparkline rendering
+ */
+@Schema(description = "Aggregated price trend summary for a product across all receipts")
+public record ProductPriceSummaryDTO(
+        @Schema(description = "Display name of the product, taken from the most recent purchase", example = "Vollmilch 3,5%")
+        String name,
+
+        @Schema(description = "Normalized (lower-cased, trimmed) name used to group purchases of the same product",
+                example = "vollmilch 3,5%")
+        String normalizedName,
+
+        @Schema(description = "Single price at the chronologically first recorded purchase", example = "1.09")
+        BigDecimal firstPrice,
+
+        @Schema(description = "Date of the chronologically first recorded purchase")
+        LocalDate firstPurchaseDate,
+
+        @Schema(description = "Single price at the chronologically latest recorded purchase", example = "1.29")
+        BigDecimal latestPrice,
+
+        @Schema(description = "Date of the chronologically latest recorded purchase")
+        LocalDate latestPurchaseDate,
+
+        @Schema(description = "Percentage change from firstPrice to latestPrice; null if firstPrice is zero", example = "18.35")
+        BigDecimal percentChange,
+
+        @Schema(description = "Number of recorded purchases of this product", example = "5")
+        int purchaseCount,
+
+        @Schema(description = "Chronologically ordered single prices, for sparkline rendering")
+        List<BigDecimal> sparklinePrices
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /** Spring Data JPA repository for {@link ReceiptItemEntity}. */
@@ -27,4 +29,22 @@ public interface ReceiptItemRepository extends JpaRepository<ReceiptItemEntity, 
      * @return an Optional containing the item if it exists and belongs to the receipt
      */
     Optional<ReceiptItemEntity> findByIdAndReceiptId(Long id, UUID receiptId);
+
+    /**
+     * Returns all receipt items with their parent receipt eagerly fetched, for price-trend aggregation.
+     *
+     * @return list of all receipt items with their receipt initialized
+     */
+    @Query("SELECT i FROM ReceiptItemEntity i JOIN FETCH i.receipt")
+    List<ReceiptItemEntity> findAllWithReceipt();
+
+    /**
+     * Returns all receipt items whose name matches the given normalized (lower-cased, trimmed) name,
+     * with their parent receipt eagerly fetched.
+     *
+     * @param normalizedName the lower-cased, trimmed product name to match
+     * @return list of matching receipt items with their receipt initialized
+     */
+    @Query("SELECT i FROM ReceiptItemEntity i JOIN FETCH i.receipt r WHERE LOWER(TRIM(i.name)) = :normalizedName")
+    List<ReceiptItemEntity> findAllByNormalizedNameWithReceipt(@Param("normalizedName") String normalizedName);
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
@@ -1,0 +1,127 @@
+package com.marvin.grocery.service;
+
+import com.marvin.grocery.dto.PriceHistoryPointDTO;
+import com.marvin.grocery.dto.ProductPriceSummaryDTO;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Computes read-only price-trend aggregations over existing receipt and receipt item data.
+ * Products are matched across receipts by exact name match, case-insensitive and whitespace-trimmed.
+ * Aggregation happens in memory rather than via SQL {@code GROUP BY}, since chronological first/latest
+ * price cannot be expressed safely with {@code MIN}/{@code MAX} alone.
+ */
+@Service
+public class PriceTrendService {
+
+    private static final Comparator<ReceiptItemEntity> CHRONOLOGICAL_ORDER =
+            Comparator.comparing(PriceTrendService::effectiveDate).thenComparing(ReceiptItemEntity::getId);
+    private static final int PERCENT_CHANGE_SCALE = 2;
+
+    private final ReceiptItemRepository receiptItemRepository;
+
+    /**
+     * Creates a new PriceTrendService with the required repository.
+     *
+     * @param receiptItemRepository the JPA repository for receipt items
+     */
+    public PriceTrendService(ReceiptItemRepository receiptItemRepository) {
+        this.receiptItemRepository = receiptItemRepository;
+    }
+
+    /**
+     * Returns a price trend summary for every distinct product, grouped by normalized name.
+     *
+     * @return a Flux emitting one summary per distinct product, ordered by display name
+     */
+    public Flux<ProductPriceSummaryDTO> findAllProductSummaries() {
+        return Mono.fromCallable(this::computeSummaries)
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMapIterable(summaries -> summaries);
+    }
+
+    /**
+     * Returns the chronologically ordered purchase history for a single product.
+     *
+     * @param name the product name; matched case-insensitively and whitespace-trimmed
+     * @return a Mono emitting the ordered list of history points, empty if the product was never purchased
+     */
+    public Mono<List<PriceHistoryPointDTO>> findHistory(String name) {
+        final String normalizedName = normalize(name);
+        return Mono.fromCallable(() -> receiptItemRepository.findAllByNormalizedNameWithReceipt(normalizedName).stream()
+                        .sorted(CHRONOLOGICAL_ORDER)
+                        .map(PriceTrendService::toHistoryPoint)
+                        .toList())
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private List<ProductPriceSummaryDTO> computeSummaries() {
+        final Map<String, List<ReceiptItemEntity>> itemsByNormalizedName = receiptItemRepository.findAllWithReceipt()
+                .stream()
+                .collect(Collectors.groupingBy(item -> normalize(item.getName())));
+        return itemsByNormalizedName.values().stream()
+                .map(PriceTrendService::toSummary)
+                .sorted(Comparator.comparing(ProductPriceSummaryDTO::name, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    private static ProductPriceSummaryDTO toSummary(List<ReceiptItemEntity> productItems) {
+        final List<ReceiptItemEntity> chronological = productItems.stream().sorted(CHRONOLOGICAL_ORDER).toList();
+        final ReceiptItemEntity first = chronological.get(0);
+        final ReceiptItemEntity latest = chronological.get(chronological.size() - 1);
+        final List<BigDecimal> sparklinePrices = chronological.stream().map(ReceiptItemEntity::getSinglePrice).toList();
+        return new ProductPriceSummaryDTO(
+                latest.getName().trim(),
+                normalize(latest.getName()),
+                first.getSinglePrice(),
+                effectiveDate(first),
+                latest.getSinglePrice(),
+                effectiveDate(latest),
+                computePercentChange(first.getSinglePrice(), latest.getSinglePrice()),
+                chronological.size(),
+                sparklinePrices
+        );
+    }
+
+    private static PriceHistoryPointDTO toHistoryPoint(ReceiptItemEntity item) {
+        return new PriceHistoryPointDTO(
+                effectiveDate(item),
+                item.getSinglePrice(),
+                item.getQuantity(),
+                item.getReceipt().getSupermarket(),
+                item.getReceipt().getId()
+        );
+    }
+
+    private static BigDecimal computePercentChange(BigDecimal firstPrice, BigDecimal latestPrice) {
+        if (firstPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return null;
+        }
+        return latestPrice.subtract(firstPrice)
+                .divide(firstPrice, PERCENT_CHANGE_SCALE + 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(PERCENT_CHANGE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private static LocalDate effectiveDate(ReceiptItemEntity item) {
+        final ReceiptEntity receipt = item.getReceipt();
+        return receipt.getReceiptDate() != null ? receipt.getReceiptDate() : receipt.getCreationDate().toLocalDate();
+    }
+
+    private static String normalize(String name) {
+        return name.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerPriceHistoryTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerPriceHistoryTest.java
@@ -1,0 +1,139 @@
+package com.marvin.grocery.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marvin.common.configuration.jackson.JacksonMapper;
+import com.marvin.grocery.dto.PriceHistoryPointDTO;
+import com.marvin.grocery.dto.ProductPriceSummaryDTO;
+import com.marvin.grocery.entity.Supermarket;
+import com.marvin.grocery.service.PriceTrendService;
+import com.marvin.grocery.service.ReceiptService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReceiptController price-history endpoint Tests")
+class ReceiptControllerPriceHistoryTest {
+
+    @Mock
+    private ReceiptService receiptService;
+
+    @Mock
+    private PriceTrendService priceTrendService;
+
+    @InjectMocks
+    private ReceiptController receiptController;
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp() {
+        final ObjectMapper objectMapper = new JacksonMapper().objectMapper();
+        webTestClient = WebTestClient.bindToController(receiptController)
+                .httpMessageCodecs(configurer -> {
+                    configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(objectMapper));
+                    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
+                })
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /receipts/products returns product price summaries")
+    void listProductSummaries_ReturnsSummaries() {
+        final ProductPriceSummaryDTO summary = new ProductPriceSummaryDTO(
+                "Vollmilch",
+                "vollmilch",
+                new BigDecimal("1.09"),
+                LocalDate.of(2026, 1, 1),
+                new BigDecimal("1.29"),
+                LocalDate.of(2026, 3, 1),
+                new BigDecimal("18.35"),
+                2,
+                List.of(new BigDecimal("1.09"), new BigDecimal("1.29"))
+        );
+        when(priceTrendService.findAllProductSummaries()).thenReturn(Flux.just(summary));
+
+        webTestClient.get()
+                .uri("/receipts/products")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].name").isEqualTo("Vollmilch")
+                .jsonPath("$[0].normalizedName").isEqualTo("vollmilch")
+                .jsonPath("$[0].firstPrice").isEqualTo(1.09)
+                .jsonPath("$[0].latestPrice").isEqualTo(1.29)
+                .jsonPath("$[0].percentChange").isEqualTo(18.35)
+                .jsonPath("$[0].purchaseCount").isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /receipts/products returns an empty array when there are no products")
+    void listProductSummaries_NoProducts_ReturnsEmptyArray() {
+        when(priceTrendService.findAllProductSummaries()).thenReturn(Flux.empty());
+
+        webTestClient.get()
+                .uri("/receipts/products")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").isArray()
+                .jsonPath("$.length()").isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("GET /receipts/products/history returns the price history for the given product name")
+    void getProductHistory_ReturnsHistory() {
+        final UUID receiptId = UUID.randomUUID();
+        final PriceHistoryPointDTO point = new PriceHistoryPointDTO(
+                LocalDate.of(2026, 1, 1), new BigDecimal("1.09"), 1, Supermarket.LIDL, receiptId);
+        when(priceTrendService.findHistory(eq("Vollmilch"))).thenReturn(Mono.just(List.of(point)));
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/receipts/products/history")
+                        .queryParam("name", "Vollmilch")
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].date").isEqualTo("2026-01-01")
+                .jsonPath("$[0].singlePrice").isEqualTo(1.09)
+                .jsonPath("$[0].quantity").isEqualTo(1)
+                .jsonPath("$[0].supermarket").isEqualTo("LIDL")
+                .jsonPath("$[0].receiptId").isEqualTo(receiptId.toString());
+    }
+
+    @Test
+    @DisplayName("GET /receipts/products/history handles free-text names with spaces and slashes")
+    void getProductHistory_NameWithSpacesAndSlashes_IsPassedThrough() {
+        final String freeTextName = "Käse / Gouda 45%";
+        when(priceTrendService.findHistory(eq(freeTextName))).thenReturn(Mono.just(List.of()));
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/receipts/products/history")
+                        .queryParam("name", freeTextName)
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").isArray()
+                .jsonPath("$.length()").isEqualTo(0);
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/PriceTrendServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/PriceTrendServiceTest.java
@@ -1,0 +1,203 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.dto.PriceHistoryPointDTO;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.entity.Supermarket;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PriceTrendService Tests")
+class PriceTrendServiceTest {
+
+    @Mock
+    private ReceiptItemRepository receiptItemRepository;
+
+    @InjectMocks
+    private PriceTrendService priceTrendService;
+
+    private static ReceiptEntity buildReceipt(LocalDate receiptDate, LocalDateTime creationDate, Supermarket supermarket) {
+        final ReceiptEntity receipt = new ReceiptEntity();
+        receipt.setId(UUID.randomUUID());
+        receipt.setReceiptDate(receiptDate);
+        receipt.setCreationDate(creationDate);
+        receipt.setSupermarket(supermarket);
+        return receipt;
+    }
+
+    private static ReceiptItemEntity buildItem(Long id, ReceiptEntity receipt, String name, BigDecimal singlePrice, int quantity) {
+        final ReceiptItemEntity item = new ReceiptItemEntity();
+        item.setId(id);
+        item.setReceipt(receipt);
+        item.setName(name);
+        item.setSinglePrice(singlePrice);
+        item.setQuantity(quantity);
+        item.setPrice(singlePrice.multiply(BigDecimal.valueOf(quantity)));
+        return item;
+    }
+
+    @Test
+    @DisplayName("Should return empty Flux when there are no receipt items")
+    void findAllProductSummaries_EmptyRepository_ReturnsEmptyFlux() {
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of());
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should merge purchases whose names differ only by case and whitespace")
+    void findAllProductSummaries_NameNormalization_MergesCaseAndWhitespaceVariants() {
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.REWE);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, "Milch", new BigDecimal("1.00"), 1);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, " milch ", new BigDecimal("1.20"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(firstItem, secondItem));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> {
+                    assertEquals("milch", summary.normalizedName());
+                    assertEquals(2, summary.purchaseCount());
+                    assertEquals(new BigDecimal("1.00"), summary.firstPrice());
+                    assertEquals(new BigDecimal("1.20"), summary.latestPrice());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should fall back to creationDate when receiptDate is null")
+    void findAllProductSummaries_NullReceiptDate_FallsBackToCreationDate() {
+        final LocalDateTime creationDate = LocalDateTime.of(2026, 3, 5, 10, 30);
+        final ReceiptEntity receipt = buildReceipt(null, creationDate, Supermarket.EDEKA);
+        final ReceiptItemEntity item = buildItem(1L, receipt, "Butter", new BigDecimal("1.79"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(item));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> {
+                    assertEquals(LocalDate.of(2026, 3, 5), summary.firstPurchaseDate());
+                    assertEquals(LocalDate.of(2026, 3, 5), summary.latestPurchaseDate());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should compute percentChange from first to latest price")
+    void findAllProductSummaries_ComputesPercentChange() {
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.LIDL);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, "Kaffee", new BigDecimal("1.00"), 1);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, "Kaffee", new BigDecimal("1.50"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(firstItem, secondItem));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> assertEquals(new BigDecimal("50.00"), summary.percentChange()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return null percentChange when the first price is zero")
+    void findAllProductSummaries_ZeroFirstPrice_PercentChangeIsNull() {
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.LIDL);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, "Gratisprobe", BigDecimal.ZERO, 1);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, "Gratisprobe", new BigDecimal("0.99"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(firstItem, secondItem));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> assertNull(summary.percentChange()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should compute percentChange when the first price is negative (discount line)")
+    void findAllProductSummaries_NegativeFirstPrice_ComputesPercentChange() {
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.LIDL);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, "Pfandrueckgabe", new BigDecimal("-0.50"), 1);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, "Pfandrueckgabe", new BigDecimal("1.00"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(firstItem, secondItem));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> assertEquals(new BigDecimal("-300.00"), summary.percentChange()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return zero percentChange for a product with a single purchase")
+    void findAllProductSummaries_SinglePurchase_ZeroPercentChange() {
+        final ReceiptEntity receipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptItemEntity item = buildItem(1L, receipt, "Honig", new BigDecimal("3.49"), 1);
+        when(receiptItemRepository.findAllWithReceipt()).thenReturn(List.of(item));
+
+        StepVerifier.create(priceTrendService.findAllProductSummaries())
+                .assertNext(summary -> {
+                    assertEquals(new BigDecimal("0.00"), summary.percentChange());
+                    assertEquals(1, summary.purchaseCount());
+                    assertEquals(List.of(new BigDecimal("3.49")), summary.sparklinePrices());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return chronologically ordered history points for a product")
+    void findHistory_ReturnsChronologicallyOrderedPoints() {
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.REWE);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, "Apfel", new BigDecimal("0.59"), 3);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, "Apfel", new BigDecimal("0.49"), 2);
+        when(receiptItemRepository.findAllByNormalizedNameWithReceipt(eq("apfel")))
+                .thenReturn(List.of(firstItem, secondItem));
+
+        StepVerifier.create(priceTrendService.findHistory("Apfel"))
+                .assertNext(history -> {
+                    assertEquals(2, history.size());
+                    final PriceHistoryPointDTO earliest = history.get(0);
+                    final PriceHistoryPointDTO latest = history.get(1);
+                    assertEquals(LocalDate.of(2026, 1, 1), earliest.date());
+                    assertEquals(new BigDecimal("0.49"), earliest.singlePrice());
+                    assertEquals(2, earliest.quantity());
+                    assertEquals(Supermarket.LIDL, earliest.supermarket());
+                    assertEquals(secondReceipt.getId(), earliest.receiptId());
+                    assertEquals(LocalDate.of(2026, 2, 1), latest.date());
+                    assertEquals(new BigDecimal("0.59"), latest.singlePrice());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should normalize the name before looking up history")
+    void findHistory_NormalizesNameForLookup() {
+        when(receiptItemRepository.findAllByNormalizedNameWithReceipt(eq("milch"))).thenReturn(List.of());
+
+        StepVerifier.create(priceTrendService.findHistory(" Milch "))
+                .assertNext(history -> assertEquals(List.of(), history))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when there is no purchase history for the product")
+    void findHistory_NoMatches_ReturnsEmptyList() {
+        when(receiptItemRepository.findAllByNormalizedNameWithReceipt(eq("unbekannt"))).thenReturn(List.of());
+
+        StepVerifier.create(priceTrendService.findHistory("unbekannt"))
+                .assertNext(history -> assertEquals(0, history.size()))
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- Add read-only price-history/trend endpoints for the grocery module: `GET /receipts/products` (per-product summaries) and `GET /receipts/products/history?name=...` (chronological history for one product).
- Products are matched across receipts by normalized name (`LOWER(TRIM(name))`); aggregation happens in Java (not SQL) since chronological first/latest price needs ordering, not `MIN`/`MAX`.
- No schema changes — pure aggregation over existing `receipt` / `receipt_item` tables.

## Test plan
- [x] `./gradlew :grocery:test --tests PriceTrendServiceTest` — pass
- [x] `./gradlew :grocery:test --tests ReceiptControllerTest` — pass, unmodified (no regression)
- [x] `./gradlew :grocery:test` — 23/23 pass
- [x] `./gradlew :grocery:checkstyleMain :grocery:checkstyleTest` — zero warnings
- [x] Verified with tdd-test-guardian agent: no existing tests modified, only new tests added

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)