### PR TITLE
fix(grocery): fix LazyInitializationException on PATCH /articles/{id}/group

### DIFF
--- a/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
+++ b/grocery/src/main/java/com/marvin/grocery/service/ArticleManagementService.java
@@ -81,10 +81,11 @@ public class ArticleManagementService {
         return Mono.fromCallable(() -> {
             final ArticleEntity article = articleRepository.findById(articleId)
                     .orElseThrow(() -> new NoSuchElementException("Article not found: " + articleId));
-            article.setArticleGroup(resolveGroup(groupId));
+            final ArticleGroupEntity group = resolveGroup(groupId);
+            article.setArticleGroup(group);
             final ArticleEntity saved = articleRepository.save(article);
             final long purchaseCount = receiptItemRepository.countByArticleId(saved.getId());
-            return toArticleDTO(saved, purchaseCount);
+            return toArticleDTO(saved, group, purchaseCount);
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
@@ -143,7 +144,10 @@ public class ArticleManagementService {
     }
 
     private ArticleDTO toArticleDTO(ArticleEntity article, long purchaseCount) {
-        final ArticleGroupEntity group = article.getArticleGroup();
+        return toArticleDTO(article, article.getArticleGroup(), purchaseCount);
+    }
+
+    private ArticleDTO toArticleDTO(ArticleEntity article, ArticleGroupEntity group, long purchaseCount) {
         return new ArticleDTO(
                 article.getId(),
                 article.getNormalizedName(),


### PR DESCRIPTION
## Summary
- Found live in prod right after deploying #246: `PATCH /articles/{id}/group` 500s with the same `org.hibernate.LazyInitializationException` on `ArticleGroupEntity` — same failure family as #246, different call site.
- `assignGroup()` set `article.setArticleGroup(resolveGroup(groupId))` on a **detached** article (loaded in an earlier, already-closed repository transaction), then called `articleRepository.save(article)`. Hibernate's `merge()` for a detached entity replaces its lazy `@ManyToOne` association with a **fresh, uninitialized proxy** rather than keeping the fully-loaded object we passed in — so reading `saved.getArticleGroup().getName()` after `save()`'s own transaction closed threw.
- Fix: build the response DTO from the `group` entity already resolved earlier in the method, instead of reading it back off the merged/saved article.

Note: existing Mockito unit tests didn't catch this because a mocked `save()` just echoes back the same in-memory object — it can't reproduce Hibernate's merge-time proxy substitution. This is a real-Hibernate-only failure mode.

## Test plan
- [x] `:grocery:test --tests ArticleManagementServiceTest` (still passes; doesn't newly cover this since Mockito can't simulate the merge behavior — see note above)
- [x] `:grocery:checkstyleMain :grocery:checkstyleTest`
- [x] Verified live against the cluster: `PATCH /articles/{id}/group` returns 200 after this fix is deployed