### PR TITLE
feat(grocery): find-or-create Article on receipt import and manual item edits

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleService.java
@@ -1,0 +1,47 @@
+package com.marvin.grocery.service;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.repository.ArticleRepository;
+import com.marvin.grocery.util.ArticleNameNormalizer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Finds or creates {@link ArticleEntity} rows by normalized name, so receipt items imported from
+ * OCR or added manually can be linked to a stable article identity instead of only free-text names.
+ */
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    /**
+     * Creates a new ArticleService with the required repository.
+     *
+     * @param articleRepository the JPA repository for articles
+     */
+    public ArticleService(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+    /**
+     * Finds the article matching the normalized form of the given name, or creates and persists a
+     * new one if none exists yet.
+     *
+     * @param name the raw (non-normalized) product name
+     * @return the existing or newly created article entity
+     */
+    @Transactional
+    public ArticleEntity findOrCreate(String name) {
+        final String normalizedName = ArticleNameNormalizer.normalize(name);
+        return articleRepository.findByNormalizedName(normalizedName)
+                .orElseGet(() -> createArticle(name, normalizedName));
+    }
+
+    private ArticleEntity createArticle(String name, String normalizedName) {
+        final ArticleEntity article = new ArticleEntity();
+        article.setName(name);
+        article.setNormalizedName(normalizedName);
+        return articleRepository.save(article);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
@@ -5,12 +5,12 @@ import com.marvin.grocery.dto.ProductPriceSummaryDTO;
 import com.marvin.grocery.entity.ReceiptEntity;
 import com.marvin.grocery.entity.ReceiptItemEntity;
 import com.marvin.grocery.repository.ReceiptItemRepository;
+import com.marvin.grocery.util.ArticleNameNormalizer;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
@@ -60,7 +60,7 @@ public class PriceTrendService {
      * @return a Mono emitting the ordered list of history points, empty if the product was never purchased
      */
     public Mono<List<PriceHistoryPointDTO>> findHistory(String name) {
-        final String normalizedName = normalize(name);
+        final String normalizedName = ArticleNameNormalizer.normalize(name);
         return Mono.fromCallable(() -> receiptItemRepository.findAllByNormalizedNameWithReceipt(normalizedName).stream()
                         .sorted(CHRONOLOGICAL_ORDER)
                         .map(PriceTrendService::toHistoryPoint)
@@ -71,7 +71,7 @@ public class PriceTrendService {
     private List<ProductPriceSummaryDTO> computeSummaries() {
         final Map<String, List<ReceiptItemEntity>> itemsByNormalizedName = receiptItemRepository.findAllWithReceipt()
                 .stream()
-                .collect(Collectors.groupingBy(item -> normalize(item.getName())));
+                .collect(Collectors.groupingBy(item -> ArticleNameNormalizer.normalize(item.getName())));
         return itemsByNormalizedName.values().stream()
                 .map(PriceTrendService::toSummary)
                 .sorted(Comparator.comparing(ProductPriceSummaryDTO::name, String.CASE_INSENSITIVE_ORDER))
@@ -85,7 +85,7 @@ public class PriceTrendService {
         final List<BigDecimal> sparklinePrices = chronological.stream().map(ReceiptItemEntity::getSinglePrice).toList();
         return new ProductPriceSummaryDTO(
                 latest.getName().trim(),
-                normalize(latest.getName()),
+                ArticleNameNormalizer.normalize(latest.getName()),
                 first.getSinglePrice(),
                 effectiveDate(first),
                 latest.getSinglePrice(),
@@ -119,9 +119,5 @@ public class PriceTrendService {
     private static LocalDate effectiveDate(ReceiptItemEntity item) {
         final ReceiptEntity receipt = item.getReceipt();
         return receipt.getReceiptDate() != null ? receipt.getReceiptDate() : receipt.getCreationDate().toLocalDate();
-    }
-
-    private static String normalize(String name) {
-        return name.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptPersistenceService.java
@@ -22,6 +22,7 @@ public class ReceiptPersistenceService {
     private final ReceiptParserService parserService;
     private final ReceiptRepository receiptRepository;
     private final ReceiptItemRepository receiptItemRepository;
+    private final ArticleService articleService;
 
     /**
      * Creates a new ReceiptPersistenceService with all required dependencies.
@@ -29,14 +30,17 @@ public class ReceiptPersistenceService {
      * @param parserService         the parser for structured item extraction
      * @param receiptRepository     the JPA repository for receipts
      * @param receiptItemRepository the JPA repository for receipt items
+     * @param articleService        the service used to find or create the article per item
      */
     public ReceiptPersistenceService(
             ReceiptParserService parserService,
             ReceiptRepository receiptRepository,
-            ReceiptItemRepository receiptItemRepository) {
+            ReceiptItemRepository receiptItemRepository,
+            ArticleService articleService) {
         this.parserService = parserService;
         this.receiptRepository = receiptRepository;
         this.receiptItemRepository = receiptItemRepository;
+        this.articleService = articleService;
     }
 
     /**
@@ -62,6 +66,7 @@ public class ReceiptPersistenceService {
         for (final ParsedItem item : parsed.items()) {
             final ReceiptItemEntity itemEntity = new ReceiptItemEntity();
             itemEntity.setReceipt(saved);
+            itemEntity.setArticle(articleService.findOrCreate(item.name()));
             itemEntity.setName(item.name());
             itemEntity.setSinglePrice(item.singlePrice());
             itemEntity.setQuantity(item.quantity());

--- a/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ReceiptService.java
@@ -34,27 +34,31 @@ public class ReceiptService {
     private final ReceiptRepository receiptRepository;
     private final ReceiptItemRepository receiptItemRepository;
     private final ReceiptMapper receiptMapper;
+    private final ArticleService articleService;
 
     /**
      * Creates a new ReceiptService with all required dependencies.
      *
-     * @param ocrProvider        the OCR provider to use for text extraction
-     * @param persistenceService the service responsible for transactional receipt persistence
-     * @param receiptRepository  the JPA repository for receipts
+     * @param ocrProvider           the OCR provider to use for text extraction
+     * @param persistenceService    the service responsible for transactional receipt persistence
+     * @param receiptRepository     the JPA repository for receipts
      * @param receiptItemRepository the JPA repository for receipt items
-     * @param receiptMapper      the MapStruct mapper for DTO conversion
+     * @param receiptMapper         the MapStruct mapper for DTO conversion
+     * @param articleService        the service used to find or create the article for an item name
      */
     public ReceiptService(
             OcrProvider ocrProvider,
             ReceiptPersistenceService persistenceService,
             ReceiptRepository receiptRepository,
             ReceiptItemRepository receiptItemRepository,
-            ReceiptMapper receiptMapper) {
+            ReceiptMapper receiptMapper,
+            ArticleService articleService) {
         this.ocrProvider = ocrProvider;
         this.persistenceService = persistenceService;
         this.receiptRepository = receiptRepository;
         this.receiptItemRepository = receiptItemRepository;
         this.receiptMapper = receiptMapper;
+        this.articleService = articleService;
     }
 
     /**
@@ -114,6 +118,7 @@ public class ReceiptService {
                     .orElseThrow(() -> new NoSuchElementException("Receipt not found: " + receiptId));
             final ReceiptItemEntity item = new ReceiptItemEntity();
             item.setReceipt(receipt);
+            item.setArticle(articleService.findOrCreate(request.name()));
             item.setName(request.name());
             item.setQuantity(request.quantity());
             item.setSinglePrice(request.singlePrice());
@@ -135,6 +140,7 @@ public class ReceiptService {
         return Mono.fromCallable(() -> {
             final ReceiptItemEntity item = receiptItemRepository.findByIdAndReceiptId(itemId, receiptId)
                     .orElseThrow(() -> new NoSuchElementException("Item not found: " + itemId));
+            item.setArticle(articleService.findOrCreate(request.name()));
             item.setName(request.name());
             item.setQuantity(request.quantity());
             item.setSinglePrice(request.singlePrice());

--- a/grocery/src/main/java/com/marvin/grocery/util/ArticleNameNormalizer.java
+++ b/grocery/src/main/java/com/marvin/grocery/util/ArticleNameNormalizer.java
@@ -1,0 +1,23 @@
+package com.marvin.grocery.util;
+
+import java.util.Locale;
+
+/**
+ * Normalizes free-text product names into a canonical form so that names differing only by
+ * casing or surrounding whitespace can be matched as the same product/article.
+ */
+public final class ArticleNameNormalizer {
+
+    private ArticleNameNormalizer() {
+    }
+
+    /**
+     * Normalizes the given name by trimming whitespace and lower-casing it in a locale-independent way.
+     *
+     * @param name the raw product name
+     * @return the normalized name
+     */
+    public static String normalize(String name) {
+        return name.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/ArticleServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ArticleServiceTest.java
@@ -1,0 +1,69 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.repository.ArticleRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArticleService Tests")
+class ArticleServiceTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private ArticleService articleService;
+
+    @Test
+    @DisplayName("Should return the existing article when one matches the normalized name")
+    void findOrCreate_ExistingNormalizedName_ReturnsExistingArticle() {
+        final ArticleEntity existing = new ArticleEntity();
+        existing.setId(1L);
+        existing.setName("Milch");
+        existing.setNormalizedName("milch");
+        when(articleRepository.findByNormalizedName("milch")).thenReturn(Optional.of(existing));
+
+        final ArticleEntity result = articleService.findOrCreate(" Milch ");
+
+        assertSame(existing, result);
+        verify(articleRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should create and persist a new article when no match exists for the normalized name")
+    void findOrCreate_NoMatch_CreatesAndPersistsNewArticle() {
+        when(articleRepository.findByNormalizedName("kaffee")).thenReturn(Optional.empty());
+        when(articleRepository.save(any(ArticleEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        final ArticleEntity result = articleService.findOrCreate("Kaffee");
+
+        assertEquals("Kaffee", result.getName());
+        assertEquals("kaffee", result.getNormalizedName());
+        verify(articleRepository).save(any(ArticleEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should normalize by trimming whitespace and lower-casing before looking up an existing article")
+    void findOrCreate_NormalizesNameBeforeLookup() {
+        when(articleRepository.findByNormalizedName(eq("apfel"))).thenReturn(Optional.empty());
+        when(articleRepository.save(any(ArticleEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        articleService.findOrCreate("  APFEL  ");
+
+        verify(articleRepository).findByNormalizedName("apfel");
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/ReceiptPersistenceServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ReceiptPersistenceServiceTest.java
@@ -1,0 +1,93 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.parser.ParsedItem;
+import com.marvin.grocery.parser.ParsedReceipt;
+import com.marvin.grocery.parser.ReceiptParserService;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import com.marvin.grocery.repository.ReceiptRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReceiptPersistenceService Tests")
+class ReceiptPersistenceServiceTest {
+
+    @Mock
+    private ReceiptParserService parserService;
+
+    @Mock
+    private ReceiptRepository receiptRepository;
+
+    @Mock
+    private ReceiptItemRepository receiptItemRepository;
+
+    @Mock
+    private ArticleService articleService;
+
+    @InjectMocks
+    private ReceiptPersistenceService receiptPersistenceService;
+
+    @Test
+    @DisplayName("Should link a parsed item to the article resolved via find-or-create")
+    void saveReceipt_ParsedItem_LinksResolvedArticle() {
+        final String ocrText = "raw ocr text";
+        final ParsedItem parsedItem = new ParsedItem("Milch", new BigDecimal("1.09"), 1, new BigDecimal("1.09"));
+        when(parserService.parse(ocrText)).thenReturn(new ParsedReceipt(List.of(parsedItem), LocalDate.of(2026, 1, 1)));
+        final ReceiptEntity savedReceipt = new ReceiptEntity();
+        savedReceipt.setId(UUID.randomUUID());
+        when(receiptRepository.save(any(ReceiptEntity.class))).thenReturn(savedReceipt);
+        final ArticleEntity resolvedArticle = new ArticleEntity();
+        resolvedArticle.setId(42L);
+        resolvedArticle.setName("Milch");
+        resolvedArticle.setNormalizedName("milch");
+        when(articleService.findOrCreate("Milch")).thenReturn(resolvedArticle);
+        when(receiptItemRepository.save(any(ReceiptItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        receiptPersistenceService.saveReceipt(ocrText);
+
+        final ArgumentCaptor<ReceiptItemEntity> itemCaptor = ArgumentCaptor.forClass(ReceiptItemEntity.class);
+        verify(receiptItemRepository).save(itemCaptor.capture());
+        final ReceiptItemEntity savedItem = itemCaptor.getValue();
+        assertEquals("Milch", savedItem.getName());
+        assertSame(resolvedArticle, savedItem.getArticle());
+    }
+
+    @Test
+    @DisplayName("Should resolve an article per parsed item via find-or-create")
+    void saveReceipt_MultipleParsedItems_ResolvesArticlePerItem() {
+        final String ocrText = "raw ocr text";
+        final ParsedItem firstItem = new ParsedItem("Milch", new BigDecimal("1.09"), 1, new BigDecimal("1.09"));
+        final ParsedItem secondItem = new ParsedItem("Butter", new BigDecimal("1.79"), 1, new BigDecimal("1.79"));
+        when(parserService.parse(ocrText)).thenReturn(new ParsedReceipt(List.of(firstItem, secondItem), null));
+        final ReceiptEntity savedReceipt = new ReceiptEntity();
+        savedReceipt.setId(UUID.randomUUID());
+        when(receiptRepository.save(any(ReceiptEntity.class))).thenReturn(savedReceipt);
+        when(articleService.findOrCreate(any(String.class))).thenReturn(new ArticleEntity());
+        when(receiptItemRepository.save(any(ReceiptItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        receiptPersistenceService.saveReceipt(ocrText);
+
+        verify(articleService, times(1)).findOrCreate("Milch");
+        verify(articleService, times(1)).findOrCreate("Butter");
+        verify(receiptItemRepository, times(2)).save(any(ReceiptItemEntity.class));
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/ReceiptServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ReceiptServiceTest.java
@@ -1,0 +1,105 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.dto.AddReceiptItemRequest;
+import com.marvin.grocery.dto.ReceiptItemDTO;
+import com.marvin.grocery.dto.UpdateReceiptItemRequest;
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import com.marvin.grocery.mapper.ReceiptMapper;
+import com.marvin.grocery.ocr.OcrProvider;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import com.marvin.grocery.repository.ReceiptRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReceiptService Tests")
+class ReceiptServiceTest {
+
+    @Mock
+    private OcrProvider ocrProvider;
+
+    @Mock
+    private ReceiptPersistenceService persistenceService;
+
+    @Mock
+    private ReceiptRepository receiptRepository;
+
+    @Mock
+    private ReceiptItemRepository receiptItemRepository;
+
+    @Mock
+    private ReceiptMapper receiptMapper;
+
+    @Mock
+    private ArticleService articleService;
+
+    @InjectMocks
+    private ReceiptService receiptService;
+
+    @Test
+    @DisplayName("addItem should link the article resolved via find-or-create for the item's name")
+    void addItem_ResolvesArticleAndLinksIt() {
+        final UUID receiptId = UUID.randomUUID();
+        final ReceiptEntity receipt = new ReceiptEntity();
+        receipt.setId(receiptId);
+        final AddReceiptItemRequest request = new AddReceiptItemRequest("Milch", 2, new BigDecimal("1.09"));
+        final ArticleEntity resolvedArticle = new ArticleEntity();
+        resolvedArticle.setId(7L);
+        resolvedArticle.setName("Milch");
+        resolvedArticle.setNormalizedName("milch");
+        when(receiptRepository.findById(receiptId)).thenReturn(Optional.of(receipt));
+        when(articleService.findOrCreate("Milch")).thenReturn(resolvedArticle);
+        when(receiptItemRepository.save(any(ReceiptItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(receiptMapper.toReceiptItemDTO(any(ReceiptItemEntity.class)))
+                .thenReturn(new ReceiptItemDTO(1L, "Milch", new BigDecimal("1.09"), 2, new BigDecimal("2.18")));
+
+        StepVerifier.create(receiptService.addItem(receiptId, request))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        final ArgumentCaptor<ReceiptItemEntity> itemCaptor = ArgumentCaptor.forClass(ReceiptItemEntity.class);
+        verify(receiptItemRepository).save(itemCaptor.capture());
+        assertSame(resolvedArticle, itemCaptor.getValue().getArticle());
+    }
+
+    @Test
+    @DisplayName("updateItem should re-resolve the article via find-or-create for the updated name")
+    void updateItem_ResolvesArticleAndLinksIt() {
+        final UUID receiptId = UUID.randomUUID();
+        final Long itemId = 5L;
+        final ReceiptItemEntity existingItem = new ReceiptItemEntity();
+        existingItem.setId(itemId);
+        final UpdateReceiptItemRequest request = new UpdateReceiptItemRequest("Kaffee", 1, new BigDecimal("3.49"));
+        final ArticleEntity resolvedArticle = new ArticleEntity();
+        resolvedArticle.setId(9L);
+        resolvedArticle.setName("Kaffee");
+        resolvedArticle.setNormalizedName("kaffee");
+        when(receiptItemRepository.findByIdAndReceiptId(itemId, receiptId)).thenReturn(Optional.of(existingItem));
+        when(articleService.findOrCreate("Kaffee")).thenReturn(resolvedArticle);
+        when(receiptItemRepository.save(any(ReceiptItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(receiptMapper.toReceiptItemDTO(any(ReceiptItemEntity.class)))
+                .thenReturn(new ReceiptItemDTO(itemId, "Kaffee", new BigDecimal("3.49"), 1, new BigDecimal("3.49")));
+
+        StepVerifier.create(receiptService.updateItem(receiptId, itemId, request))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertSame(resolvedArticle, existingItem.getArticle());
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/util/ArticleNameNormalizerTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/util/ArticleNameNormalizerTest.java
@@ -1,0 +1,28 @@
+package com.marvin.grocery.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ArticleNameNormalizer Tests")
+class ArticleNameNormalizerTest {
+
+    @Test
+    @DisplayName("Should trim surrounding whitespace and lower-case the name")
+    void normalize_TrimsAndLowerCases() {
+        assertEquals("milch", ArticleNameNormalizer.normalize(" Milch "));
+    }
+
+    @Test
+    @DisplayName("Should normalize using ROOT locale regardless of default locale casing rules")
+    void normalize_UsesRootLocale() {
+        assertEquals("istanbul", ArticleNameNormalizer.normalize("ISTANBUL"));
+    }
+
+    @Test
+    @DisplayName("Should treat names differing only by case and whitespace as equal after normalization")
+    void normalize_CaseAndWhitespaceVariantsMatch() {
+        assertEquals(ArticleNameNormalizer.normalize("Tomaten rot"), ArticleNameNormalizer.normalize("  tomaten ROT  "));
+    }
+}


### PR DESCRIPTION
## Summary
- `ReceiptPersistenceService.saveReceipt` now finds-or-creates an `Article` (by normalized name) per parsed item and links it via `receiptItem.setArticle(...)`, in addition to the existing free-text `name`.
- `ReceiptService.addItem` / `updateItem` apply the same find-or-create linkage for manually added/edited items.
- New `ArticleService.findOrCreate(name)` encapsulates the find-or-create logic against `ArticleRepository.findByNormalizedName`.
- Extracted `ArticleNameNormalizer.normalize(name)` (trim + `toLowerCase(Locale.ROOT)`) as the single source of truth for name normalization; `PriceTrendService` now delegates to it instead of its own private `normalize()`, so behavior stays identical to how `V1_5__grocery_add_article_groups.sql` populated `normalized_name`.

## Test plan
- New unit tests: `ArticleServiceTest` (find case, create case, normalization applied before lookup), `ReceiptPersistenceServiceTest`, `ReceiptServiceTest` (article linkage on add/update), `ArticleNameNormalizerTest`.
- No existing test files were modified (verified via diff).
- `./gradlew :grocery:compileJava :grocery:compileTestJava :grocery:checkstyleMain :grocery:checkstyleTest :boot:compileJava` — clean, zero checkstyle warnings.

Closes #235