### PR TITLE
fix(grocery): fix LazyInitializationException on GET /articles

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
+++ b/grocery/src/main/java/com/marvin/grocery/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package com.marvin.grocery.repository;
 
 import com.marvin.grocery.entity.ArticleEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -19,6 +20,16 @@ public interface ArticleRepository extends JpaRepository<ArticleEntity, Long> {
      * @return an Optional containing the article if one exists for that normalized name
      */
     Optional<ArticleEntity> findByNormalizedName(String normalizedName);
+
+    /**
+     * Returns all articles with their article group eagerly fetched, so callers can read the group
+     * outside the repository's transaction boundary without triggering lazy initialization.
+     * Articles without a group assignment are included, with a null group.
+     *
+     * @return list of all articles with their article group initialized
+     */
+    @Query("SELECT a FROM ArticleEntity a LEFT JOIN FETCH a.articleGroup")
+    List<ArticleEntity> findAllWithGroup();
 
     /**
      * Clears the group assignment for every article referencing the given group id, so deleting a

--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
@@ -62,7 +62,7 @@ public class ArticleManagementService {
         return Mono.fromCallable(() -> {
             final Map<Long, Long> purchaseCounts = receiptItemRepository.countPurchasesGroupedByArticle().stream()
                     .collect(Collectors.toMap(ArticlePurchaseCount::getArticleId, ArticlePurchaseCount::getPurchaseCount));
-            return articleRepository.findAll().stream()
+            return articleRepository.findAllWithGroup().stream()
                     .map(article -> toArticleDTO(article, purchaseCounts.getOrDefault(article.getId(), 0L)))
                     .toList();
         }).subscribeOn(Schedulers.boundedElastic()).flatMapIterable(Function.identity());

--- a/grocery/src/test/java/com/marvin/grocery/repository/ArticleRepositoryTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/repository/ArticleRepositoryTest.java
@@ -5,11 +5,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.marvin.grocery.entity.ArticleEntity;
 import com.marvin.grocery.entity.ArticleGroupEntity;
+import java.util.List;
 import java.util.Optional;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -31,6 +34,37 @@ class ArticleRepositoryTest {
 
     @Autowired
     private ArticleGroupRepository articleGroupRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void findAllWithGroupEagerlyInitializesTheArticleGroupProxy() {
+        final ArticleGroupEntity group = articleGroupRepository.save(newGroup("Dairy"));
+        final ArticleEntity article = newArticle("Milch", "milch");
+        article.setArticleGroup(group);
+        articleRepository.save(article);
+        entityManager.flush();
+        entityManager.clear();
+
+        final List<ArticleEntity> found = articleRepository.findAllWithGroup();
+
+        assertThat(found).hasSize(1);
+        assertThat(Hibernate.isInitialized(found.get(0).getArticleGroup())).isTrue();
+        assertThat(found.get(0).getArticleGroup().getName()).isEqualTo("Dairy");
+    }
+
+    @Test
+    void findAllWithGroupIncludesArticlesWithoutAGroupAssignment() {
+        articleRepository.save(newArticle("Brot", "brot"));
+        entityManager.flush();
+        entityManager.clear();
+
+        final List<ArticleEntity> found = articleRepository.findAllWithGroup();
+
+        assertThat(found).hasSize(1);
+        assertThat(found.get(0).getArticleGroup()).isNull();
+    }
 
     @Test
     void findByNormalizedNameReturnsMatchingArticle() {

--- a/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
+++ b/grocery/src/test/java/com/marvin/grocery/service/ArticleManagementServiceTest.java
@@ -72,7 +72,7 @@ class ArticleManagementServiceTest {
     @DisplayName("Should list all articles with group info and purchase count")
     void findAllArticles_ReturnsArticlesWithGroupAndPurchaseCount() {
         article.setArticleGroup(group);
-        when(articleRepository.findAll()).thenReturn(List.of(article));
+        when(articleRepository.findAllWithGroup()).thenReturn(List.of(article));
         when(receiptItemRepository.countPurchasesGroupedByArticle())
                 .thenReturn(List.of(countOf(1L, 5L)));
 
@@ -93,7 +93,7 @@ class ArticleManagementServiceTest {
     @Test
     @DisplayName("Should default purchase count to zero and group fields to null when unassigned")
     void findAllArticles_NoGroupNoPurchases_DefaultsToZeroAndNull() {
-        when(articleRepository.findAll()).thenReturn(List.of(article));
+        when(articleRepository.findAllWithGroup()).thenReturn(List.of(article));
         when(receiptItemRepository.countPurchasesGroupedByArticle()).thenReturn(List.of());
 
         final Flux<ArticleDTO> result = articleManagementService.findAllArticles();


### PR DESCRIPTION
## Summary
- `GET /articles` 500s with `LazyInitializationException` for any article that has an `articleGroup` assigned.
- `ArticleManagementService.findAllArticles()` mapped `articleRepository.findAll()` results to DTOs *after* the repository's own read-only transaction had already closed, so touching the lazy `articleGroup` proxy in `toArticleDTO` failed with "no session".
- Added `ArticleRepository.findAllWithGroup()` — a `LEFT JOIN FETCH` query mirroring the existing fetch-join pattern in `ReceiptItemRepository` — and switched the service to use it instead of plain `findAll()`.

## Test plan
- [x] `:grocery:test --tests ArticleManagementServiceTest` (unit tests, updated mocks)
- [x] `:grocery:checkstyleMain :grocery:checkstyleTest`
- [x] Added `ArticleRepositoryTest` cases asserting the group proxy is initialized after `entityManager.clear()`, and that ungrouped articles are still included — not runnable in this sandbox (no Docker/Testcontainers access) but follows the existing `@DataJpaTest`/Testcontainers pattern in the same file
- [ ] Manually hit `GET /articles` against a real DB with at least one grouped article and confirm 200