### PR TITLE
Fix grocery/it-news Spring bean name collision

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/controller/ArticleController.java
+++ b/grocery/src/main/java/com/marvin/grocery/controller/ArticleController.java
@@ -31,7 +31,7 @@ import reactor.core.publisher.Mono;
  * REST controller for managing grocery articles and article groups, as groundwork for a future
  * frontend management GUI.
  */
-@RestController
+@RestController("groceryArticleController")
 @Tag(name = "Grocery Articles", description = "Manage grocery articles and their group assignments")
 public class ArticleController {
 

--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /** Spring Data JPA repository for {@link ArticleEntity}. */
-@Repository
+@Repository("groceryArticleRepository")
 public interface ArticleRepository extends JpaRepository<ArticleEntity, Long> {
 
     /**

--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Finds or creates {@link ArticleEntity} rows by normalized name, so receipt items imported from
  * OCR or added manually can be linked to a stable article identity instead of only free-text names.
  */
-@Service
+@Service("groceryArticleService")
 public class ArticleService {
 
     private final ArticleRepository articleRepository;


### PR DESCRIPTION
## Summary
- `grocery.controller.ArticleController`, `grocery.service.ArticleService`, and `grocery.repository.ArticleRepository` shared default Spring bean names with identically-named classes in `it-news`, throwing `ConflictingBeanDefinitionException` on startup.
- This was discovered live in production: a routine deploy replaced the single backend replica with the broken build, and since the image is tagged `:latest` there was no `kubectl rollout undo` path back — the pod crash-looped until this fix was built and rolled out.
- Gives the grocery beans explicit names (`groceryArticleController`, `groceryArticleService`, `groceryArticleRepository`), following the existing `FlywayConfigGrocery`/`FlywayConfigItNews` naming pattern already used in this codebase.

## Test plan
- [x] `./gradlew :grocery:compileJava :grocery:checkstyleMain` passes
- [x] Verified no other Spring-bean class name collisions exist across any module pair
- [x] Rebuilt and redeployed to the cluster; pod is `1/1 Running`, Flyway migrations validated, no startup errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)