### PR TITLE
feat(grocery): add article/article_group schema and backfill migration

### DIFF
--- a/grocery/build.gradle
+++ b/grocery/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
+    testImplementation 'org.testcontainers:postgresql:1.20.4'
 }
 
 tasks.named('test') {

--- a/grocery/src/main/java/com/marvin/grocery/entity/ArticleEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ArticleEntity.java
@@ -1,0 +1,57 @@
+package com.marvin.grocery.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * JPA entity representing a normalized grocery article that {@link ReceiptItemEntity} rows can be
+ * linked to, so free-text receipt positions can be grouped by a stable identity instead of raw text.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "article", schema = "grocery")
+public class ArticleEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "article_id_gen")
+    @SequenceGenerator(name = "article_id_gen", sequenceName = "grocery.article_id_seq", allocationSize = 1)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "normalized_name", nullable = false, unique = true)
+    private String normalizedName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_group_id")
+    private ArticleGroupEntity articleGroup;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ArticleEntity that = (ArticleEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/entity/ArticleGroupEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ArticleGroupEntity.java
@@ -1,0 +1,44 @@
+package com.marvin.grocery.entity;
+
+import com.marvin.costs.entity.BasicEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/** JPA entity representing a group of related {@link ArticleEntity} instances, e.g. "Tomatoes". */
+@Getter
+@Setter
+@Entity
+@Table(name = "article_group", schema = "grocery")
+public class ArticleGroupEntity extends BasicEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "article_group_id_gen")
+    @SequenceGenerator(name = "article_group_id_gen", sequenceName = "grocery.article_group_id_seq", allocationSize = 1)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ArticleGroupEntity that = (ArticleGroupEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/entity/ReceiptItemEntity.java
+++ b/grocery/src/main/java/com/marvin/grocery/entity/ReceiptItemEntity.java
@@ -32,6 +32,10 @@ public class ReceiptItemEntity {
     @JoinColumn(name = "receipt_id", nullable = false)
     private ReceiptEntity receipt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private ArticleEntity article;
+
     @Column(name = "name", nullable = false)
     private String name;
 

--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticleGroupRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticleGroupRepository.java
@@ -1,0 +1,10 @@
+package com.marvin.grocery.repository;
+
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link ArticleGroupEntity}. */
+@Repository
+public interface ArticleGroupRepository extends JpaRepository<ArticleGroupEntity, Long> {
+}

--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
@@ -1,0 +1,19 @@
+package com.marvin.grocery.repository;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Spring Data JPA repository for {@link ArticleEntity}. */
+@Repository
+public interface ArticleRepository extends JpaRepository<ArticleEntity, Long> {
+
+    /**
+     * Finds the article matching the given normalized (lower-cased, trimmed) name.
+     *
+     * @param normalizedName the normalized product name to match
+     * @return an Optional containing the article if one exists for that normalized name
+     */
+    Optional<ArticleEntity> findByNormalizedName(String normalizedName);
+}

--- a/grocery/src/main/resources/db/migration/grocery/V1_5__grocery_add_article_groups.sql
+++ b/grocery/src/main/resources/db/migration/grocery/V1_5__grocery_add_article_groups.sql
@@ -1,0 +1,37 @@
+CREATE TABLE grocery.article_group
+(
+    id            BIGSERIAL PRIMARY KEY,
+    name          VARCHAR(255) NOT NULL,
+    creation_date TIMESTAMP    NOT NULL,
+    last_modified TIMESTAMP    NOT NULL
+);
+
+CREATE TABLE grocery.article
+(
+    id               BIGSERIAL PRIMARY KEY,
+    name             VARCHAR(255) NOT NULL,
+    normalized_name  VARCHAR(255) NOT NULL UNIQUE,
+    article_group_id BIGINT REFERENCES grocery.article_group (id),
+    creation_date    TIMESTAMP    NOT NULL,
+    last_modified    TIMESTAMP    NOT NULL
+);
+
+ALTER TABLE grocery.receipt_item
+    ADD COLUMN article_id BIGINT REFERENCES grocery.article (id);
+
+-- Backfill: create exactly one article per distinct normalized (lower-cased, trimmed) receipt_item
+-- name that already exists in the data. The lowest-id row of each group is used as the sample name.
+INSERT INTO grocery.article (name, normalized_name, creation_date, last_modified)
+SELECT DISTINCT ON (LOWER(TRIM(ri.name)))
+    ri.name,
+    LOWER(TRIM(ri.name)),
+    now(),
+    now()
+FROM grocery.receipt_item ri
+ORDER BY LOWER(TRIM(ri.name)), ri.id;
+
+-- Link every existing receipt_item row to the article matching its normalized name.
+UPDATE grocery.receipt_item ri
+SET article_id = a.id
+FROM grocery.article a
+WHERE LOWER(TRIM(ri.name)) = a.normalized_name;

--- a/grocery/src/test/java/com/marvin/grocery/migration/ArticleBackfillMigrationTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/migration/ArticleBackfillMigrationTest.java
@@ -1,0 +1,119 @@
+package com.marvin.grocery.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies that the {@code V1_5__grocery_add_article_groups} Flyway migration backfills the new
+ * {@code article} table cleanly against pre-existing {@code receipt_item} data: one article per
+ * distinct normalized name, no duplicates, and every existing row linked via {@code article_id}.
+ */
+@Testcontainers
+class ArticleBackfillMigrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Test
+    void backfillCreatesOneArticlePerNormalizedNameAndLinksAllExistingReceiptItems() throws Exception {
+        migrateGroceryUpTo("1.4");
+
+        final UUID receiptId = UUID.randomUUID();
+        try (Connection connection = openConnection()) {
+            insertReceipt(connection, receiptId);
+            insertReceiptItem(connection, receiptId, "Tomaten rot");
+            insertReceiptItem(connection, receiptId, " tomaten ROT ");
+            insertReceiptItem(connection, receiptId, "Gurke");
+        }
+
+        migrateGroceryUpTo(null);
+
+        try (Connection connection = openConnection()) {
+            assertArticleCountAndUniqueness(connection, 2);
+            assertEveryReceiptItemHasAnArticle(connection);
+            assertDuplicateNormalizedNamesShareTheSameArticle(connection);
+        }
+    }
+
+    private void assertArticleCountAndUniqueness(final Connection connection, final int expectedCount) throws Exception {
+        final Set<String> normalizedNames = new HashSet<>();
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT normalized_name FROM grocery.article")) {
+            while (resultSet.next()) {
+                normalizedNames.add(resultSet.getString(1));
+            }
+        }
+        assertThat(normalizedNames).hasSize(expectedCount);
+    }
+
+    private void assertEveryReceiptItemHasAnArticle(final Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement
+                        .executeQuery("SELECT COUNT(*) FROM grocery.receipt_item WHERE article_id IS NULL")) {
+            resultSet.next();
+            assertThat(resultSet.getInt(1)).isZero();
+        }
+    }
+
+    private void assertDuplicateNormalizedNamesShareTheSameArticle(final Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(
+                        "SELECT DISTINCT article_id FROM grocery.receipt_item WHERE LOWER(TRIM(name)) = 'tomaten rot'")) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private void insertReceipt(final Connection connection, final UUID receiptId) throws Exception {
+        final String sql = "INSERT INTO grocery.receipt (id, receipt_date, creation_date, last_modified) "
+                + "VALUES (?, ?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, receiptId);
+            statement.setObject(2, LocalDateTime.now().toLocalDate());
+            statement.setObject(3, LocalDateTime.now());
+            statement.setObject(4, LocalDateTime.now());
+            statement.executeUpdate();
+        }
+    }
+
+    private void insertReceiptItem(final Connection connection, final UUID receiptId, final String name) throws Exception {
+        final String sql = "INSERT INTO grocery.receipt_item (receipt_id, name, price) VALUES (?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, receiptId);
+            statement.setString(2, name);
+            statement.setBigDecimal(3, BigDecimal.valueOf(1.99));
+            statement.executeUpdate();
+        }
+    }
+
+    private Connection openConnection() throws Exception {
+        return DriverManager.getConnection(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+
+    private void migrateGroceryUpTo(final String targetVersion) {
+        final FluentConfiguration configuration = Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .schemas("grocery")
+                .locations("classpath:db/migration/grocery");
+        if (targetVersion != null) {
+            configuration.target(targetVersion);
+        }
+        configuration.load().migrate();
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/repository/ArticleGroupRepositoryTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ArticleGroupRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.marvin.grocery.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Repository integration test for {@link ArticleGroupEntity}, exercising the real grocery Flyway migrations. */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ArticleGroupRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Test
+    void saveAndFindByIdPersistsNameAndAuditTimestamps() {
+        final ArticleGroupEntity group = new ArticleGroupEntity();
+        group.setName("Tomatoes");
+
+        final ArticleGroupEntity saved = articleGroupRepository.save(group);
+
+        final Optional<ArticleGroupEntity> found = articleGroupRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Tomatoes");
+        assertThat(found.get().getCreationDate()).isNotNull();
+        assertThat(found.get().getLastModified()).isNotNull();
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/repository/ArticleRepositoryTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ArticleRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.marvin.grocery.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Repository integration test for {@link ArticleEntity}, exercising the real grocery Flyway migrations. */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ArticleRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Test
+    void findByNormalizedNameReturnsMatchingArticle() {
+        articleRepository.save(newArticle("Tomaten rot", "tomaten rot"));
+
+        final Optional<ArticleEntity> found = articleRepository.findByNormalizedName("tomaten rot");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Tomaten rot");
+    }
+
+    @Test
+    void findByNormalizedNameReturnsEmptyWhenNoArticleMatches() {
+        final Optional<ArticleEntity> found = articleRepository.findByNormalizedName("does-not-exist");
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void savingTwoArticlesWithSameNormalizedNameViolatesUniqueConstraint() {
+        articleRepository.saveAndFlush(newArticle("Gurke", "gurke"));
+
+        assertThatThrownBy(() -> articleRepository.saveAndFlush(newArticle("GURKE", "gurke")))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void articleCanBeLinkedToAnArticleGroup() {
+        final ArticleGroupEntity group = articleGroupRepository.save(newGroup("Vegetables"));
+        final ArticleEntity article = newArticle("Karotte", "karotte");
+        article.setArticleGroup(group);
+
+        final ArticleEntity saved = articleRepository.save(article);
+
+        final Optional<ArticleEntity> found = articleRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getArticleGroup()).isNotNull();
+        assertThat(found.get().getArticleGroup().getId()).isEqualTo(group.getId());
+    }
+
+    private ArticleEntity newArticle(final String name, final String normalizedName) {
+        final ArticleEntity article = new ArticleEntity();
+        article.setName(name);
+        article.setNormalizedName(normalizedName);
+        return article;
+    }
+
+    private ArticleGroupEntity newGroup(final String name) {
+        final ArticleGroupEntity group = new ArticleGroupEntity();
+        group.setName(name);
+        return group;
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/repository/ReceiptItemArticleAssociationTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ReceiptItemArticleAssociationTest.java
@@ -1,0 +1,82 @@
+package com.marvin.grocery.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Repository integration test verifying the nullable {@code article} link on {@link ReceiptItemEntity}. */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ReceiptItemArticleAssociationTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ReceiptRepository receiptRepository;
+
+    @Autowired
+    private ReceiptItemRepository receiptItemRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Test
+    void receiptItemCanBeSavedWithoutAnArticleLink() {
+        final ReceiptItemEntity saved = saveReceiptWithItem(null);
+
+        final Optional<ReceiptItemEntity> found = receiptItemRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getArticle()).isNull();
+    }
+
+    @Test
+    void receiptItemCanBeLinkedToAnArticle() {
+        final ArticleEntity article = articleRepository.save(newArticle("Tomaten", "tomaten"));
+
+        final ReceiptItemEntity saved = saveReceiptWithItem(article);
+
+        final Optional<ReceiptItemEntity> found = receiptItemRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getArticle()).isNotNull();
+        assertThat(found.get().getArticle().getId()).isEqualTo(article.getId());
+    }
+
+    private ReceiptItemEntity saveReceiptWithItem(final ArticleEntity article) {
+        final ReceiptEntity receipt = new ReceiptEntity();
+        receipt.setReceiptDate(LocalDate.of(2026, 1, 1));
+        receiptRepository.save(receipt);
+
+        final ReceiptItemEntity item = new ReceiptItemEntity();
+        item.setReceipt(receipt);
+        item.setName("Tomaten");
+        item.setPrice(BigDecimal.valueOf(1.99));
+        item.setSinglePrice(BigDecimal.valueOf(1.99));
+        item.setQuantity(1);
+        item.setArticle(article);
+        return receiptItemRepository.save(item);
+    }
+
+    private ArticleEntity newArticle(final String name, final String normalizedName) {
+        final ArticleEntity article = new ArticleEntity();
+        article.setName(name);
+        article.setNormalizedName(normalizedName);
+        return article;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Flyway migration `V1_5__grocery_add_article_groups.sql` creating `grocery.article_group` and `grocery.article` tables, plus a nullable `article_id` FK on `grocery.receipt_item`.
- Backfills one `article` row per distinct normalized (`LOWER(TRIM(name))`) receipt item name and links all matching `receipt_item` rows to it, with no duplicates.
- Adds `ArticleEntity`/`ArticleGroupEntity` JPA entities and `ArticleRepository`/`ArticleGroupRepository` Spring Data repositories, and wires a nullable `article` association onto `ReceiptItemEntity`.

## Test plan
- [x] `./gradlew :grocery:compileJava :grocery:compileTestJava :grocery:checkstyleMain :grocery:checkstyleTest :boot:compileJava` passes
- [x] New repository/migration tests written first (TDD) — Testcontainers-based, not runnable in this sandboxed environment (no Docker), but exercised via CI
- [x] No existing test files modified (verified via `git diff --stat` against master)

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)