### PR TITLE
fix(grocery): include article id in ArticleDTO

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/dto/ArticleDTO.java
+++ b/grocery/src/main/java/com/marvin/grocery/dto/ArticleDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * Data Transfer Object representing a normalized grocery article and its group assignment.
  *
+ * @param id             database identifier of the article
  * @param normalizedName the normalized (lower-cased, trimmed) name used for de-duplication
  * @param name           the display name of the article
  * @param groupId        the id of the assigned article group, or null if unassigned
@@ -13,6 +14,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @Schema(description = "A normalized grocery article with its optional group assignment and purchase count")
 public record ArticleDTO(
+        @Schema(description = "Database identifier of the article", example = "1")
+        Long id,
+
         @Schema(description = "Normalized (lower-cased, trimmed) article name", example = "vollmilch 3,5%")
         String normalizedName,
 

--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
@@ -145,6 +145,7 @@ public class ArticleManagementService {
     private ArticleDTO toArticleDTO(ArticleEntity article, long purchaseCount) {
         final ArticleGroupEntity group = article.getArticleGroup();
         return new ArticleDTO(
+                article.getId(),
                 article.getNormalizedName(),
                 article.getName(),
                 group == null ? null : group.getId(),

--- a/grocery/src/test/java/com/marvin/grocery/controller/ArticleControllerTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/controller/ArticleControllerTest.java
@@ -36,7 +36,7 @@ class ArticleControllerTest {
     @Test
     @DisplayName("Should return all articles as a Flux")
     void listArticles_ReturnsFluxOfArticles() {
-        final ArticleDTO dto = new ArticleDTO("vollmilch", "Vollmilch", 3L, "Dairy", 5L);
+        final ArticleDTO dto = new ArticleDTO(1L, "vollmilch", "Vollmilch", 3L, "Dairy", 5L);
         when(articleManagementService.findAllArticles()).thenReturn(Flux.just(dto));
 
         final Flux<ArticleDTO> result = articleController.listArticles();
@@ -49,7 +49,7 @@ class ArticleControllerTest {
     @Test
     @DisplayName("Should return 200 with the updated article after assigning a group")
     void assignGroup_ArticleAndGroupExist_Returns200() {
-        final ArticleDTO dto = new ArticleDTO("vollmilch", "Vollmilch", 3L, "Dairy", 5L);
+        final ArticleDTO dto = new ArticleDTO(1L, "vollmilch", "Vollmilch", 3L, "Dairy", 5L);
         when(articleManagementService.assignGroup(1L, 3L)).thenReturn(Mono.just(dto));
 
         final Mono<ResponseEntity<ArticleDTO>> result =
@@ -59,6 +59,7 @@ class ArticleControllerTest {
                 .assertNext(response -> {
                     assertEquals(200, response.getStatusCode().value());
                     assertNotNull(response.getBody());
+                    assertEquals(1L, response.getBody().id());
                     assertEquals(3L, response.getBody().groupId());
                 })
                 .verifyComplete();

--- a/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
@@ -80,6 +80,7 @@ class ArticleManagementServiceTest {
 
         StepVerifier.create(result)
                 .assertNext(dto -> {
+                    assertEquals(1L, dto.id());
                     assertEquals("vollmilch", dto.normalizedName());
                     assertEquals("Vollmilch", dto.name());
                     assertEquals(3L, dto.groupId());
@@ -99,6 +100,7 @@ class ArticleManagementServiceTest {
 
         StepVerifier.create(result)
                 .assertNext(dto -> {
+                    assertEquals(1L, dto.id());
                     assertEquals(0L, dto.purchaseCount());
                     assertNull(dto.groupId());
                     assertNull(dto.groupName());
@@ -118,6 +120,7 @@ class ArticleManagementServiceTest {
 
         StepVerifier.create(result)
                 .assertNext(dto -> {
+                    assertEquals(1L, dto.id());
                     assertEquals(3L, dto.groupId());
                     assertEquals("Dairy", dto.groupName());
                     assertEquals(2L, dto.purchaseCount());


### PR DESCRIPTION
## Summary
- `ArticleDTO` (from `GET /articles`) was missing the article's `id`, even though `PATCH /articles/{id}/group` requires it — no client could actually assign an article to a group.
- Add `id` as the first field of `ArticleDTO`, mapped from `ArticleEntity.getId()` in `ArticleManagementService.toArticleDTO`.

Discovered while implementing the frontend article-group management page (Marvin1912/frontend#292).

## Test plan
- [x] Updated `ArticleManagementServiceTest` and `ArticleControllerTest` first (red), then fixed the DTO/mapping (green)
- [x] `./gradlew :grocery:test` — all unit tests pass (pre-existing Testcontainers integration tests fail in this sandbox due to no Docker socket access, unrelated to this change — verified same failures exist on master)
- [x] `./gradlew :grocery:checkstyleMain :grocery:checkstyleTest` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)