### PR TITLE
feat(grocery): article-group CRUD service and REST endpoints

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ArticleController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ArticleController.java
@@ -1,0 +1,176 @@
+package com.marvin.grocery.controller;
+
+import com.marvin.grocery.dto.ArticleDTO;
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.dto.ArticleGroupRequest;
+import com.marvin.grocery.dto.UpdateArticleGroupAssignmentRequest;
+import com.marvin.grocery.service.ArticleManagementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.NoSuchElementException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller for managing grocery articles and article groups, as groundwork for a future
+ * frontend management GUI.
+ */
+@RestController
+@Tag(name = "Grocery Articles", description = "Manage grocery articles and their group assignments")
+public class ArticleController {
+
+    private final ArticleManagementService articleManagementService;
+
+    /**
+     * Creates a new ArticleController with the required service.
+     *
+     * @param articleManagementService the service handling article and article group management
+     */
+    public ArticleController(ArticleManagementService articleManagementService) {
+        this.articleManagementService = articleManagementService;
+    }
+
+    /**
+     * Lists all articles with their group assignment and purchase count.
+     *
+     * @return a Flux emitting all article DTOs
+     */
+    @GetMapping("/articles")
+    @Operation(
+            summary = "List all articles",
+            description = "Returns every article with its normalized name, display name, group assignment, and "
+                    + "the number of receipt items referencing it.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Article list returned",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = ArticleDTO.class)))
+                )
+            }
+    )
+    public Flux<ArticleDTO> listArticles() {
+        return articleManagementService.findAllArticles();
+    }
+
+    /**
+     * Assigns the given article to a group, or clears the assignment when groupId is null.
+     *
+     * @param id      the id of the article to update
+     * @param request the group assignment payload
+     * @return a Mono with 200 OK and the updated article, or 404 if the article or group is not found
+     */
+    @PatchMapping("/articles/{id}/group")
+    @Operation(
+            summary = "Assign or clear an article's group",
+            description = "Sets the article's group to the given groupId, or clears it when groupId is null.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Article updated",
+                        content = @Content(schema = @Schema(implementation = ArticleDTO.class))
+                ),
+                @ApiResponse(responseCode = "404", description = "Article or article group not found")
+            }
+    )
+    public Mono<ResponseEntity<ArticleDTO>> assignGroup(
+            @PathVariable @Parameter(description = "Id of the article") Long id,
+            @RequestBody UpdateArticleGroupAssignmentRequest request) {
+        return articleManagementService.assignGroup(id, request.groupId())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates a new article group.
+     *
+     * @param request the fields for the new group
+     * @return a Mono with 201 Created and the new group
+     */
+    @PostMapping("/article-groups")
+    @Operation(
+            summary = "Create an article group",
+            description = "Creates a new article group with the given name.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Article group created",
+                        content = @Content(schema = @Schema(implementation = ArticleGroupDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Invalid request body (validation failed)")
+            }
+    )
+    public Mono<ResponseEntity<ArticleGroupDTO>> createGroup(@Valid @RequestBody ArticleGroupRequest request) {
+        return articleManagementService.createGroup(request.name())
+                .map(group -> ResponseEntity.status(HttpStatus.CREATED).body(group));
+    }
+
+    /**
+     * Renames an existing article group.
+     *
+     * @param id      the id of the group to rename
+     * @param request the new name
+     * @return a Mono with 200 OK and the updated group, or 404 if not found
+     */
+    @PutMapping("/article-groups/{id}")
+    @Operation(
+            summary = "Rename an article group",
+            description = "Updates the display name of an existing article group.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Article group updated",
+                        content = @Content(schema = @Schema(implementation = ArticleGroupDTO.class))
+                ),
+                @ApiResponse(responseCode = "400", description = "Invalid request body (validation failed)"),
+                @ApiResponse(responseCode = "404", description = "Article group not found")
+            }
+    )
+    public Mono<ResponseEntity<ArticleGroupDTO>> renameGroup(
+            @PathVariable @Parameter(description = "Id of the article group") Long id,
+            @Valid @RequestBody ArticleGroupRequest request) {
+        return articleManagementService.renameGroup(id, request.name())
+                .map(ResponseEntity::ok)
+                .onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Deletes an article group, decoupling (not cascade-deleting) any articles assigned to it.
+     *
+     * @param id the id of the group to delete
+     * @return a Mono with 204 No Content on success, or 404 Not Found if the group does not exist
+     */
+    @DeleteMapping("/article-groups/{id}")
+    @Operation(
+            summary = "Delete an article group",
+            description = "Deletes the group and clears the group assignment on any articles that referenced it; "
+                    + "articles and receipt items are never cascade-deleted.",
+            responses = {
+                @ApiResponse(responseCode = "204", description = "Article group deleted"),
+                @ApiResponse(responseCode = "404", description = "Article group not found")
+            }
+    )
+    public Mono<ResponseEntity<Void>> deleteGroup(
+            @PathVariable @Parameter(description = "Id of the article group to delete") Long id) {
+        final ResponseEntity<Void> noContent = ResponseEntity.<Void>noContent().build();
+        final ResponseEntity<Void> notFound = ResponseEntity.<Void>notFound().build();
+        return articleManagementService.deleteGroup(id)
+                .thenReturn(noContent)
+                .onErrorReturn(NoSuchElementException.class, notFound);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/dto/ArticleDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ArticleDTO.java
@@ -1,0 +1,31 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing a normalized grocery article and its group assignment.
+ *
+ * @param normalizedName the normalized (lower-cased, trimmed) name used for de-duplication
+ * @param name           the display name of the article
+ * @param groupId        the id of the assigned article group, or null if unassigned
+ * @param groupName      the name of the assigned article group, or null if unassigned
+ * @param purchaseCount  the number of receipt items referencing this article
+ */
+@Schema(description = "A normalized grocery article with its optional group assignment and purchase count")
+public record ArticleDTO(
+        @Schema(description = "Normalized (lower-cased, trimmed) article name", example = "vollmilch 3,5%")
+        String normalizedName,
+
+        @Schema(description = "Display name of the article", example = "Vollmilch 3,5%")
+        String name,
+
+        @Schema(description = "Id of the assigned article group, null if unassigned", example = "3")
+        Long groupId,
+
+        @Schema(description = "Name of the assigned article group, null if unassigned", example = "Dairy")
+        String groupName,
+
+        @Schema(description = "Number of receipt items referencing this article", example = "12")
+        long purchaseCount
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/dto/ArticleGroupDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ArticleGroupDTO.java
@@ -1,0 +1,19 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object representing an article group.
+ *
+ * @param id   database identifier of the group
+ * @param name display name of the group
+ */
+@Schema(description = "A group that articles can be assigned to")
+public record ArticleGroupDTO(
+        @Schema(description = "Database identifier of the article group", example = "3")
+        Long id,
+
+        @Schema(description = "Display name of the article group", example = "Dairy")
+        String name
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/dto/ArticleGroupRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ArticleGroupRequest.java
@@ -1,0 +1,20 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for creating or renaming an article group.
+ *
+ * @param name the new display name of the group
+ */
+@Schema(description = "Fields for creating or renaming an article group")
+public record ArticleGroupRequest(
+
+        @Schema(description = "Display name of the article group", example = "Dairy")
+        @NotBlank
+        @Size(max = 255)
+        String name
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/dto/UpdateArticleGroupAssignmentRequest.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/UpdateArticleGroupAssignmentRequest.java
@@ -1,0 +1,16 @@
+package com.marvin.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Request body for assigning or clearing an article's group.
+ *
+ * @param groupId the id of the group to assign, or null to clear the assignment
+ */
+@Schema(description = "Article group assignment payload")
+public record UpdateArticleGroupAssignmentRequest(
+
+        @Schema(description = "Id of the article group to assign; null clears the assignment", example = "3")
+        Long groupId
+) {
+}

--- a/grocery/src/main/java/com/marvin/grocery/mapper/ArticleGroupMapper.java
+++ b/grocery/src/main/java/com/marvin/grocery/mapper/ArticleGroupMapper.java
@@ -1,0 +1,18 @@
+package com.marvin.grocery.mapper;
+
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import org.mapstruct.Mapper;
+
+/** MapStruct mapper for converting between article group entities and DTOs. */
+@Mapper(componentModel = "spring")
+public interface ArticleGroupMapper {
+
+    /**
+     * Maps an article group entity to a DTO.
+     *
+     * @param entity the article group entity to map
+     * @return the article group DTO
+     */
+    ArticleGroupDTO toArticleGroupDTO(ArticleGroupEntity entity);
+}

--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticlePurchaseCount.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticlePurchaseCount.java
@@ -1,0 +1,21 @@
+package com.marvin.grocery.repository;
+
+/**
+ * Spring Data projection pairing an article id with the number of receipt items referencing it.
+ */
+public interface ArticlePurchaseCount {
+
+    /**
+     * Returns the id of the article being counted.
+     *
+     * @return the article id
+     */
+    Long getArticleId();
+
+    /**
+     * Returns the number of receipt items referencing the article.
+     *
+     * @return the purchase count
+     */
+    long getPurchaseCount();
+}

--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
@@ -3,6 +3,9 @@ package com.marvin.grocery.repository;
 import com.marvin.grocery.entity.ArticleEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /** Spring Data JPA repository for {@link ArticleEntity}. */
@@ -16,4 +19,14 @@ public interface ArticleRepository extends JpaRepository<ArticleEntity, Long> {
      * @return an Optional containing the article if one exists for that normalized name
      */
     Optional<ArticleEntity> findByNormalizedName(String normalizedName);
+
+    /**
+     * Clears the group assignment for every article referencing the given group id, so deleting a
+     * group only decouples its articles instead of cascading the delete onto them.
+     *
+     * @param groupId the id of the article group being detached
+     */
+    @Modifying
+    @Query("UPDATE ArticleEntity a SET a.articleGroup = null WHERE a.articleGroup.id = :groupId")
+    void clearArticleGroup(@Param("groupId") Long groupId);
 }

--- a/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ReceiptItemRepository.java
@@ -47,4 +47,22 @@ public interface ReceiptItemRepository extends JpaRepository<ReceiptItemEntity, 
      */
     @Query("SELECT i FROM ReceiptItemEntity i JOIN FETCH i.receipt r WHERE LOWER(TRIM(i.name)) = :normalizedName")
     List<ReceiptItemEntity> findAllByNormalizedNameWithReceipt(@Param("normalizedName") String normalizedName);
+
+    /**
+     * Returns the number of receipt items referencing the given article.
+     *
+     * @param articleId the id of the article to count receipt items for
+     * @return the number of matching receipt items
+     */
+    long countByArticleId(Long articleId);
+
+    /**
+     * Returns the number of receipt items referencing each article that has at least one, grouped
+     * by article id, so the full article list can be built without an N+1 query per article.
+     *
+     * @return one projection per article id that has at least one referencing receipt item
+     */
+    @Query("SELECT i.article.id AS articleId, COUNT(i) AS purchaseCount FROM ReceiptItemEntity i "
+            + "WHERE i.article IS NOT NULL GROUP BY i.article.id")
+    List<ArticlePurchaseCount> countPurchasesGroupedByArticle();
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleGroupDeletionService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleGroupDeletionService.java
@@ -1,0 +1,45 @@
+package com.marvin.grocery.service;
+
+import com.marvin.grocery.repository.ArticleGroupRepository;
+import com.marvin.grocery.repository.ArticleRepository;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Deletes article groups while atomically decoupling (never cascade-deleting) the articles that
+ * reference them, so receipt items keep their article link intact.
+ */
+@Service
+public class ArticleGroupDeletionService {
+
+    private final ArticleGroupRepository articleGroupRepository;
+    private final ArticleRepository articleRepository;
+
+    /**
+     * Creates a new ArticleGroupDeletionService with the required repositories.
+     *
+     * @param articleGroupRepository the JPA repository for article groups
+     * @param articleRepository      the JPA repository for articles
+     */
+    public ArticleGroupDeletionService(ArticleGroupRepository articleGroupRepository, ArticleRepository articleRepository) {
+        this.articleGroupRepository = articleGroupRepository;
+        this.articleRepository = articleRepository;
+    }
+
+    /**
+     * Deletes the article group with the given id after clearing the group assignment on every
+     * article that references it. Both steps run in a single transaction, so articles and receipt
+     * items are never cascade-deleted.
+     *
+     * @param id the id of the article group to delete
+     */
+    @Transactional
+    public void deleteAndDetach(Long id) {
+        if (!articleGroupRepository.existsById(id)) {
+            throw new NoSuchElementException("Article group not found: " + id);
+        }
+        articleRepository.clearArticleGroup(id);
+        articleGroupRepository.deleteById(id);
+    }
+}

--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
@@ -1,0 +1,154 @@
+package com.marvin.grocery.service;
+
+import com.marvin.grocery.dto.ArticleDTO;
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import com.marvin.grocery.mapper.ArticleGroupMapper;
+import com.marvin.grocery.repository.ArticleGroupRepository;
+import com.marvin.grocery.repository.ArticlePurchaseCount;
+import com.marvin.grocery.repository.ArticleRepository;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Orchestrates reactive read/write access to articles and article groups for the management API,
+ * wrapping blocking JPA calls onto the bounded-elastic scheduler.
+ */
+@Service
+public class ArticleManagementService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleGroupRepository articleGroupRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+    private final ArticleGroupDeletionService articleGroupDeletionService;
+    private final ArticleGroupMapper articleGroupMapper;
+
+    /**
+     * Creates a new ArticleManagementService with all required dependencies.
+     *
+     * @param articleRepository           the JPA repository for articles
+     * @param articleGroupRepository      the JPA repository for article groups
+     * @param receiptItemRepository       the JPA repository for receipt items
+     * @param articleGroupDeletionService the service handling atomic group deletion and detachment
+     * @param articleGroupMapper          the MapStruct mapper for article group DTO conversion
+     */
+    public ArticleManagementService(
+            ArticleRepository articleRepository,
+            ArticleGroupRepository articleGroupRepository,
+            ReceiptItemRepository receiptItemRepository,
+            ArticleGroupDeletionService articleGroupDeletionService,
+            ArticleGroupMapper articleGroupMapper) {
+        this.articleRepository = articleRepository;
+        this.articleGroupRepository = articleGroupRepository;
+        this.receiptItemRepository = receiptItemRepository;
+        this.articleGroupDeletionService = articleGroupDeletionService;
+        this.articleGroupMapper = articleGroupMapper;
+    }
+
+    /**
+     * Returns all articles with their group assignment and purchase count.
+     *
+     * @return a Flux emitting one article DTO per stored article
+     */
+    public Flux<ArticleDTO> findAllArticles() {
+        return Mono.fromCallable(() -> {
+            final Map<Long, Long> purchaseCounts = receiptItemRepository.countPurchasesGroupedByArticle().stream()
+                    .collect(Collectors.toMap(ArticlePurchaseCount::getArticleId, ArticlePurchaseCount::getPurchaseCount));
+            return articleRepository.findAll().stream()
+                    .map(article -> toArticleDTO(article, purchaseCounts.getOrDefault(article.getId(), 0L)))
+                    .toList();
+        }).subscribeOn(Schedulers.boundedElastic()).flatMapIterable(Function.identity());
+    }
+
+    /**
+     * Assigns the given article to the given group, or clears the assignment when groupId is null.
+     * Emits {@link NoSuchElementException} if the article does not exist, or if a non-null groupId
+     * does not reference an existing group.
+     *
+     * @param articleId the id of the article to update
+     * @param groupId   the id of the group to assign, or null to clear the assignment
+     * @return a Mono emitting the updated article DTO
+     */
+    public Mono<ArticleDTO> assignGroup(Long articleId, Long groupId) {
+        return Mono.fromCallable(() -> {
+            final ArticleEntity article = articleRepository.findById(articleId)
+                    .orElseThrow(() -> new NoSuchElementException("Article not found: " + articleId));
+            article.setArticleGroup(resolveGroup(groupId));
+            final ArticleEntity saved = articleRepository.save(article);
+            final long purchaseCount = receiptItemRepository.countByArticleId(saved.getId());
+            return toArticleDTO(saved, purchaseCount);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Creates a new article group with the given name.
+     *
+     * @param name the display name of the new group
+     * @return a Mono emitting the created group DTO
+     */
+    public Mono<ArticleGroupDTO> createGroup(String name) {
+        return Mono.fromCallable(() -> {
+            final ArticleGroupEntity group = new ArticleGroupEntity();
+            group.setName(name);
+            return articleGroupMapper.toArticleGroupDTO(articleGroupRepository.save(group));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Renames the article group with the given id.
+     * Emits {@link NoSuchElementException} if no group with that id exists.
+     *
+     * @param id   the id of the group to rename
+     * @param name the new display name
+     * @return a Mono emitting the updated group DTO
+     */
+    public Mono<ArticleGroupDTO> renameGroup(Long id, String name) {
+        return Mono.fromCallable(() -> {
+            final ArticleGroupEntity group = articleGroupRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException("Article group not found: " + id));
+            group.setName(name);
+            return articleGroupMapper.toArticleGroupDTO(articleGroupRepository.save(group));
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Deletes the article group with the given id, decoupling (not cascade-deleting) any articles
+     * that were assigned to it.
+     * Emits {@link NoSuchElementException} if no group with that id exists.
+     *
+     * @param id the id of the group to delete
+     * @return an empty Mono on success, or an error Mono if the group does not exist
+     */
+    public Mono<Void> deleteGroup(Long id) {
+        return Mono.fromCallable(() -> {
+            articleGroupDeletionService.deleteAndDetach(id);
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic()).then();
+    }
+
+    private ArticleGroupEntity resolveGroup(Long groupId) {
+        if (groupId == null) {
+            return null;
+        }
+        return articleGroupRepository.findById(groupId)
+                .orElseThrow(() -> new NoSuchElementException("Article group not found: " + groupId));
+    }
+
+    private ArticleDTO toArticleDTO(ArticleEntity article, long purchaseCount) {
+        final ArticleGroupEntity group = article.getArticleGroup();
+        return new ArticleDTO(
+                article.getNormalizedName(),
+                article.getName(),
+                group == null ? null : group.getId(),
+                group == null ? null : group.getName(),
+                purchaseCount);
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/controller/ArticleControllerTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ArticleControllerTest.java
@@ -1,0 +1,157 @@
+package com.marvin.grocery.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.dto.ArticleDTO;
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.dto.ArticleGroupRequest;
+import com.marvin.grocery.dto.UpdateArticleGroupAssignmentRequest;
+import com.marvin.grocery.service.ArticleManagementService;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArticleController Tests")
+class ArticleControllerTest {
+
+    @Mock
+    private ArticleManagementService articleManagementService;
+
+    @InjectMocks
+    private ArticleController articleController;
+
+    @Test
+    @DisplayName("Should return all articles as a Flux")
+    void listArticles_ReturnsFluxOfArticles() {
+        final ArticleDTO dto = new ArticleDTO("vollmilch", "Vollmilch", 3L, "Dairy", 5L);
+        when(articleManagementService.findAllArticles()).thenReturn(Flux.just(dto));
+
+        final Flux<ArticleDTO> result = articleController.listArticles();
+
+        StepVerifier.create(result)
+                .expectNext(dto)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 200 with the updated article after assigning a group")
+    void assignGroup_ArticleAndGroupExist_Returns200() {
+        final ArticleDTO dto = new ArticleDTO("vollmilch", "Vollmilch", 3L, "Dairy", 5L);
+        when(articleManagementService.assignGroup(1L, 3L)).thenReturn(Mono.just(dto));
+
+        final Mono<ResponseEntity<ArticleDTO>> result =
+                articleController.assignGroup(1L, new UpdateArticleGroupAssignmentRequest(3L));
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals(3L, response.getBody().groupId());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 404 when the article does not exist")
+    void assignGroup_ArticleNotFound_Returns404() {
+        when(articleManagementService.assignGroup(eq(99L), eq(3L)))
+                .thenReturn(Mono.error(new NoSuchElementException("Article not found: 99")));
+
+        final Mono<ResponseEntity<ArticleDTO>> result =
+                articleController.assignGroup(99L, new UpdateArticleGroupAssignmentRequest(3L));
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 201 with the created group")
+    void createGroup_ValidRequest_Returns201() {
+        final ArticleGroupDTO dto = new ArticleGroupDTO(3L, "Dairy");
+        when(articleManagementService.createGroup("Dairy")).thenReturn(Mono.just(dto));
+
+        final Mono<ResponseEntity<ArticleGroupDTO>> result =
+                articleController.createGroup(new ArticleGroupRequest("Dairy"));
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(201, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Dairy", response.getBody().name());
+                })
+                .verifyComplete();
+
+        verify(articleManagementService).createGroup("Dairy");
+    }
+
+    @Test
+    @DisplayName("Should return 200 with the renamed group")
+    void renameGroup_GroupExists_Returns200() {
+        final ArticleGroupDTO dto = new ArticleGroupDTO(3L, "Milk Products");
+        when(articleManagementService.renameGroup(3L, "Milk Products")).thenReturn(Mono.just(dto));
+
+        final Mono<ResponseEntity<ArticleGroupDTO>> result =
+                articleController.renameGroup(3L, new ArticleGroupRequest("Milk Products"));
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCode().value());
+                    assertNotNull(response.getBody());
+                    assertEquals("Milk Products", response.getBody().name());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 404 when renaming an unknown group")
+    void renameGroup_GroupNotFound_Returns404() {
+        when(articleManagementService.renameGroup(eq(99L), eq("New Name")))
+                .thenReturn(Mono.error(new NoSuchElementException("Article group not found: 99")));
+
+        final Mono<ResponseEntity<ArticleGroupDTO>> result =
+                articleController.renameGroup(99L, new ArticleGroupRequest("New Name"));
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 204 after successful group deletion")
+    void deleteGroup_GroupExists_Returns204() {
+        when(articleManagementService.deleteGroup(3L)).thenReturn(Mono.empty());
+
+        final Mono<ResponseEntity<Void>> result = articleController.deleteGroup(3L);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(204, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return 404 when deleting an unknown group")
+    void deleteGroup_GroupNotFound_Returns404() {
+        when(articleManagementService.deleteGroup(99L))
+                .thenReturn(Mono.error(new NoSuchElementException("Article group not found: 99")));
+
+        final Mono<ResponseEntity<Void>> result = articleController.deleteGroup(99L);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(404, response.getStatusCode().value()))
+                .verifyComplete();
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/mapper/ArticleGroupMapperTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/mapper/ArticleGroupMapperTest.java
@@ -1,0 +1,28 @@
+package com.marvin.grocery.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+@DisplayName("ArticleGroupMapper Tests")
+class ArticleGroupMapperTest {
+
+    private final ArticleGroupMapper articleGroupMapper = Mappers.getMapper(ArticleGroupMapper.class);
+
+    @Test
+    @DisplayName("Should map an article group entity to its DTO")
+    void toArticleGroupDTO_MapsIdAndName() {
+        final ArticleGroupEntity entity = new ArticleGroupEntity();
+        entity.setId(3L);
+        entity.setName("Dairy");
+
+        final ArticleGroupDTO dto = articleGroupMapper.toArticleGroupDTO(entity);
+
+        assertEquals(3L, dto.id());
+        assertEquals("Dairy", dto.name());
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/repository/ArticleGroupDetachmentTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ArticleGroupDetachmentTest.java
@@ -1,0 +1,74 @@
+package com.marvin.grocery.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Repository integration test verifying that {@link ArticleRepository#clearArticleGroup(Long)}
+ * decouples articles from a group without deleting them, mirroring the codebase's Flyway migrations.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ArticleGroupDetachmentTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Test
+    @Transactional
+    void clearArticleGroupNullsGroupReferenceWithoutDeletingArticle() {
+        final ArticleGroupEntity group = articleGroupRepository.save(newGroup("Vegetables"));
+        final ArticleEntity article = newArticle("Karotte", "karotte");
+        article.setArticleGroup(group);
+        final ArticleEntity saved = articleRepository.saveAndFlush(article);
+
+        articleRepository.clearArticleGroup(group.getId());
+        articleRepository.flush();
+
+        final Optional<ArticleEntity> found = articleRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getArticleGroup()).isNull();
+    }
+
+    @Test
+    void clearArticleGroupIsNoOpWhenNoArticleReferencesTheGroup() {
+        final ArticleGroupEntity group = articleGroupRepository.save(newGroup("Empty Group"));
+
+        articleRepository.clearArticleGroup(group.getId());
+
+        assertThat(articleGroupRepository.findById(group.getId())).isPresent();
+    }
+
+    private ArticleEntity newArticle(final String name, final String normalizedName) {
+        final ArticleEntity article = new ArticleEntity();
+        article.setName(name);
+        article.setNormalizedName(normalizedName);
+        return article;
+    }
+
+    private ArticleGroupEntity newGroup(final String name) {
+        final ArticleGroupEntity group = new ArticleGroupEntity();
+        group.setName(name);
+        return group;
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/repository/ReceiptItemPurchaseCountTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ReceiptItemPurchaseCountTest.java
@@ -1,0 +1,88 @@
+package com.marvin.grocery.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ReceiptEntity;
+import com.marvin.grocery.entity.ReceiptItemEntity;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Repository integration test for the purchase-count queries on {@link ReceiptItemRepository},
+ * exercising the real grocery Flyway migrations.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ReceiptItemPurchaseCountTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ReceiptRepository receiptRepository;
+
+    @Autowired
+    private ReceiptItemRepository receiptItemRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Test
+    void countByArticleIdReturnsNumberOfReferencingReceiptItems() {
+        final ArticleEntity article = articleRepository.save(newArticle("Tomaten", "tomaten"));
+        saveReceiptWithItem(article);
+        saveReceiptWithItem(article);
+
+        final long count = receiptItemRepository.countByArticleId(article.getId());
+
+        assertThat(count).isEqualTo(2L);
+    }
+
+    @Test
+    void countPurchasesGroupedByArticleOmitsArticlesWithoutReceiptItems() {
+        final ArticleEntity purchased = articleRepository.save(newArticle("Gurke", "gurke"));
+        articleRepository.save(newArticle("Never bought", "never bought"));
+        saveReceiptWithItem(purchased);
+
+        final List<ArticlePurchaseCount> counts = receiptItemRepository.countPurchasesGroupedByArticle();
+
+        assertThat(counts)
+                .extracting(ArticlePurchaseCount::getArticleId, ArticlePurchaseCount::getPurchaseCount)
+                .containsExactly(tuple(purchased.getId(), 1L));
+    }
+
+    private ReceiptItemEntity saveReceiptWithItem(final ArticleEntity article) {
+        final ReceiptEntity receipt = new ReceiptEntity();
+        receipt.setReceiptDate(LocalDate.of(2026, 1, 1));
+        receiptRepository.save(receipt);
+
+        final ReceiptItemEntity item = new ReceiptItemEntity();
+        item.setReceipt(receipt);
+        item.setName(article.getName());
+        item.setPrice(BigDecimal.valueOf(1.99));
+        item.setSinglePrice(BigDecimal.valueOf(1.99));
+        item.setQuantity(1);
+        item.setArticle(article);
+        return receiptItemRepository.save(item);
+    }
+
+    private ArticleEntity newArticle(final String name, final String normalizedName) {
+        final ArticleEntity article = new ArticleEntity();
+        article.setName(name);
+        article.setNormalizedName(normalizedName);
+        return article;
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/ArticleGroupDeletionServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ArticleGroupDeletionServiceTest.java
@@ -1,0 +1,52 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.repository.ArticleGroupRepository;
+import com.marvin.grocery.repository.ArticleRepository;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArticleGroupDeletionService Tests")
+class ArticleGroupDeletionServiceTest {
+
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private ArticleGroupDeletionService articleGroupDeletionService;
+
+    @Test
+    @DisplayName("Should clear article group references and delete the group when it exists")
+    void deleteAndDetach_GroupExists_ClearsReferencesThenDeletesGroup() {
+        when(articleGroupRepository.existsById(1L)).thenReturn(true);
+
+        articleGroupDeletionService.deleteAndDetach(1L);
+
+        verify(articleRepository).clearArticleGroup(1L);
+        verify(articleGroupRepository).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("Should throw NoSuchElementException and not touch articles when group does not exist")
+    void deleteAndDetach_GroupNotFound_ThrowsAndDoesNotTouchArticles() {
+        when(articleGroupRepository.existsById(99L)).thenReturn(false);
+
+        assertThrows(NoSuchElementException.class, () -> articleGroupDeletionService.deleteAndDetach(99L));
+
+        verify(articleRepository, never()).clearArticleGroup(99L);
+        verify(articleGroupRepository, never()).deleteById(99L);
+    }
+}

--- a/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
@@ -1,0 +1,251 @@
+package com.marvin.grocery.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marvin.grocery.dto.ArticleDTO;
+import com.marvin.grocery.dto.ArticleGroupDTO;
+import com.marvin.grocery.entity.ArticleEntity;
+import com.marvin.grocery.entity.ArticleGroupEntity;
+import com.marvin.grocery.mapper.ArticleGroupMapper;
+import com.marvin.grocery.repository.ArticleGroupRepository;
+import com.marvin.grocery.repository.ArticlePurchaseCount;
+import com.marvin.grocery.repository.ArticleRepository;
+import com.marvin.grocery.repository.ReceiptItemRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArticleManagementService Tests")
+class ArticleManagementServiceTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Mock
+    private ReceiptItemRepository receiptItemRepository;
+
+    @Mock
+    private ArticleGroupDeletionService articleGroupDeletionService;
+
+    @Mock
+    private ArticleGroupMapper articleGroupMapper;
+
+    @InjectMocks
+    private ArticleManagementService articleManagementService;
+
+    private ArticleGroupEntity group;
+    private ArticleEntity article;
+
+    @BeforeEach
+    void setUp() {
+        group = new ArticleGroupEntity();
+        group.setId(3L);
+        group.setName("Dairy");
+
+        article = new ArticleEntity();
+        article.setId(1L);
+        article.setName("Vollmilch");
+        article.setNormalizedName("vollmilch");
+    }
+
+    @Test
+    @DisplayName("Should list all articles with group info and purchase count")
+    void findAllArticles_ReturnsArticlesWithGroupAndPurchaseCount() {
+        article.setArticleGroup(group);
+        when(articleRepository.findAll()).thenReturn(List.of(article));
+        when(receiptItemRepository.countPurchasesGroupedByArticle())
+                .thenReturn(List.of(countOf(1L, 5L)));
+
+        final Flux<ArticleDTO> result = articleManagementService.findAllArticles();
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertEquals("vollmilch", dto.normalizedName());
+                    assertEquals("Vollmilch", dto.name());
+                    assertEquals(3L, dto.groupId());
+                    assertEquals("Dairy", dto.groupName());
+                    assertEquals(5L, dto.purchaseCount());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should default purchase count to zero and group fields to null when unassigned")
+    void findAllArticles_NoGroupNoPurchases_DefaultsToZeroAndNull() {
+        when(articleRepository.findAll()).thenReturn(List.of(article));
+        when(receiptItemRepository.countPurchasesGroupedByArticle()).thenReturn(List.of());
+
+        final Flux<ArticleDTO> result = articleManagementService.findAllArticles();
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertEquals(0L, dto.purchaseCount());
+                    assertNull(dto.groupId());
+                    assertNull(dto.groupName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should assign the article to the given group")
+    void assignGroup_ArticleAndGroupExist_AssignsGroup() {
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(article));
+        when(articleGroupRepository.findById(3L)).thenReturn(Optional.of(group));
+        when(articleRepository.save(any(ArticleEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(receiptItemRepository.countByArticleId(1L)).thenReturn(2L);
+
+        final Mono<ArticleDTO> result = articleManagementService.assignGroup(1L, 3L);
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertEquals(3L, dto.groupId());
+                    assertEquals("Dairy", dto.groupName());
+                    assertEquals(2L, dto.purchaseCount());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should clear the group assignment when groupId is null")
+    void assignGroup_NullGroupId_ClearsAssignment() {
+        article.setArticleGroup(group);
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(article));
+        when(articleRepository.save(any(ArticleEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(receiptItemRepository.countByArticleId(1L)).thenReturn(0L);
+
+        final Mono<ArticleDTO> result = articleManagementService.assignGroup(1L, null);
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertNull(dto.groupId());
+                    assertNull(dto.groupName());
+                })
+                .verifyComplete();
+        verify(articleGroupRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("Should emit NoSuchElementException when the article does not exist")
+    void assignGroup_ArticleNotFound_EmitsError() {
+        when(articleRepository.findById(99L)).thenReturn(Optional.empty());
+
+        final Mono<ArticleDTO> result = articleManagementService.assignGroup(99L, 3L);
+
+        StepVerifier.create(result)
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Should emit NoSuchElementException when the requested group does not exist")
+    void assignGroup_GroupNotFound_EmitsError() {
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(article));
+        when(articleGroupRepository.findById(42L)).thenReturn(Optional.empty());
+
+        final Mono<ArticleDTO> result = articleManagementService.assignGroup(1L, 42L);
+
+        StepVerifier.create(result)
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Should create and map a new article group")
+    void createGroup_CreatesAndReturnsMappedGroup() {
+        when(articleGroupRepository.save(any(ArticleGroupEntity.class))).thenReturn(group);
+        when(articleGroupMapper.toArticleGroupDTO(group)).thenReturn(new ArticleGroupDTO(3L, "Dairy"));
+
+        final Mono<ArticleGroupDTO> result = articleManagementService.createGroup("Dairy");
+
+        StepVerifier.create(result)
+                .assertNext(dto -> assertEquals("Dairy", dto.name()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should rename an existing group")
+    void renameGroup_GroupExists_RenamesAndReturnsMappedGroup() {
+        when(articleGroupRepository.findById(3L)).thenReturn(Optional.of(group));
+        when(articleGroupRepository.save(any(ArticleGroupEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(articleGroupMapper.toArticleGroupDTO(any(ArticleGroupEntity.class)))
+                .thenAnswer(invocation -> {
+                    final ArticleGroupEntity entity = invocation.getArgument(0);
+                    return new ArticleGroupDTO(entity.getId(), entity.getName());
+                });
+
+        final Mono<ArticleGroupDTO> result = articleManagementService.renameGroup(3L, "Milk Products");
+
+        StepVerifier.create(result)
+                .assertNext(dto -> assertEquals("Milk Products", dto.name()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit NoSuchElementException when renaming an unknown group")
+    void renameGroup_GroupNotFound_EmitsError() {
+        when(articleGroupRepository.findById(99L)).thenReturn(Optional.empty());
+
+        final Mono<ArticleGroupDTO> result = articleManagementService.renameGroup(99L, "New Name");
+
+        StepVerifier.create(result)
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Should delegate group deletion to the deletion service")
+    void deleteGroup_DelegatesToDeletionService() {
+        final Mono<Void> result = articleManagementService.deleteGroup(3L);
+
+        StepVerifier.create(result).verifyComplete();
+
+        verify(articleGroupDeletionService).deleteAndDetach(3L);
+    }
+
+    @Test
+    @DisplayName("Should propagate NoSuchElementException from the deletion service")
+    void deleteGroup_UnknownGroup_PropagatesError() {
+        doThrow(new NoSuchElementException("Article group not found: 99"))
+                .when(articleGroupDeletionService).deleteAndDetach(99L);
+
+        final Mono<Void> result = articleManagementService.deleteGroup(99L);
+
+        StepVerifier.create(result)
+                .expectError(NoSuchElementException.class)
+                .verify();
+    }
+
+    private ArticlePurchaseCount countOf(final Long articleId, final long purchaseCount) {
+        return new ArticlePurchaseCount() {
+            @Override
+            public Long getArticleId() {
+                return articleId;
+            }
+
+            @Override
+            public long getPurchaseCount() {
+                return purchaseCount;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ArticleManagementService` (reactive orchestrator) and `ArticleGroupDeletionService` (transactional detach-then-delete) in the `grocery` module.
- Adds a new `ArticleController` with:
  - `GET /articles` — all articles with `normalizedName`, `name`, `groupId`/`groupName` (nullable), `purchaseCount` (aggregated from `receipt_item`, no N+1)
  - `POST /article-groups` `{name}` — create a group (201)
  - `PUT /article-groups/{id}` `{name}` — rename a group (200 / 404)
  - `DELETE /article-groups/{id}` — deletes the group and only clears `article.article_group_id` on referencing articles in the same transaction; articles and `receipt_item` rows are never cascade-deleted (204 / 404)
  - `PATCH /articles/{id}/group` `{groupId}` (nullable) — assign or clear an article's group (200 / 404 for unknown article or group)
- 404s follow the existing codebase convention: services throw `NoSuchElementException`, controller maps it via `.onErrorReturn(NoSuchElementException.class, ResponseEntity.notFound().build())`, matching `ReceiptController`.
- New DTOs (`ArticleDTO`, `ArticleGroupDTO`, `ArticleGroupRequest`, `UpdateArticleGroupAssignmentRequest`) and a new `ArticleGroupMapper` (MapStruct), following existing DTO/mapper conventions.
- New repository methods: `ArticleRepository.clearArticleGroup(groupId)` (bulk detach) and `ReceiptItemRepository.countByArticleId` / `countPurchasesGroupedByArticle` (aggregate purchase counts).

Closes #236

## Test plan
- [x] TDD: tests written alongside the new logic; no existing test file was modified (verified via `git diff master -- grocery/src/test` and the `tdd-test-guardian` agent).
- [x] `./gradlew :grocery:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :grocery:test --tests "com.marvin.grocery.service.*" --tests "com.marvin.grocery.controller.*" --tests "com.marvin.grocery.mapper.*" --tests "com.marvin.grocery.util.*" --tests "com.marvin.grocery.dto.*" --tests "com.marvin.grocery.parser.*" --tests "com.marvin.grocery.ocr.*"` — BUILD SUCCESSFUL (all new Mockito/StepVerifier-based unit tests pass: `ArticleManagementServiceTest`, `ArticleGroupDeletionServiceTest`, `ArticleControllerTest`, `ArticleGroupMapperTest`)
- [x] `./gradlew :grocery:checkstyleMain :grocery:checkstyleTest` — BUILD SUCCESSFUL, zero warnings
- [ ] `ArticleGroupDetachmentTest` and `ReceiptItemPurchaseCountTest` are new Testcontainers-based repository tests (same pattern as existing `ArticleGroupRepositoryTest`/`ArticleRepositoryTest`); they compile locally but require Docker to execute, which isn't available in this sandbox — they should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)