### PR TITLE
feat(grocery): add articleName to price-history response

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/dto/PriceHistoryPointDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/PriceHistoryPointDTO.java
@@ -14,6 +14,8 @@ import java.util.UUID;
  * @param quantity    number of units purchased
  * @param supermarket supermarket where this purchase was made; null if not set
  * @param receiptId   id of the receipt this purchase belongs to
+ * @param articleName display name of the {@code Article} that contributed this purchase; lets a
+ *                    merged group's history be traced back to the specific name variant it came from
  */
 @Schema(description = "A single historical price data point for a product")
 public record PriceHistoryPointDTO(
@@ -30,6 +32,9 @@ public record PriceHistoryPointDTO(
         Supermarket supermarket,
 
         @Schema(description = "Id of the receipt this purchase belongs to")
-        UUID receiptId
+        UUID receiptId,
+
+        @Schema(description = "Display name of the Article that contributed this purchase", example = "Vollmilch")
+        String articleName
 ) {
 }

--- a/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/PriceTrendService.java
@@ -112,7 +112,8 @@ public class PriceTrendService {
                 item.getSinglePrice(),
                 item.getQuantity(),
                 item.getReceipt().getSupermarket(),
-                item.getReceipt().getId()
+                item.getReceipt().getId(),
+                item.getArticle().getName()
         );
     }
 

--- a/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerPriceHistoryTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ReceiptControllerPriceHistoryTest.java
@@ -101,7 +101,7 @@ class ReceiptControllerPriceHistoryTest {
     void getArticleGroupHistory_ReturnsHistory() {
         final UUID receiptId = UUID.randomUUID();
         final PriceHistoryPointDTO point = new PriceHistoryPointDTO(
-                LocalDate.of(2026, 1, 1), new BigDecimal("1.09"), 1, Supermarket.LIDL, receiptId);
+                LocalDate.of(2026, 1, 1), new BigDecimal("1.09"), 1, Supermarket.LIDL, receiptId, "Vollmilch");
         when(priceTrendService.findHistory(eq(1L))).thenReturn(Mono.just(List.of(point)));
 
         webTestClient.get()
@@ -113,7 +113,8 @@ class ReceiptControllerPriceHistoryTest {
                 .jsonPath("$[0].singlePrice").isEqualTo(1.09)
                 .jsonPath("$[0].quantity").isEqualTo(1)
                 .jsonPath("$[0].supermarket").isEqualTo("LIDL")
-                .jsonPath("$[0].receiptId").isEqualTo(receiptId.toString());
+                .jsonPath("$[0].receiptId").isEqualTo(receiptId.toString())
+                .jsonPath("$[0].articleName").isEqualTo("Vollmilch");
     }
 
     @Test

--- a/grocery/src/test/java/com/marvin/grocery/service/PriceTrendServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/PriceTrendServiceTest.java
@@ -233,8 +233,10 @@ class PriceTrendServiceTest {
                     assertEquals(2, earliest.quantity());
                     assertEquals(Supermarket.LIDL, earliest.supermarket());
                     assertEquals(secondReceipt.getId(), earliest.receiptId());
+                    assertEquals("Apfel", earliest.articleName());
                     assertEquals(LocalDate.of(2026, 2, 1), latest.date());
                     assertEquals(new BigDecimal("0.59"), latest.singlePrice());
+                    assertEquals("Apfel", latest.articleName());
                 })
                 .verifyComplete();
     }
@@ -253,7 +255,43 @@ class PriceTrendServiceTest {
                 .thenReturn(List.of(firstItem, secondItem));
 
         StepVerifier.create(priceTrendService.findHistory(1L))
-                .assertNext(history -> assertEquals(2, history.size()))
+                .assertNext(history -> {
+                    assertEquals(2, history.size());
+                    assertEquals("Vollmilch", history.get(0).articleName());
+                    assertEquals("H-Milch", history.get(1).articleName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should attribute supermarket and articleName per-point across multiple supermarkets and article variants")
+    void findHistory_MultipleSupermarketsAndArticleVariants_AttributesPerPointCorrectly() {
+        final ArticleGroupEntity group = buildGroup(1L, "Milch");
+        final ArticleEntity vollmilch = buildArticle(10L, "Vollmilch", group);
+        final ArticleEntity hMilch = buildArticle(11L, "H-Milch", group);
+        final ArticleEntity biomilch = buildArticle(12L, "Bio-Milch", group);
+        final ReceiptEntity firstReceipt = buildReceipt(LocalDate.of(2026, 1, 1), null, Supermarket.LIDL);
+        final ReceiptEntity secondReceipt = buildReceipt(LocalDate.of(2026, 2, 1), null, Supermarket.REWE);
+        final ReceiptEntity thirdReceipt = buildReceipt(LocalDate.of(2026, 3, 1), null, Supermarket.EDEKA);
+        final ReceiptItemEntity firstItem = buildItem(1L, firstReceipt, vollmilch, "Vollmilch", new BigDecimal("1.09"), 1);
+        final ReceiptItemEntity secondItem = buildItem(2L, secondReceipt, hMilch, "H-Milch", new BigDecimal("1.19"), 1);
+        final ReceiptItemEntity thirdItem = buildItem(3L, thirdReceipt, biomilch, "Bio-Milch", new BigDecimal("1.49"), 1);
+        when(receiptItemRepository.findAllByArticleGroupIdWithReceipt(eq(1L)))
+                .thenReturn(List.of(firstItem, secondItem, thirdItem));
+
+        StepVerifier.create(priceTrendService.findHistory(1L))
+                .assertNext(history -> {
+                    assertEquals(3, history.size());
+                    final PriceHistoryPointDTO first = history.get(0);
+                    final PriceHistoryPointDTO second = history.get(1);
+                    final PriceHistoryPointDTO third = history.get(2);
+                    assertEquals(Supermarket.LIDL, first.supermarket());
+                    assertEquals("Vollmilch", first.articleName());
+                    assertEquals(Supermarket.REWE, second.supermarket());
+                    assertEquals("H-Milch", second.articleName());
+                    assertEquals(Supermarket.EDEKA, third.supermarket());
+                    assertEquals("Bio-Milch", third.articleName());
+                })
                 .verifyComplete();
     }
 


### PR DESCRIPTION
## Summary
- Adds a new `articleName` field to `PriceHistoryPointDTO`, carrying the display name of the `Article` (`item.getArticle().getName()`) that contributed each purchase.
- Updates `PriceTrendService.toHistoryPoint` to populate the new field.
- Extends `PriceTrendServiceTest` and `ReceiptControllerPriceHistoryTest` to cover the new field, including a new test with purchases across multiple supermarkets and multiple article name-variants within the same group, asserting per-point (not just "some value present") correctness of both `supermarket` and `articleName`.

Closes #238

## Test plan
- [x] `./gradlew :grocery:test --tests "com.marvin.grocery.service.PriceTrendServiceTest" --tests "com.marvin.grocery.controller.ReceiptControllerPriceHistoryTest"` — BUILD SUCCESSFUL
- [x] `./gradlew :grocery:checkstyleMain :grocery:checkstyleTest` — BUILD SUCCESSFUL
- [x] `./gradlew :grocery:build -x test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)